### PR TITLE
Renames SCG into NT on Fleet berets and patches. Also some loadout changes.

### DIFF
--- a/maps/torch/items/clothing/solgov-accessory.dm
+++ b/maps/torch/items/clothing/solgov-accessory.dm
@@ -109,29 +109,29 @@ patches
 
 /obj/item/clothing/accessory/solgov/fleet_patch
 	name = "\improper First Fleet patch"
-	desc = "A fancy shoulder patch carrying insignia of First Fleet, the Sol Guard, stationed in Sol."
+	desc = "A fancy shoulder patch carrying insignia of First Fleet."
 	icon_state = "fleetpatch1"
 	on_rolled = list("down" = "none")
 	slot = ACCESSORY_SLOT_INSIGNIA
 
 /obj/item/clothing/accessory/solgov/fleet_patch/second
 	name = "\improper Second Fleet patch"
-	desc = "A well-worn shoulder patch carrying insignia of Second Fleet, the Home Guard, tasked with defense of Sol territories."
+	desc = "A well-worn shoulder patch carrying insignia of Second Fleet."
 	icon_state = "fleetpatch2"
 
 /obj/item/clothing/accessory/solgov/fleet_patch/third
 	name = "\improper Third Fleet patch"
-	desc = "A scuffed shoulder patch carrying insignia of Third Fleet, the Border Guard, guarding borders of Sol territory against Vox and pirates."
+	desc = "A scuffed shoulder patch carrying insignia of Third Fleet."
 	icon_state = "fleetpatch3"
 
 /obj/item/clothing/accessory/solgov/fleet_patch/fourth
 	name = "\improper Fourth Fleet patch"
-	desc = "A pristine shoulder patch carrying insignia of Fourth Fleet, stationed on Skrell border."
+	desc = "A pristine shoulder patch carrying insignia of Fourth Fleet."
 	icon_state = "fleetpatch4"
 
 /obj/item/clothing/accessory/solgov/fleet_patch/fifth
 	name = "\improper Fifth Fleet patch"
-	desc = "A tactical shoulder patch carrying insignia of Fifth Fleet, the Quick Reaction Force, recently formed and outfited with last tech."
+	desc = "A tactical shoulder patch carrying insignia of Fifth Fleet."
 	icon_state = "fleetpatch5"
 
 /*****
@@ -402,7 +402,7 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/command/army
 	icon_state = "dept_marine"
-	desc = "Insignia denoting assignment to the command department. These fit Army uniforms."
+	desc = "Insignia denoting assignment to the command department. These fit Army and Marine Corps uniforms."
 	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/engineering
@@ -423,7 +423,7 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/engineering/army
 	icon_state = "dept_marine"
-	desc = "Insignia denoting assignment to the engineering department. These fit Army uniforms."
+	desc = "Insignia denoting assignment to the engineering department. These fit Army and Marine Corps uniforms."
 	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/security
@@ -445,7 +445,7 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/security/army
 	icon_state = "dept_marine"
-	desc = "Insignia denoting assignment to the security department. These fit Army uniforms."
+	desc = "Insignia denoting assignment to the security department. These fit Army and Marine Corps uniforms."
 	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/medical
@@ -468,7 +468,7 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/medical/army
 	icon_state = "dept_marine"
-	desc = "Insignia denoting assignment to the medical department. These fit Army uniforms."
+	desc = "Insignia denoting assignment to the medical department. These fit Army and Marine Corps uniforms."
 	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/supply
@@ -490,7 +490,7 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/supply/army
 	icon_state = "dept_marine"
-	desc = "Insignia denoting assignment to the supply department. These fit Army uniforms."
+	desc = "Insignia denoting assignment to the supply department. These fit Army and Marine Corps uniforms."
 	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/service
@@ -512,7 +512,7 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/service/army
 	icon_state = "dept_marine"
-	desc = "Insignia denoting assignment to the service department. These fit Army uniforms."
+	desc = "Insignia denoting assignment to the service department. These fit Army and Marine Corps uniforms."
 	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/exploration
@@ -533,7 +533,7 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/exploration/army
 	icon_state = "dept_marine"
-	desc = "Insignia denoting assignment to the exploration department. These fit Army uniforms."
+	desc = "Insignia denoting assignment to the exploration department. These fit Army and Marine Corps uniforms."
 	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/research

--- a/maps/torch/items/clothing/solgov-head.dm
+++ b/maps/torch/items/clothing/solgov-head.dm
@@ -324,27 +324,27 @@
 
 /obj/item/clothing/head/beret/solgov/fleet/branch
 	name = "first fleet beret"
-	desc = "An SCG Fleet beret carrying insignia of First Fleet, the Sol Guard, stationed in Sol. For personnel that are more inclined towards style than safety."
+	desc = "A NT Fleet beret carrying insignia of First Fleet. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_first"
 
 /obj/item/clothing/head/beret/solgov/fleet/branch/second
 	name = "second fleet beret"
-	desc = "An SCG Fleet beret carrying insignia of Second Fleet, the Home Guard, tasked with defense of Sol territories. For personnel that are more inclined towards style than safety."
+	desc = "A NT Fleet beret carrying insignia of Second Fleet. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_second"
 
 /obj/item/clothing/head/beret/solgov/fleet/branch/third
 	name = "third fleet beret"
-	desc = "An SCG Fleet beret carrying insignia of Third Fleet, the Border Guard, guarding borders of Sol territory against Vox and pirates. For personnel that are more inclined towards style than safety."
+	desc = "A NT Fleet beret carrying insignia of Third Fleet. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_third"
 
 /obj/item/clothing/head/beret/solgov/fleet/branch/fourth
 	name = "fourth fleet beret"
-	desc = "An SCG Fleet beret carrying insignia of Fourth Fleet, stationed on Skrell border. For personnel that are more inclined towards style than safety."
+	desc = "A NT Fleet beret carrying insignia of Fourth Fleet. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_fourth"
 
 /obj/item/clothing/head/beret/solgov/fleet/branch/fifth
 	name = "fifth fleet beret"
-	desc = "An SCG Fleet beret carrying insignia of Fifth Fleet, the Quick Reaction Force, recently formed and outfited with last tech. For personnel that are more inclined towards style than safety."
+	desc = "A NT Fleet beret carrying insignia of Fifth Fleet. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_fifth"
 
 //ushanka

--- a/maps/torch/items/clothing/solgov-under.dm
+++ b/maps/torch/items/clothing/solgov-under.dm
@@ -202,7 +202,7 @@
 
 /obj/item/clothing/under/solgov/utility/army
 	name = "army fatigues"
-	desc = "The utility uniform of the SCG Army, made from durable material."
+	desc = "The utility uniform of the SCG Army and Marine Corps, made from durable material."
 	icon_state = "greenutility"
 	item_state = "jensensuit"
 	worn_state = "greenutility"
@@ -396,7 +396,7 @@
 
 /obj/item/clothing/under/solgov/service/army
 	name = "army service uniform"
-	desc = "The service uniform of the SCG Army. Slimming."
+	desc = "The service uniform of the SCG Army and Marine Corps. Slimming."
 	icon_state = "greenservice"
 	item_state = "johnny"
 	worn_state = "greenservice"
@@ -407,7 +407,7 @@
 
 /obj/item/clothing/under/solgov/service/army/skirt
 	name = "army service skirt"
-	desc = "The service uniform skirt of the SCG Army. Slimming."
+	desc = "The service uniform skirt of the SCG Army and Marine Corps. Slimming."
 	icon_state = "greenservicefem"
 	worn_state = "greenservicefem"
 	sprite_sheets = list(
@@ -416,7 +416,7 @@
 
 /obj/item/clothing/under/solgov/service/army/command
 	name = "marine officer's service uniform"
-	desc = "The service uniform of the SCG Army. Slimming and stylish."
+	desc = "The service uniform of the SCG Army and Marine Corps. Slimming and stylish."
 	icon_state = "greenservice_com"
 	item_state = "johnny"
 	worn_state = "greenservice_com"
@@ -424,7 +424,7 @@
 
 /obj/item/clothing/under/solgov/service/army/command/skirt
 	name = "marine officer's service skirt"
-	desc = "The service uniform skirt of the SCG Army. Slimming and stylish."
+	desc = "The service uniform skirt of the SCG Army and Marine Corps. Slimming and stylish."
 	icon_state = "greenservicefem_com"
 	worn_state = "greenservicefem_com"
 
@@ -438,7 +438,7 @@
 
 /obj/item/clothing/under/solgov/mildress/army
 	name = "army dress uniform"
-	desc = "The dress uniform of the SCG Army, class given form."
+	desc = "The dress uniform of the SCG Army and Marine Corps, class given form."
 	icon_state = "blackdress"
 	worn_state = "blackdress"
 	sprite_sheets = list(
@@ -447,7 +447,7 @@
 
 /obj/item/clothing/under/solgov/mildress/army/skirt
 	name = "army dress skirt"
-	desc = "A  feminine version of the SCG Army dress uniform, class given form."
+	desc = "A feminine version of the SCG Army dress uniform, class given form."
 	icon_state = "blackdressfem"
 	worn_state = "blackdressfem"
 	sprite_sheets = list(
@@ -456,7 +456,7 @@
 
 /obj/item/clothing/under/solgov/mildress/army/command
 	name = "army officer's dress uniform"
-	desc = "The dress uniform of the SCG Army, even classier in gold."
+	desc = "The dress uniform of the SCG Army and Marine Corps, even classier in gold."
 	icon_state = "blackdress"
 	worn_state = "blackdress_com"
 

--- a/maps/torch/loadout/loadout_head.dm
+++ b/maps/torch/loadout/loadout_head.dm
@@ -81,7 +81,7 @@
 
 /datum/gear/head/fleetberet
 	display_name = "Fleet branch beret selection"
-	description = "A beret denoting service in one of the fleets within the SCG Fleet."
+	description = "A beret denoting service in one of the fleets within the NT Fleet."
 	path = /obj/item/clothing/head/beret/solgov/fleet/branch
 	allowed_branches = list(/datum/mil_branch/fleet)
 

--- a/maps/torch/loadout/loadout_head_boh.dm
+++ b/maps/torch/loadout/loadout_head_boh.dm
@@ -1,0 +1,12 @@
+/datum/gear/uniform/misc_military_cover
+	display_name = "military cover selection"
+	description = "A selection of military covers."
+	path = /obj/item/clothing/head
+	allowed_branches = list(/datum/mil_branch/marine_corps)
+
+/datum/gear/uniform/misc_military_cover/New()
+	..()
+	var/milmisc_cover = list()
+	milmisc_cover += /obj/item/clothing/head/solgov/utility/army/urban
+	milmisc_cover += /obj/item/clothing/head/solgov/utility/army/tan
+	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(milmisc_cover)

--- a/maps/torch/loadout/loadout_head_boh.dm
+++ b/maps/torch/loadout/loadout_head_boh.dm
@@ -2,6 +2,7 @@
 	display_name = "military cover selection"
 	description = "A selection of military covers."
 	path = /obj/item/clothing/head
+	cost = 0
 	allowed_branches = list(/datum/mil_branch/marine_corps)
 
 /datum/gear/uniform/misc_military_cover/New()

--- a/maps/torch/loadout/loadout_uniform_boh.dm
+++ b/maps/torch/loadout/loadout_uniform_boh.dm
@@ -2,7 +2,7 @@
 	display_name = "military fatigue selection"
 	description = "A selection of military uniforms."
 	path = /obj/item/clothing/under
-	allowed_branches = MILITARY_BRANCHES
+	allowed_branches = list(/datum/mil_branch/marine_corps)
 
 /datum/gear/uniform/misc_military/New()
 	..()

--- a/maps/torch/loadout/loadout_uniform_boh.dm
+++ b/maps/torch/loadout/loadout_uniform_boh.dm
@@ -2,6 +2,7 @@
 	display_name = "military fatigue selection"
 	description = "A selection of military uniforms."
 	path = /obj/item/clothing/under
+	cost = 0
 	allowed_branches = list(/datum/mil_branch/marine_corps)
 
 /datum/gear/uniform/misc_military/New()

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -133,6 +133,7 @@
 	#include "loadout/loadout_eyes.dm"
 	#include "loadout/loadout_gloves.dm"
 	#include "loadout/loadout_head.dm"
+	#include "loadout/loadout_head_boh.dm"
 	#include "loadout/loadout_shoes.dm"
 	#include "loadout/loadout_suit.dm"
 	#include "loadout/loadout_uniform.dm"


### PR DESCRIPTION
:cl: Anonymous
tweak: Renames fleet's berets and patches descriptions to be NT.
tweak: Camo military fatigue is now only for Marines, but made free of charge.
rscadd: Camo utility covers.
tweak: Lazy attempt to justify SMC wearing SCG Army uniform via description update.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->