### PR TITLE
Unnecessary Marine Uniform code refactor, but also service hats, garrison hats and loadout additions

### DIFF
--- a/maps/torch/datums/uniforms_marine-corps.dm
+++ b/maps/torch/datums/uniforms_marine-corps.dm
@@ -9,13 +9,20 @@
 	utility_under = /obj/item/clothing/under/solgov/utility/army
 	utility_shoes = /obj/item/clothing/shoes/dutyboots
 	utility_hat = /obj/item/clothing/head/solgov/utility/army
-	utility_extra = list(/obj/item/clothing/head/beret/solgov, /obj/item/clothing/head/ushanka/solgov/army, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army, /obj/item/clothing/head/soft/solgov)
+	utility_extra = list(
+		/obj/item/clothing/head/beret/solgov,
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov
+	)
 
 	service_under = /obj/item/clothing/under/solgov/service/army
 	service_skirt = /obj/item/clothing/under/solgov/service/army/skirt
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army
 	service_shoes = /obj/item/clothing/shoes/dress
-	service_hat = /obj/item/clothing/head/solgov/service/army/garrison
+	service_hat = /obj/item/clothing/head/solgov/service/army
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison)
 
 	dress_under = /obj/item/clothing/under/solgov/mildress/army
 	dress_skirt = /obj/item/clothing/under/solgov/mildress/army/skirt
@@ -31,15 +38,18 @@
 	departments = COM
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/command
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/army/command,
-						 /obj/item/clothing/head/beret/solgov,
-						 /obj/item/clothing/head/ushanka/solgov/army,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-						 /obj/item/clothing/head/soft/solgov,
-						 /obj/item/clothing/gloves/thick/duty/solgov/cmd)
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/command,
+		/obj/item/clothing/head/beret/solgov,
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/cmd
+	)
 
-	service_hat = /obj/item/clothing/head/solgov/dress/army/command
+	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison/command)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
@@ -57,18 +67,22 @@
 	departments = ENG
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/engineering
-	utility_extra = list(/obj/item/clothing/head/beret/solgov,
-						 /obj/item/clothing/head/ushanka/solgov/army,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-						 /obj/item/clothing/head/soft/solgov,
-						 /obj/item/clothing/gloves/thick/duty/solgov/eng)
+	utility_extra = list(
+		/obj/item/clothing/head/beret/solgov,
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/eng
+	)
 
 /decl/hierarchy/mil_uniform/marine_corps/eng/noncom
 	name = "Marine Corps engineering NCO"
 	min_rank = 4
 
-	service_hat = /obj/item/clothing/head/solgov/dress/army
+	service_hat = /obj/item/clothing/head/solgov/service/army
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army
 
@@ -76,14 +90,19 @@
 	name = "Marine Corps engineering CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/army/command,
-						 /obj/item/clothing/head/beret/solgov,
-						 /obj/item/clothing/head/ushanka/solgov/army,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-						 /obj/item/clothing/head/soft/solgov,
-						 /obj/item/clothing/gloves/thick/duty/solgov/eng)
-	service_hat = /obj/item/clothing/head/solgov/dress/army/command
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/command,
+		/obj/item/clothing/head/beret/solgov,
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/eng
+	)
+
+	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison/command)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
@@ -104,19 +123,22 @@
 	name = "Marine Corps security"
 	departments = SEC
 
-	utility_extra = list(/obj/item/clothing/head/beret/solgov,
-						 /obj/item/clothing/head/ushanka/solgov/army,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-						 /obj/item/clothing/head/soft/solgov,
-						 /obj/item/clothing/gloves/thick/duty/solgov/sec,
-						 /obj/item/clothing/under/solgov/utility/army/security)
+	utility_extra = list(
+		/obj/item/clothing/head/beret/solgov,
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/sec,
+		/obj/item/clothing/under/solgov/utility/army/security)
 
 /decl/hierarchy/mil_uniform/marine_corps/sec/noncom
 	name = "Marine Corps security NCO"
 	min_rank = 4
 
-	service_hat = /obj/item/clothing/head/solgov/dress/army
+	service_hat = /obj/item/clothing/head/solgov/service/army
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison, /obj/item/clothing/head/solgov/service/army/campaign)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army
 
@@ -124,14 +146,19 @@
 	name = "Marine Corps security CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/army/command,
-						 /obj/item/clothing/head/beret/solgov,
-						 /obj/item/clothing/head/ushanka/solgov/army,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-						 /obj/item/clothing/head/soft/solgov,
-						 /obj/item/clothing/gloves/thick/duty/solgov/sec)
-	service_hat = /obj/item/clothing/head/solgov/dress/army/command
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/command,
+		/obj/item/clothing/head/beret/solgov,
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/sec
+	)
+
+	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison/command)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
@@ -153,17 +180,20 @@
 	departments = MED
 
 	utility_extra = list(
-						 /obj/item/clothing/head/ushanka/solgov/army,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-						 /obj/item/clothing/head/soft/solgov,
-						 /obj/item/clothing/gloves/thick/duty/solgov/med)
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/med
+	)
 
 /decl/hierarchy/mil_uniform/marine_corps/med/noncom
 	name = "Marine Corps medical NCO"
 	min_rank = 4
 
-	service_hat = /obj/item/clothing/head/solgov/dress/army
+	service_hat = /obj/item/clothing/head/solgov/service/army
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army
 
@@ -171,14 +201,19 @@
 	name = "Marine Corps medical CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/army/command,
-						 /obj/item/clothing/head/beret/solgov,
-						 /obj/item/clothing/head/ushanka/solgov/army,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-						 /obj/item/clothing/head/soft/solgov,
-						 /obj/item/clothing/gloves/thick/duty/solgov/med)
-	service_hat = /obj/item/clothing/head/solgov/dress/army/command
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/command,
+		/obj/item/clothing/head/beret/solgov,
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/med
+	)
+
+	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison/command)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
@@ -201,17 +236,20 @@
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/supply
 	utility_extra = list(
-						 /obj/item/clothing/head/ushanka/solgov/army,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-						 /obj/item/clothing/head/soft/solgov,
-						 /obj/item/clothing/gloves/thick/duty/solgov/sup)
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/sup
+	)
 
 /decl/hierarchy/mil_uniform/marine_corps/sup/noncom
 	name = "Marine Corps supply NCO"
 	min_rank = 4
 
-	service_hat = /obj/item/clothing/head/solgov/dress/army
+	service_hat = /obj/item/clothing/head/solgov/service/army
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army
 
@@ -219,14 +257,19 @@
 	name = "Marine Corps supply CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/army/command,
-						 /obj/item/clothing/head/beret/solgov,
-						 /obj/item/clothing/head/ushanka/solgov/army,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-						 /obj/item/clothing/head/soft/solgov,
-						 /obj/item/clothing/gloves/thick/duty/solgov/sup)
-	service_hat = /obj/item/clothing/head/solgov/dress/army/command
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/command,
+		/obj/item/clothing/head/beret/solgov,
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/sup
+	)
+
+	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison/command)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
@@ -236,12 +279,20 @@
 	name = "Marine Corps supply senior command"
 	min_rank = 15
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/army/command, /obj/item/clothing/head/beret/solgov, /obj/item/clothing/head/ushanka/solgov/army, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army, /obj/item/clothing/head/soft/solgov)
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/command,
+		/obj/item/clothing/head/beret/solgov,
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov
+	)
+
 	utility_under = /obj/item/clothing/under/solgov/utility/army/command
 
-	service_hat = /obj/item/clothing/head/solgov/dress/army/command
+	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
-
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison/command)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
@@ -253,17 +304,20 @@
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/service
 	utility_extra = list(
-						 /obj/item/clothing/head/ushanka/solgov/army,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-						 /obj/item/clothing/head/soft/solgov,
-						 /obj/item/clothing/gloves/thick/duty/solgov/svc)
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/svc
+	)
 
 /decl/hierarchy/mil_uniform/marine_corps/srv/noncom
 	name = "Marine Corps service NCO"
 	min_rank = 4
 
-	service_hat = /obj/item/clothing/head/solgov/dress/army
+	service_hat = /obj/item/clothing/head/solgov/service/army
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army
 
@@ -271,14 +325,19 @@
 	name = "Marine Corps service CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/army/command,
-						 /obj/item/clothing/head/beret/solgov,
-						 /obj/item/clothing/head/ushanka/solgov/army,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-						 /obj/item/clothing/head/soft/solgov,
-						 /obj/item/clothing/gloves/thick/duty/solgov/svc)
-	service_hat = /obj/item/clothing/head/solgov/dress/army/command
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/command,
+		/obj/item/clothing/head/beret/solgov,
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/svc
+	)
+
+	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison/command)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
@@ -290,17 +349,20 @@
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/exploration
 	utility_extra = list(
-						 /obj/item/clothing/head/ushanka/solgov/army,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-						 /obj/item/clothing/head/soft/solgov,
-						 /obj/item/clothing/gloves/thick/duty/solgov/exp)
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/exp
+	)
 
 /decl/hierarchy/mil_uniform/marine_corps/exp/noncom
 	name = "Marine Corps exploration NCO"
 	min_rank = 4
 
-	service_hat = /obj/item/clothing/head/solgov/dress/army
+	service_hat = /obj/item/clothing/head/solgov/service/army
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army
 
@@ -308,14 +370,19 @@
 	name = "Marine Corps exploration CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/army/command,
-						 /obj/item/clothing/head/beret/solgov,
-						 /obj/item/clothing/head/ushanka/solgov/army,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-						 /obj/item/clothing/head/soft/solgov,
-						 /obj/item/clothing/gloves/thick/duty/solgov/exp)
-	service_hat = /obj/item/clothing/head/solgov/dress/army/command
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/command,
+		/obj/item/clothing/head/beret/solgov,
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/exp
+	)
+
+	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison/command)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
@@ -331,8 +398,9 @@
 	name = "Marine Corps support NCO"
 	min_rank = 4
 
-	service_hat = /obj/item/clothing/head/solgov/dress/army
+	service_hat = /obj/item/clothing/head/solgov/service/army
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison, /obj/item/clothing/head/solgov/service/army/campaign)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army
 
@@ -340,11 +408,20 @@
 	name = "Marine Corps command support CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/army/command, /obj/item/clothing/head/beret/solgov, /obj/item/clothing/head/ushanka/solgov/army, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army, /obj/item/clothing/head/soft/solgov)
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/command,
+		/obj/item/clothing/head/beret/solgov,
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov
+	)
+
 	utility_under = /obj/item/clothing/under/solgov/utility/army/command
 
-	service_hat = /obj/item/clothing/head/solgov/dress/army/command
+	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
+	service_extra = list(/obj/item/clothing/head/solgov/service/army/garrison/command)
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/army/command
@@ -354,14 +431,18 @@
 	name = "Marine Corps senior command support"
 	min_rank = 15
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/army/command,
-						 /obj/item/clothing/head/beret/solgov,
-						 /obj/item/clothing/head/ushanka/solgov/army,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-						 /obj/item/clothing/head/soft/solgov)
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/command,
+		/obj/item/clothing/head/beret/solgov,
+		/obj/item/clothing/head/ushanka/solgov/army,
+		/obj/item/clothing/head/ushanka/solgov/army/green,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+		/obj/item/clothing/head/soft/solgov
+	)
+
 	utility_under = /obj/item/clothing/under/solgov/utility/army/command
 
-	service_hat = /obj/item/clothing/head/solgov/dress/army/command
+	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
 
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command

--- a/maps/torch/job/outfits/boh_outfits.dm
+++ b/maps/torch/job/outfits/boh_outfits.dm
@@ -1,5 +1,10 @@
 // Modular additions, for now.
 // Command
+/decl/hierarchy/outfit/job/torch/crew/command/CO/fleet
+	name = OUTFIT_JOB_NAME("Commanding Officer - Fleet")
+	uniform = /obj/item/clothing/under/solgov/utility/fleet/command
+	shoes = /obj/item/clothing/shoes/dutyboots
+
 /decl/hierarchy/outfit/job/torch/crew/command/XO/marine
 	name = OUTFIT_JOB_NAME("Executive Officer - Marine Corps")
 	uniform = /obj/item/clothing/under/solgov/utility/army/command

--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -1,6 +1,17 @@
 // Consist of modular changes, for now.
 
 // Command
+/// Captain is basically a modular fix.
+/datum/job/captain
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/command/CO/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/o6,
+		/datum/mil_rank/fleet/o6
+	)
+
 /datum/job/hop
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,

--- a/maps/torch/loadout/loadout_accessories_boh.dm
+++ b/maps/torch/loadout/loadout_accessories_boh.dm
@@ -30,15 +30,16 @@
 
 /datum/gear/tactical/arm_guards/misc
 	display_name = "miscellaneous arm guards selection"
+	description = "A selection of arm guards in various colors."
 	path = /obj/item/clothing/accessory/armguards
 	allowed_branches = list(/datum/mil_branch/civilian, /datum/mil_branch/solgov, /datum/mil_branch/marine_corps)
 
 /datum/gear/tactical/arm_guards/misc/New()
 	..()
 	var/arm_guards = list()
-	arm_guards["blue arm guards"] = /obj/item/clothing/accessory/armguards/blue
 	arm_guards["green arm guards"] = /obj/item/clothing/accessory/armguards/green
 	arm_guards["tan arm guards"] = /obj/item/clothing/accessory/armguards/tan
+	arm_guards["blue arm guards"] = /obj/item/clothing/accessory/armguards/blue
 	gear_tweaks += new/datum/gear_tweak/path(arm_guards)
 
 // Legs
@@ -55,13 +56,14 @@
 
 /datum/gear/tactical/leg_guards/misc
 	display_name = "miscellaneous leg guards selection"
+	description = "A selection of leg guards in various colors."
 	path = /obj/item/clothing/accessory/legguards
 	allowed_branches = list(/datum/mil_branch/civilian, /datum/mil_branch/solgov, /datum/mil_branch/marine_corps)
 
 /datum/gear/tactical/leg_guards/misc/New()
 	..()
 	var/leg_guards = list()
-	leg_guards["blue leg guards"] = /obj/item/clothing/accessory/legguards/blue
 	leg_guards["green leg guards"] = /obj/item/clothing/accessory/legguards/green
 	leg_guards["tan leg guards"] = /obj/item/clothing/accessory/legguards/tan
+	leg_guards["blue leg guards"] = /obj/item/clothing/accessory/legguards/blue
 	gear_tweaks += new/datum/gear_tweak/path(leg_guards)

--- a/maps/torch/loadout/loadout_accessories_boh.dm
+++ b/maps/torch/loadout/loadout_accessories_boh.dm
@@ -14,3 +14,54 @@
 	display_name = "Marine Corps patch (xenoic division)"
 	path = /obj/item/clothing/accessory/solgov/smc_patch/xeno
 	allowed_branches = list(/datum/mil_branch/marine_corps)
+
+/// Limb guards
+// Arms
+/datum/gear/tactical/arm_guards
+	display_name = "black arm guards"
+	path = /obj/item/clothing/accessory/armguards
+	cost = 2
+	allowed_roles = ARMORED_ROLES
+
+/datum/gear/tactical/arm_guards/navy
+	display_name = "navy arm guards"
+	path = /obj/item/clothing/accessory/armguards/navy
+	allowed_branches = list(/datum/mil_branch/fleet, /datum/mil_branch/civilian)
+
+/datum/gear/tactical/arm_guards/misc
+	display_name = "miscellaneous arm guards selection"
+	path = /obj/item/clothing/accessory/armguards
+	allowed_branches = list(/datum/mil_branch/civilian, /datum/mil_branch/solgov, /datum/mil_branch/marine_corps)
+
+/datum/gear/tactical/arm_guards/misc/New()
+	..()
+	var/arm_guards = list()
+	arm_guards["blue arm guards"] = /obj/item/clothing/accessory/armguards/blue
+	arm_guards["green arm guards"] = /obj/item/clothing/accessory/armguards/green
+	arm_guards["tan arm guards"] = /obj/item/clothing/accessory/armguards/tan
+	gear_tweaks += new/datum/gear_tweak/path(arm_guards)
+
+// Legs
+/datum/gear/tactical/leg_guards
+	display_name = "black leg guards"
+	path = /obj/item/clothing/accessory/legguards
+	cost = 2
+	allowed_roles = ARMORED_ROLES
+
+/datum/gear/tactical/leg_guards/navy
+	display_name = "navy leg guards"
+	path = /obj/item/clothing/accessory/legguards/navy
+	allowed_branches = list(/datum/mil_branch/fleet, /datum/mil_branch/civilian)
+
+/datum/gear/tactical/leg_guards/misc
+	display_name = "miscellaneous leg guards selection"
+	path = /obj/item/clothing/accessory/legguards
+	allowed_branches = list(/datum/mil_branch/civilian, /datum/mil_branch/solgov, /datum/mil_branch/marine_corps)
+
+/datum/gear/tactical/leg_guards/misc/New()
+	..()
+	var/leg_guards = list()
+	leg_guards["blue leg guards"] = /obj/item/clothing/accessory/legguards/blue
+	leg_guards["green leg guards"] = /obj/item/clothing/accessory/legguards/green
+	leg_guards["tan leg guards"] = /obj/item/clothing/accessory/legguards/tan
+	gear_tweaks += new/datum/gear_tweak/path(leg_guards)

--- a/maps/torch/loadout/loadout_uniform_boh.dm
+++ b/maps/torch/loadout/loadout_uniform_boh.dm
@@ -1,0 +1,11 @@
+/datum/gear/uniform/misc_military
+	display_name = "military fatigue selection"
+	path = /obj/item/clothing/under
+	allowed_branches = MILITARY_BRANCHES
+
+/datum/gear/uniform/misc_military/New()
+	..()
+	var/milmisc = list()
+	milmisc += /obj/item/clothing/under/solgov/utility/army/urban
+	milmisc += /obj/item/clothing/under/solgov/utility/army/tan
+	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(milmisc)

--- a/maps/torch/loadout/loadout_uniform_boh.dm
+++ b/maps/torch/loadout/loadout_uniform_boh.dm
@@ -1,5 +1,6 @@
 /datum/gear/uniform/misc_military
 	display_name = "military fatigue selection"
+	description = "A selection of military uniforms."
 	path = /obj/item/clothing/under
 	allowed_branches = MILITARY_BRANCHES
 

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -136,6 +136,7 @@
 	#include "loadout/loadout_shoes.dm"
 	#include "loadout/loadout_suit.dm"
 	#include "loadout/loadout_uniform.dm"
+	#include "loadout/loadout_uniform_boh.dm"
 	#include "loadout/loadout_xeno.dm"
 	#include "loadout/loadout_augments.dm"
 	#include "loadout/~defines.dm"

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -186,7 +186,8 @@
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o4,
-		/datum/mil_rank/fleet/o5
+		/datum/mil_rank/fleet/o5,
+		/datum/mil_rank/fleet/o6
 	)
 
 	assistant_job = /datum/job/crew


### PR DESCRIPTION
:cl:
tweak: Marine Uniforms shall now have proper service hats and garrison hats. Also drill sergeant hats for ComSupport (SEAs) and Security NCOs.
bugfix: CO can be in Fleet branch (questioning BS12 code).
rscadd: Limb guards in loadout, includes colored versions (green, tan, blue).
rscadd: Tan and urban military fatigues in loadout, only for military branches.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->