### PR TITLE
alters security skills default max level and increases cost

### DIFF
--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -60,6 +60,8 @@ GLOBAL_LIST_EMPTY(skills)
 /decl/hierarchy/skill/security
 	name = "Security"
 	ID	 = "security"
+	difficulty = SKILL_HARD
+	default_max = SKILL_EXPERT
 
 /decl/hierarchy/skill/engineering
 	name = "Engineering"


### PR DESCRIPTION
🆑 Combat Skills have had their max level for all jobs raised to 'Experienced', and cost has been accordingly increased. 🆑 