### PR TITLE
changes starting breath masks in survival kits

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -81,7 +81,7 @@
 	name = "crew survival kit"
 	desc = "A box decorated in warning colors that contains a limited supply of survival tools. The panel and white stripe indicate this one contains oxygen."
 	icon_state = "survival"
-	startswith = list(/obj/item/clothing/mask/breath = 1,
+	startswith = list(/obj/item/clothing/mask/breath/scba = 1,
 					/obj/item/weapon/tank/emergency/oxygen = 1,
 					/obj/item/weapon/reagent_containers/hypospray/autoinjector = 1,
 					/obj/item/stack/medical/bruise_pack = 1,


### PR DESCRIPTION
Changes the starting breathing masks in the survival kits from the typical blue sprite to the SCBA mask engineers get, for more realism and aesthetic in roleplay; it seems more of a typical mask to use in deep space, or on bastion in general; to completely seal your face.