### PR TITLE
Buffs and Tweaks

### DIFF
--- a/code/modules/boh/infantry/dagon_inf.dm
+++ b/code/modules/boh/infantry/dagon_inf.dm
@@ -30,10 +30,9 @@
 	                    SKILL_PILOT       = SKILL_BASIC)
 	skill_points = 22
 
-	access = list(access_maint_tunnels, access_external_airlocks, access_emergency_storage,
-			            access_eva, access_sec_doors, access_solgov_crew, access_gun, access_petrov, access_petrov_security,
+	access = list(access_maint_tunnels, access_solgov_crew, access_petrov, access_petrov_security,
 			            access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy, access_hangar, access_guppy_helm, access_infantry,
-			            access_infcom, access_inftech, access_brig, access_security, access_aquila)
+			            access_infcom, access_inftech, access_aquila)
 
 	software_on_spawn = list(/datum/computer_file/program/deck_management,
 							 /datum/computer_file/program/reports)
@@ -61,10 +60,9 @@
 		/datum/mil_rank/marine_corps/e6
 		)
 
-	access = list(access_maint_tunnels, access_external_airlocks, access_emergency_storage,
-			            access_eva, access_sec_doors, access_solgov_crew, access_gun, access_petrov, access_petrov_security,
+	access = list(access_maint_tunnels, access_solgov_crew, access_petrov, access_petrov_security,
 			            access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy, access_hangar, access_guppy_helm, access_infantry,
-			            access_inftech, access_brig, access_security, access_aquila)
+			            access_inftech, access_aquila)
 
 	min_skill = list(	SKILL_CONSTRUCTION = SKILL_ADEPT,
 						SKILL_ELECTRICAL   = SKILL_ADEPT,
@@ -93,10 +91,9 @@
 	/datum/mil_rank/marine_corps/e5
 	)
 
-	access = list(access_maint_tunnels, access_external_airlocks, access_emergency_storage,
-			            access_eva, access_sec_doors, access_solgov_crew, access_gun, access_petrov, access_petrov_security,
+	access = list(access_maint_tunnels, access_solgov_crew, access_petrov, access_petrov_security,
 			            access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy, access_hangar, access_guppy_helm, access_infantry,
-			            access_brig, access_security, access_aquila)
+			            access_aquila)
 
 	software_on_spawn = list(/datum/computer_file/program/deck_management)
 

--- a/code/modules/boh/infantry/firearms.dm
+++ b/code/modules/boh/infantry/firearms.dm
@@ -3,26 +3,42 @@
 // Sec Bullpup
 /////////
 /obj/item/weapon/gun/projectile/automatic/bullpup_rifle/sec
-	name = "bullpup rifle"
+	name = "Z9 Bulldog"
 	desc = "The Hephaestus Industries Z9 Bulldog is a newer generation bullpup carbine. It appears to be heavily modified: forcing the feed of one round type, a permanent semi-auto setting and the removal of the auto-eject function. Lame. \
-	Still has the kickass grenade launcher, though!"
+	Still has the kickass grenade launcher, though! The aforementioned forced munition is a highly specialized frangible bullet. Designed to minimize crossfire damage, alongside civilian casualties."
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
 	ammo_type = /obj/item/ammo_casing/rifle/military/low
 	magazine_type = /obj/item/ammo_magazine/mil_rifle/sec
-	allowed_magazines = /obj/item/ammo_magazine/mil_rifle/sec
+	allowed_magazines = list(/obj/item/ammo_magazine/mil_rifle/sec, /obj/item/ammo_magazine/mil_rifle/sec/large)
 	auto_eject = 0
 	starts_loaded = 0
 	one_hand_penalty = 6 //lower power rounds
-	req_access = list(access_hop)
+	jam_chance = 5 //frangible rounds might shatter if they're chambered improperly.
+	req_access = list(access_infantry)
 	authorized_modes = list(UNAUTHORIZED)
 	firemodes = list(
 		list(mode_name="semi auto",       burst=1,    fire_delay=null,    move_delay=null, use_launcher=null, one_hand_penalty=8, burst_accuracy=null, dispersion=null),
+		list(mode_name="bump fire", burst=2, fire_delay=null, move_delay=1,    one_hand_penalty=8, burst_accuracy=list(0,-1,-1),       dispersion=list(0.0, 0.6, 1.0)),
 		list(mode_name="fire grenades",  burst=null, fire_delay=null, move_delay=null, use_launcher=1,    one_hand_penalty=10, burst_accuracy=null, dispersion=null)
 		)
 
 //loaded
 /obj/item/weapon/gun/projectile/automatic/bullpup_rifle/sec/loaded
 	starts_loaded = 1
+
+/////////
+// rifle 2
+/////////
+/obj/item/weapon/gun/energy/laser/secure/infantry
+	name = "G40B carbine"
+	desc = "A Hephaestus Industries G40B carbine, designed to kill with concentrated energy blasts. Fitted with safety chips to make sure discharge aboard a 'safe zone' is impossible.\
+	Additionally, it features a higher capacity."
+	charge_cost = 10
+	req_access = list(access_infantry)
+	authorized_modes = list(UNAUTHORIZED)
+	firemodes = list(
+		list(mode_name="authorized", burst=1, fire_delay=null, move_delay=null, one_hand_penalty=4, burst_accuracy=null, dispersion=null),
+		)
 
 /////////
 // c20
@@ -32,7 +48,7 @@
 	desc = "The NanoTrasen C-20b is a lightweight and rapid firing SMG. This is an older model, capable of only firing in semi-automatic and three-round bursts. \
 	Additionally, it does not feature the auto-eject function of the more modern version."
 	auto_eject = 0
-	req_access = list(access_hop)
+	req_access = list(access_infantry)
 	authorized_modes = list(UNAUTHORIZED)
 
 	firemodes = list(
@@ -58,8 +74,11 @@
 	name = "P10"
 	desc = "The Hephaestus Industries P10 - a mass produced kinetic sidearm in widespread service with the SCGDF. It has a slide restrictor, preventing quick-draw type shooting."
 	fire_delay = 12
-	req_access = list(access_hop)
+	req_access = list(access_infantry)
 	authorized_modes = list(UNAUTHORIZED)
+	firemodes = list(
+		list(mode_name="authorized", burst=1, fire_delay=null, move_delay=null, one_hand_penalty=2, burst_accuracy=null, dispersion=null),
+		)
 
 /////////
 // LMG
@@ -68,16 +87,38 @@
 	name = "L7 SAW"
 	desc = "A rather traditionally made L7 SAW with a pleasantly lacquered wooden pistol grip. Has 'Aussec Armoury- 2561' engraved on the reciever. \
 	It appears to have a firing restrictor installed, to prevent firing without authorization aboard the Dagon."
-	req_access = list(access_hop)
+	req_access = list(access_infantry)
 	authorized_modes = list(UNAUTHORIZED)
+	firemodes = list(
+		list(mode_name="semi auto", burst=1, fire_delay=null, move_delay=null, one_hand_penalty=6, burst_accuracy=null, dispersion=null),
+		list(mode_name="short bursts", burst=5, fire_delay=null, move_delay=4, one_hand_penalty=8, burst_accuracy=list(0,-1,-1), dispersion=list(0.0, 0.6, 1.0))
+		)
+
+//rifle
+/obj/item/weapon/gun/projectile/automatic/bullpup_rifle/sec/lmg
+	name = "Z6 Komodo"
+	desc = "The Hephaestus Industries Z6 Komodo is an old bullpup carbine conversion. \
+	It adds the possibility of automatic fire, though at the cost of likely jams."
+	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
+	auto_eject = 1
+	one_hand_penalty = 8
+	jam_chance = 15 //frangible rounds might shatter if they're chambered improperly. Especially so with such a high firerate.
+	firemodes = list(
+		list(mode_name="semi auto", burst=1, fire_delay=null, move_delay=null, use_launcher=null, one_hand_penalty=8, burst_accuracy=null, dispersion=null),
+		list(mode_name="burst fire",  burst=5, fire_delay=null, move_delay=2, one_hand_penalty=10, burst_accuracy=list(0,-1,-1), dispersion=list(0.0, 0.6, 1.0)),
+		list(mode_name="fire grenades",  burst=null, fire_delay=null, move_delay=null, use_launcher=1,    one_hand_penalty=10, burst_accuracy=null, dispersion=null)
+		)
 
 /////////
 // Recoilless Rifle
 /////////
-/obj/item/weapon/gun/launcher/rocket/recoilless/sec //can't be registered, but that doesn't matter as this prevents firing regardless
+/obj/item/weapon/gun/launcher/rocket/recoilless/sec
 	name = "TVP-3"
-	req_access = list(access_hop)
-	authorized_modes = list(UNAUTHORIZED)
+	req_access = list(access_infantry)
+	authorized_modes = list(UNAUTHORIZED) //can't be registered, but that doesn't matter as this prevents firing regardless
+	firemodes = list(
+		list(mode_name="authorized", burst=1, fire_delay=null, move_delay=null, one_hand_penalty=12, burst_accuracy=null, dispersion=null),
+		)
 
 /obj/item/weapon/gun/launcher/rocket/recoilless/sec/free_fire()
 	var/my_z = get_z(src)

--- a/code/modules/boh/infantry/storage.dm
+++ b/code/modules/boh/infantry/storage.dm
@@ -76,8 +76,8 @@
 
 /obj/item/gunbox/infantry/attack_self(mob/living/user)
 	var/list/options = list()
-	options["Grenadier"] = list(/obj/item/weapon/gun/projectile/automatic/bullpup_rifle/sec/loaded,/obj/item/weapon/gun/projectile/pistol/military/sec,/obj/item/weapon/grenade/frag/shell,/obj/item/weapon/grenade/frag/shell,/obj/item/weapon/grenade/frag/shell)
-	options["Rifleman"] = list(/obj/item/weapon/gun/projectile/automatic/bullpup_rifle/sec/loaded,/obj/item/weapon/gun/projectile/pistol/military/sec,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/frag)
+	options["Grenadier"] = list(/obj/item/weapon/gun/projectile/automatic/bullpup_rifle/sec/loaded,/obj/item/ammo_magazine/mil_rifle/sec,/obj/item/weapon/gun/projectile/pistol/military/sec,/obj/item/weapon/grenade/frag/shell,/obj/item/weapon/grenade/frag/shell,/obj/item/weapon/grenade/frag/shell)
+	options["Rifleman"] = list(/obj/item/weapon/gun/energy/laser/secure/infantry,/obj/item/weapon/gun/projectile/pistol/military/sec,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/frag)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)
 		var/list/things_to_spawn = options[choice]
@@ -93,7 +93,7 @@
 /obj/item/gunbox/infcom/attack_self(mob/living/user)
 	var/list/options = list()
 	options["Ballistic"] = list(/obj/item/weapon/gun/projectile/automatic/merc_smg/sec,/obj/item/weapon/gun/energy/revolver/secure)
-	options["Energy"] = list(/obj/item/weapon/gun/energy/taser/carbine/ext,/obj/item/weapon/gun/projectile/pistol/military/sec)
+	options["Energy"] = list(/obj/item/weapon/gun/energy/laser/secure/infantry,/obj/item/weapon/gun/energy/revolver/secure)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)
 		var/list/things_to_spawn = options[choice]
@@ -109,7 +109,7 @@
 /obj/item/gunbox/inftech/attack_self(mob/living/user)
 	var/list/options = list()
 	options["Demolitions"] = list(/obj/item/weapon/gun/launcher/rocket/recoilless/sec,/obj/item/ammo_casing/rocket/rcr,/obj/item/ammo_casing/rocket/rcr,/obj/item/weapon/gun/projectile/pistol/military/sec)
-	options["Dedicated SAG"] = list(/obj/item/weapon/gun/projectile/automatic/l6_saw/sec,/obj/item/weapon/gun/projectile/pistol/military/sec)
+	options["Dedicated SAG"] = list(/obj/item/weapon/gun/projectile/automatic/bullpup_rifle/sec/lmg,/obj/item/ammo_magazine/mil_rifle/sec/large,/obj/item/ammo_magazine/mil_rifle/sec/large,/obj/item/weapon/gun/projectile/pistol/military/sec)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)
 		var/list/things_to_spawn = options[choice]
@@ -142,9 +142,6 @@
 		/obj/item/ammo_casing/rocket/rcr,
 		/obj/item/ammo_casing/rocket/rcr,
 		/obj/item/ammo_casing/rocket/rcr,
-		/obj/item/ammo_magazine/box/machinegun,
-		/obj/item/ammo_magazine/box/machinegun,
-		/obj/item/ammo_magazine/box/machinegun,
 		/obj/item/weapon/rcd_ammo/large,
 		/obj/item/weapon/rcd_ammo/large
 		)

--- a/code/modules/boh/infantry/vending.dm
+++ b/code/modules/boh/infantry/vending.dm
@@ -3,8 +3,9 @@
 	desc = "A munition vendor."
 	req_access = list(access_infantry)
 	products = list(
-		/obj/item/ammo_magazine/mil_rifle/sec = 6,
-		/obj/item/ammo_magazine/pistol/double = 4,
-		/obj/item/ammo_magazine/smg = 2,
-		/obj/item/stack/medical/advanced/bruise_pack = 2,
-		/obj/item/stack/medical/advanced/ointment = 2)
+		/obj/item/ammo_magazine/mil_rifle/sec = 12,
+		/obj/item/ammo_magazine/mil_rifle/sec/large = 2,
+		/obj/item/ammo_magazine/pistol/double = 8,
+		/obj/item/ammo_magazine/smg = 6,
+		/obj/item/stack/medical/advanced/bruise_pack = 4,
+		/obj/item/stack/medical/advanced/ointment = 4)

--- a/code/modules/boh/offsite/syndi.dm
+++ b/code/modules/boh/offsite/syndi.dm
@@ -5,8 +5,6 @@
 /mob/living/simple_animal/hostile/retaliate/malf_drone/syndi
 	speak = list("ALERT.","Hostile entities detected.","Threat parameters set.","Bring sub-systems up to combat alert alpha.")
 	projectiletype = /obj/item/projectile/beam/drone/weak
-	malfunctioning = 0
-	hostile_drone = 1
 	faction = "syndicate"
 
 /obj/item/projectile/beam/drone/weak
@@ -19,9 +17,4 @@
 /mob/living/simple_animal/hostile/retaliate/malf_drone/guard
 	speak = list("Unregistered personnel detected. Engaging.")
 	projectiletype = /obj/item/projectile/beam/drone/weak
-	malfunctioning = 0
-	hostile_drone = 1
 	faction = "icarus"
-
-/obj/item/projectile/beam/drone/weak
-	damage = 5

--- a/code/modules/boh_misc/munitions.dm
+++ b/code/modules/boh_misc/munitions.dm
@@ -80,12 +80,11 @@
 	icon_state= "rod"
 	damage_type = BURN
 	damage = 95
-	armor_penetration = 35
-	damage_flags = DAM_BULLET | DAM_SHARP | DAM_EDGE
+	armor_penetration = 65 //not 100, because recoilless rifles don't have that high of a velocity
+	damage_flags = DAM_BULLET | DAM_SHARP | DAM_EDGE | DAM_DISPERSED | DAM_EXPLODE
 
 	on_hit(var/atom/target, var/blocked = 0)
 		explosion(target, 1, 6, 12)
-		damage_type = BURN
 		return 1
 
 /////////
@@ -126,17 +125,24 @@
 /////////
 //casing
 /obj/item/ammo_casing/rifle/military/low
-	desc = "A low-power bullet casing."
+	desc = "A frangible bullet casing."
 	caliber = CALIBER_RIFLE_MILITARY
 	projectile_type = /obj/item/projectile/bullet/rifle/military/sec
 
 //projectile
 /obj/item/projectile/bullet/rifle/military/sec
-	damage = 35
-	armor_penetration = 5
-	penetration_modifier = 1
+	damage = 60 //higher damage
+	armor_penetration = 5 //much worse pen - frangible bullets
+	penetration_modifier = 2 //higher post pen
 
 //mag
 /obj/item/ammo_magazine/mil_rifle/sec
-	name = "low-power rifle magazine"
+	name = "frangible munitions rifle magazine"
 	ammo_type = /obj/item/ammo_casing/rifle/military/low
+
+//bigger mag
+/obj/item/ammo_magazine/mil_rifle/sec/large
+	name = "high-cap frangible munitions rifle magazine"
+	icon_state = "assault_rifle"
+	ammo_type = /obj/item/ammo_casing/rifle/military/low
+	max_ammo = 35

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -270,7 +270,7 @@
 	firemodes = list(
 		list(mode_name="short bursts",	can_autofire=0, burst=5, fire_delay=5, move_delay=12, one_hand_penalty=8, burst_accuracy = list(0,-1,-1,-2,-2),          dispersion = list(0.6, 1.0, 1.0, 1.0, 1.2)),
 		list(mode_name="long bursts",	can_autofire=0, burst=8, fire_delay=5, one_hand_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(1.0, 1.0, 1.0, 1.0, 1.2)),
-		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=1, one_hand_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(1.0, 1.0, 1.0, 1.0, 1.2)),
+		list(mode_name="full auto",		can_autofire=1, burst=4, fire_delay=1, one_hand_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(1.0, 1.0, 1.0, 1.0, 1.2)),
 		)
 
 	var/cover_open = 0
@@ -304,7 +304,7 @@
 /obj/item/weapon/gun/projectile/automatic/l6_saw/on_update_icon()
 	..()
 	if(istype(ammo_magazine, /obj/item/ammo_magazine/box))
-		icon_state = "l6[cover_open ? "open" : "closed"][round(ammo_magazine.stored_ammo.len, 25)]"
+		icon_state = "l6[cover_open ? "open" : "closed"]"
 		item_state = "l6[cover_open ? "open" : "closed"]"
 	else if(ammo_magazine)
 		icon_state = "l6[cover_open ? "open" : "closed"]mag"


### PR DESCRIPTION
- - -
Tweaks:
 - Infantry access has been corrected.
 - Infantry Technician now has access to a proper squad support weapon.
 - Infantry _ballistic_ rifles have been significantly buffed. They've a new type of round, that, while lacking in AP value, has a significant amount of damage on the base line. It is made to reflect the role given to Infantry, and is rather worthless against anyone with armor.
 - Infantry Rifleman selection from the gunbox adjusted. They can now select a proper laser rifle, with 20 shots over the standard 10.
 - Infantry vending machine adjusted to have a larger number of items to dispense. This also includes one new item, a large magazine for the rifles given to Infantry.
 - Recoilless Rifle buffed. Again. Dispersed damage upon hitting, alongside much more penetration to represent the purpose of the launched projectile.
 - Combat drones should now act appropriately.
