### PR TITLE
Fixes FOR REAL most marine ranks not getting anything in uniform vendor

### DIFF
--- a/maps/torch/datums/uniforms_marine-corps.dm
+++ b/maps/torch/datums/uniforms_marine-corps.dm
@@ -43,7 +43,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
-	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
+	dress_extra = list(/obj/item/clothing/head/beret/solgov)
 
 /decl/hierarchy/mil_uniform/marine_corps/com/seniorofficer
 	name = "Marine Corps senior command"
@@ -87,7 +87,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
-	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
+	dress_extra = list(/obj/item/clothing/head/beret/solgov)
 
 /decl/hierarchy/mil_uniform/marine_corps/eng/officer/com //Can only be officers
 	name = "Marine Corps engineering command"
@@ -135,7 +135,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
-	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
+	dress_extra = list(/obj/item/clothing/head/beret/solgov)
 
 /decl/hierarchy/mil_uniform/marine_corps/sec/officer/com //Can only be officers
 	name = "Marine Corps security command"
@@ -182,7 +182,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
-	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
+	dress_extra = list(/obj/item/clothing/head/beret/solgov)
 
 /decl/hierarchy/mil_uniform/marine_corps/med/officer/com //Can only be officers
 	name = "Marine Corps medical command"
@@ -230,7 +230,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
-	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
+	dress_extra = list(/obj/item/clothing/head/beret/solgov)
 
 /decl/hierarchy/mil_uniform/marine_corps/sup/seniorofficer
 	name = "Marine Corps supply senior command"
@@ -245,7 +245,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
-	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
+	dress_extra = list(/obj/item/clothing/head/beret/solgov)
 
 /decl/hierarchy/mil_uniform/marine_corps/srv
 	name = "Marine Corps service"
@@ -282,7 +282,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
-	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
+	dress_extra = list(/obj/item/clothing/head/beret/solgov)
 
 /decl/hierarchy/mil_uniform/marine_corps/exp
 	name = "Marine Corps exploration"
@@ -319,7 +319,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
-	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
+	dress_extra = list(/obj/item/clothing/head/beret/solgov)
 
 /decl/hierarchy/mil_uniform/marine_corps/spt
 	name = "Marine Corps command support"
@@ -348,7 +348,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
-	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
+	dress_extra = list(/obj/item/clothing/head/beret/solgov)
 
 /decl/hierarchy/mil_uniform/marine_corps/spt/seniorofficer
 	name = "Marine Corps senior command support"
@@ -366,4 +366,4 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
-	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
+	dress_extra = list(/obj/item/clothing/head/beret/solgov)

--- a/maps/torch/datums/uniforms_marine-corps.dm
+++ b/maps/torch/datums/uniforms_marine-corps.dm
@@ -1,6 +1,6 @@
 /decl/hierarchy/mil_uniform/marine_corps
 	name = "Master marine corps outfit"
-	hierarchy_type = /decl/hierarchy/mil_uniform/army
+	hierarchy_type = /decl/hierarchy/mil_uniform/marine_corps
 	branches = list(/datum/mil_branch/marine_corps)
 
 	pt_under = /obj/item/clothing/under/solgov/pt/army
@@ -26,7 +26,7 @@
 
 	dress_extra = list(/obj/item/clothing/head/beret/solgov)
 
-/decl/hierarchy/mil_uniform/army/com //Can only be officers
+/decl/hierarchy/mil_uniform/marine_corps/com //Can only be officers
 	name = "Marine Corps command"
 	departments = COM
 
@@ -45,17 +45,14 @@
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
 	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
 
-/decl/hierarchy/mil_uniform/army/com/seniorofficer
+/decl/hierarchy/mil_uniform/marine_corps/com/seniorofficer
 	name = "Marine Corps senior command"
 	min_rank = 15
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 
-//	service_over = /obj/item/clothing/suit/storage/solgov/service/army/flag
-//	dress_over = /obj/item/clothing/suit/dress/solgov/army/flag
-
-/decl/hierarchy/mil_uniform/army/eng
+/decl/hierarchy/mil_uniform/marine_corps/eng
 	name = "Marine Corps engineering"
 	departments = ENG
 
@@ -66,7 +63,7 @@
 						 /obj/item/clothing/head/soft/solgov,
 						 /obj/item/clothing/gloves/thick/duty/solgov/eng)
 
-/decl/hierarchy/mil_uniform/army/eng/noncom
+/decl/hierarchy/mil_uniform/marine_corps/eng/noncom
 	name = "Marine Corps engineering NCO"
 	min_rank = 4
 
@@ -75,7 +72,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army
 
-/decl/hierarchy/mil_uniform/army/eng/officer
+/decl/hierarchy/mil_uniform/marine_corps/eng/officer
 	name = "Marine Corps engineering CO"
 	min_rank = 11
 
@@ -92,18 +89,18 @@
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
 	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
 
-/decl/hierarchy/mil_uniform/army/eng/officer/com //Can only be officers
+/decl/hierarchy/mil_uniform/marine_corps/eng/officer/com //Can only be officers
 	name = "Marine Corps engineering command"
 	departments = ENG|COM
 
-/decl/hierarchy/mil_uniform/army/eng/officer/com/seniorofficer
+/decl/hierarchy/mil_uniform/marine_corps/eng/officer/com/seniorofficer
 	name = "Marine Corps engineering senior command"
 	min_rank = 15
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 
-/decl/hierarchy/mil_uniform/army/sec
+/decl/hierarchy/mil_uniform/marine_corps/sec
 	name = "Marine Corps security"
 	departments = SEC
 
@@ -114,7 +111,7 @@
 						 /obj/item/clothing/gloves/thick/duty/solgov/sec,
 						 /obj/item/clothing/under/solgov/utility/army/security)
 
-/decl/hierarchy/mil_uniform/army/sec/noncom
+/decl/hierarchy/mil_uniform/marine_corps/sec/noncom
 	name = "Marine Corps security NCO"
 	min_rank = 4
 
@@ -123,7 +120,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army
 
-/decl/hierarchy/mil_uniform/army/sec/officer
+/decl/hierarchy/mil_uniform/marine_corps/sec/officer
 	name = "Marine Corps security CO"
 	min_rank = 11
 
@@ -140,18 +137,18 @@
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
 	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
 
-/decl/hierarchy/mil_uniform/army/sec/officer/com //Can only be officers
+/decl/hierarchy/mil_uniform/marine_corps/sec/officer/com //Can only be officers
 	name = "Marine Corps security command"
 	departments = SEC|COM
 
-/decl/hierarchy/mil_uniform/army/sec/officer/com/seniorofficer
+/decl/hierarchy/mil_uniform/marine_corps/sec/officer/com/seniorofficer
 	name = "Marine Corps security senior command"
 	min_rank = 15
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 
-/decl/hierarchy/mil_uniform/army/med
+/decl/hierarchy/mil_uniform/marine_corps/med
 	name = "Marine Corps medical"
 	departments = MED
 
@@ -161,7 +158,7 @@
 						 /obj/item/clothing/head/soft/solgov,
 						 /obj/item/clothing/gloves/thick/duty/solgov/med)
 
-/decl/hierarchy/mil_uniform/army/med/noncom
+/decl/hierarchy/mil_uniform/marine_corps/med/noncom
 	name = "Marine Corps medical NCO"
 	min_rank = 4
 
@@ -170,7 +167,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army
 
-/decl/hierarchy/mil_uniform/army/med/officer
+/decl/hierarchy/mil_uniform/marine_corps/med/officer
 	name = "Marine Corps medical CO"
 	min_rank = 11
 
@@ -187,18 +184,18 @@
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
 	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
 
-/decl/hierarchy/mil_uniform/army/med/officer/com //Can only be officers
+/decl/hierarchy/mil_uniform/marine_corps/med/officer/com //Can only be officers
 	name = "Marine Corps medical command"
 	departments = MED|COM
 
-/decl/hierarchy/mil_uniform/army/med/officer/com/seniorofficer
+/decl/hierarchy/mil_uniform/marine_corps/med/officer/com/seniorofficer
 	name = "Marine Corps medical senior command"
 	min_rank = 15
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 
-/decl/hierarchy/mil_uniform/army/sup
+/decl/hierarchy/mil_uniform/marine_corps/sup
 	name = "Marine Corps supply"
 	departments = SUP
 
@@ -209,7 +206,7 @@
 						 /obj/item/clothing/head/soft/solgov,
 						 /obj/item/clothing/gloves/thick/duty/solgov/sup)
 
-/decl/hierarchy/mil_uniform/army/sup/noncom
+/decl/hierarchy/mil_uniform/marine_corps/sup/noncom
 	name = "Marine Corps supply NCO"
 	min_rank = 4
 
@@ -218,7 +215,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army
 
-/decl/hierarchy/mil_uniform/army/sup/officer
+/decl/hierarchy/mil_uniform/marine_corps/sup/officer
 	name = "Marine Corps supply CO"
 	min_rank = 11
 
@@ -235,7 +232,7 @@
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
 	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
 
-/decl/hierarchy/mil_uniform/army/sup/seniorofficer
+/decl/hierarchy/mil_uniform/marine_corps/sup/seniorofficer
 	name = "Marine Corps supply senior command"
 	min_rank = 15
 
@@ -250,7 +247,7 @@
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
 	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
 
-/decl/hierarchy/mil_uniform/army/srv
+/decl/hierarchy/mil_uniform/marine_corps/srv
 	name = "Marine Corps service"
 	departments = SRV
 
@@ -261,7 +258,7 @@
 						 /obj/item/clothing/head/soft/solgov,
 						 /obj/item/clothing/gloves/thick/duty/solgov/svc)
 
-/decl/hierarchy/mil_uniform/army/srv/noncom
+/decl/hierarchy/mil_uniform/marine_corps/srv/noncom
 	name = "Marine Corps service NCO"
 	min_rank = 4
 
@@ -270,7 +267,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army
 
-/decl/hierarchy/mil_uniform/army/srv/officer
+/decl/hierarchy/mil_uniform/marine_corps/srv/officer
 	name = "Marine Corps service CO"
 	min_rank = 11
 
@@ -287,7 +284,7 @@
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
 	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
 
-/decl/hierarchy/mil_uniform/army/exp
+/decl/hierarchy/mil_uniform/marine_corps/exp
 	name = "Marine Corps exploration"
 	departments = EXP
 
@@ -298,7 +295,7 @@
 						 /obj/item/clothing/head/soft/solgov,
 						 /obj/item/clothing/gloves/thick/duty/solgov/exp)
 
-/decl/hierarchy/mil_uniform/army/exp/noncom
+/decl/hierarchy/mil_uniform/marine_corps/exp/noncom
 	name = "Marine Corps exploration NCO"
 	min_rank = 4
 
@@ -307,7 +304,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army
 
-/decl/hierarchy/mil_uniform/army/exp/officer
+/decl/hierarchy/mil_uniform/marine_corps/exp/officer
 	name = "Marine Corps exploration CO"
 	min_rank = 11
 
@@ -324,13 +321,13 @@
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
 	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
 
-/decl/hierarchy/mil_uniform/army/spt
+/decl/hierarchy/mil_uniform/marine_corps/spt
 	name = "Marine Corps command support"
 	departments = SPT
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/command
 
-/decl/hierarchy/mil_uniform/army/spt/noncom
+/decl/hierarchy/mil_uniform/marine_corps/spt/noncom
 	name = "Marine Corps support NCO"
 	min_rank = 4
 
@@ -339,7 +336,7 @@
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army
 
-/decl/hierarchy/mil_uniform/army/spt/officer
+/decl/hierarchy/mil_uniform/marine_corps/spt/officer
 	name = "Marine Corps command support CO"
 	min_rank = 11
 
@@ -353,7 +350,7 @@
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
 	dress_extra = list(/obj/item/weapon/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov)
 
-/decl/hierarchy/mil_uniform/army/spt/seniorofficer
+/decl/hierarchy/mil_uniform/marine_corps/spt/seniorofficer
 	name = "Marine Corps senior command support"
 	min_rank = 15
 


### PR DESCRIPTION
:cl: Anonymous
bugfix: Fixes most marine ranks not having anything in uniform vendor. This time for sure.
tweak: Marines do not get fleet sword anymore.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->