### PR TITLE
Species and Access Tweaks(Read description)

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -128,7 +128,7 @@
 		access_expedition_shuttle, access_guppy, access_hangar, access_petrov, access_petrov_helm, access_guppy_helm,
 		access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_petrov_rd,
 		access_petrov_security, access_petrov_maint, access_pathfinder, access_explorer, access_eva, access_solgov_crew,
-		access_expedition_shuttle, access_expedition_shuttle_helm, access_maint_tunnels
+		access_expedition_shuttle, access_expedition_shuttle_helm, access_maint_tunnels, access_robotics
 	)
 	minimal_access = list()
 

--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -25,7 +25,7 @@
 						access_mining_station, access_xenobiology, access_xenoarch, access_nanotrasen, access_solgov_crew,
 						access_expedition_shuttle, access_guppy, access_hangar, access_petrov, access_petrov_helm, access_guppy_helm,
 						access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_petrov_security,
-						access_petrov_maint)
+						access_petrov_maint, access_robotics)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_COMPUTER    = SKILL_BASIC,
 	                    SKILL_FINANCE     = SKILL_BASIC,
@@ -79,7 +79,7 @@
 	access = list(access_tox, access_tox_storage, access_research, access_petrov, access_petrov_helm,
 						access_mining_office, access_mining_station, access_xenobiology, access_guppy_helm,
 						access_xenoarch, access_nanotrasen, access_expedition_shuttle, access_guppy, access_hangar,
-						access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry)
+						access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_robotics)
 	minimal_access = list()
 	skill_points = 20
 

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -9,7 +9,7 @@
 		/datum/species/human/mule = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
 	)
 
-#define HUMAN_ONLY_JOBS /datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/representative, /datum/job/sea
+#define HUMAN_ONLY_JOBS /datum/job/captain, /datum/job/hop, /datum/job/representative, /datum/job/sea
 	species_to_job_blacklist = list(
 		/datum/species/unathi  = list(HUMAN_ONLY_JOBS), //Other jobs unavailable via branch restrictions,
 		/datum/species/unathi/yeosa = list(HUMAN_ONLY_JOBS),
@@ -20,7 +20,6 @@
 		/datum/species/sergal/northern = list(HUMAN_ONLY_JOBS),
 		/datum/species/sergal/eastern = list(HUMAN_ONLY_JOBS),
 		/datum/species/akula = list(HUMAN_ONLY_JOBS),
-		/datum/species/custom= list(HUMAN_ONLY_JOBS),
 		/datum/species/humanathi= list(HUMAN_ONLY_JOBS),
 		/datum/species/tajaran= list(HUMAN_ONLY_JOBS),
 		/datum/species/vasilissan= list(HUMAN_ONLY_JOBS),


### PR DESCRIPTION
Does a few changes here and there as listed:
- Removes the custom species locks (do note that your custom species still has to be some form of human whether full body or otherwise to be XO or CO)
- Gives robotics access to all science crew. It just doesn't make sense that a science crewmember is unable to even make synthetics/silicons.