### PR TITLE
neural lace fix for species with no robotic internal organs

### DIFF
--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -167,7 +167,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	. += "<br>"
 	if(config.use_cortical_stacks)
 		. += "Neural lace: "
-		if(mob_species.spawn_flags & SPECIES_NO_LACE)
+		if(mob_species.spawn_flags & SPECIES_NO_LACE || SPECIES_NO_ROBOTIC_INTERNAL_ORGANS)
 			. += "incompatible."
 		else
 			. += pref.has_cortical_stack ? "present." : "<b>not present.</b>"


### PR DESCRIPTION
adds check for SPECIES_NO_ROBOTIC_INTERNAL_ORGANS on character creation