### PR TITLE
Keys less confusing

### DIFF
--- a/code/modules/boh/sd_keyturn/keys.dm
+++ b/code/modules/boh/sd_keyturn/keys.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/sd_key
 	name = "self destruct key"
-	desc = "For when the final duty must be performed."
+	desc = "For when the final duty must be performed. The key can only be imprinted by a head of staff, premature activation is not required."
 	icon = 'icons/boh/items/sd_keys.dmi'
 	icon_state = "key_base"
 	w_class = ITEM_SIZE_TINY


### PR DESCRIPTION
Changelog:

- I dont know how to do a changelog and its about 8 pm and I am tired and that is bad and that is what a cowboy would do.

- Nuclear self destruct keys now have a description letting people know that they do not need to be activated at roundstart to imprint DNA since they can actually be only imprinted by Heads of Staff.