### PR TITLE
Makes Zip guns illegal

### DIFF
--- a/code/modules/projectiles/guns/projectile/zipgun.dm
+++ b/code/modules/projectiles/guns/projectile/zipgun.dm
@@ -10,6 +10,7 @@
 	max_shells = 1 //literally just a barrel
 	has_safety = FALSE
 	w_class = ITEM_SIZE_NORMAL
+	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 1, TECH_ESOTERIC = 2)
 
 	var/global/list/ammo_types = list(
 		/obj/item/ammo_casing/pistol,


### PR DESCRIPTION
Zip guns now have level 2 illegals, along with its normal combat 2 and mats 1