### PR TITLE
Senior Engineer Access Update

### DIFF
--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -36,7 +36,7 @@
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_janitor, access_construction,
-			            access_tcomsat, access_solgov_crew, access_seneng, access_hangar, access_network)
+			            access_tcomsat, access_solgov_crew, access_seneng, access_hangar, access_network, access_robotics, access_robotics_engineering)
 
 	software_on_spawn = list(/datum/computer_file/program/power_monitor,
 							 /datum/computer_file/program/supermatter_monitor,


### PR DESCRIPTION
What, your roboticist is out and you have a senior engineer that can fix a shutdown robot, but lack the access? Tough luck!...until now.
-Adds robotics access to the senior engineer.