### PR TITLE
Changes Fleet and EC Ranks for Bridge Officers

### DIFF
--- a/maps/torch/items/clothing/solgov-accessory.dm
+++ b/maps/torch/items/clothing/solgov-accessory.dm
@@ -597,10 +597,20 @@ ranks - ec
 	desc = "Insignia denoting the rank of Ensign."
 	icon_state = "ecrank_o1"
 
+/obj/item/clothing/accessory/solgov/rank/ec/officer/o2
+	name = "ranks (O-2 lieutenant junior-grade)"
+	desc = "Insignia denoting the rank of Lieutenant Junior-Grade."
+	icon_state = "ecrank_o3"
+
 /obj/item/clothing/accessory/solgov/rank/ec/officer/o3
 	name = "ranks (O-3 lieutenant)"
 	desc = "Insignia denoting the rank of Lieutenant."
 	icon_state = "ecrank_o3"
+
+/obj/item/clothing/accessory/solgov/rank/ec/officer/o4
+	name = "ranks (O-4 lieutenant commander)"
+	desc = "Insignia denoting the rank of Lieutenant Commander"
+	icon_state = "ecrank_05"
 
 /obj/item/clothing/accessory/solgov/rank/ec/officer/o5
 	name = "ranks (O-5 commander)"
@@ -689,8 +699,8 @@ ranks - fleet
 	desc = "Insignia denoting the mythical rank of Warrant Officer. Too bad it's obviously fake."
 
 /obj/item/clothing/accessory/solgov/rank/fleet/officer/o2
-	name = "ranks (O-2 sub-lieutenant)"
-	desc = "Insignia denoting the rank of Sub-lieutenant."
+	name = "ranks (O-2 lieutenant junior-grade)"
+	desc = "Insignia denoting the rank of Lieutenant Junior-Grade."
 
 /obj/item/clothing/accessory/solgov/rank/fleet/officer/o3
 	name = "ranks (O-3 lieutenant)"

--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -50,7 +50,6 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/ec/o5,
-		/datum/mil_rank/fleet/o4,
 		/datum/mil_rank/fleet/o5
 	)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,

--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -373,7 +373,13 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/ec/o1,
-		/datum/mil_rank/fleet/o1
+		/datum/mil-rank/ec/o2,
+		/datum/mil_rank/ec/o3,
+		/datum/mil_rank/ec/o4,
+		/datum/mil_rank/fleet/o1,
+		/datum/mil_rank/fleet/o2,
+		/datum/mil_rank/fleet/o3,
+		/datum/mil_rank/fleet/o4
 	)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_PILOT       = SKILL_ADEPT)

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -389,8 +389,8 @@
 	sort_order = 11
 
 /datum/mil_rank/fleet/o2
-	name = "Sub-lieutenant"
-	name_short = "SLT"
+	name = "Lieutenant Junior-Grade"
+	name_short = "LTJG"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o2, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 12
 
@@ -483,11 +483,23 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/officer)
 	sort_order = 11
 
+/datum/mil_rank/ec/o2
+	name = "Lieutenant Junior-Grade"
+	name_short = "LTJG"
+	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/officer/o2)
+	sort_order = 12
+
 /datum/mil_rank/ec/o3
 	name = "Lieutenant"
 	name_short = "LT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/officer/o3)
 	sort_order = 13
+
+/datum/mil_rank/ec/o4
+	name = "Lieutenant Commander"
+	name_short = "LTCDR"
+	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/officer/o4)
+	sort_order = 14
 
 /datum/mil_rank/ec/o5
 	name = "Commander"


### PR DESCRIPTION
- - -
Tweaks:
- Removes Sub-Lieutenant.
- Adds Lieutenant Junior-Grade in it's place.
- Exploration Corps now has Lieutenant Junior-Grades and Lieutenant Commanders.
- Bridge Officers can now choose Ensign, Lieutenant Junior-Grade, Lieutenant, and Lieutenant Commander as their ranks, as it should be.

Future tweaks, and Edits: [[1]](https://github.com/BoHBranch/BoH-Bay/pull/278/commits/dfdbc03505a2d0af9076aef61b907825d7248922)
- Executive Officer no longer has Lieutenant Commander under it's rank availability.
- You must be a Commander to hold the position of Executive Officer in the Nanotrasen Fleet (NTF).

Makes the bridge officer crew more diverse like an actual starship.
Players should pick only for diversity between these ranks based on your command experience.
(I.e an Ensign having less command or overall bridge experience than a Lieutenant Commander)