### PR TITLE
Tweaks n snix

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/footwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/footwear.dm
@@ -12,7 +12,6 @@
 /datum/gear/shoes/boots
 	display_name = "boot selection"
 	path = /obj/item/clothing/shoes
-	cost = 2
 
 /datum/gear/shoes/boots/New()
 	..()

--- a/code/modules/client/preference_setup/loadout/lists/gloves.dm
+++ b/code/modules/client/preference_setup/loadout/lists/gloves.dm
@@ -1,5 +1,5 @@
 /datum/gear/gloves
-	cost = 2
+	cost = 1
 	slot = slot_gloves
 	sort_category = "Gloves and Handwear"
 	category = /datum/gear/gloves
@@ -12,12 +12,12 @@
 /datum/gear/gloves/latex
 	display_name = "gloves, latex"
 	path = /obj/item/clothing/gloves/latex
-	cost = 3
+	cost = 2
 
 /datum/gear/gloves/nitrile
 	display_name = "gloves, nitrile"
 	path = /obj/item/clothing/gloves/latex/nitrile
-	cost = 3
+	cost = 2
 
 /datum/gear/gloves/rainbow
 	display_name = "gloves, rainbow"
@@ -54,10 +54,10 @@
 /datum/gear/gloves/botany
 	display_name = "gloves, botany"
 	path = /obj/item/clothing/gloves/thick/botany
-	cost = 3
+	cost = 2
 	allowed_roles = list(/datum/job/rd, /datum/job/scientist, /datum/job/chef, /datum/job/bartender, /datum/job/assistant)
 
 /datum/gear/gloves/work
 	display_name = "gloves, work"
 	path = /obj/item/clothing/gloves/thick
-	cost = 3
+	cost = 2

--- a/maps/torch/datums/uniforms.dm
+++ b/maps/torch/datums/uniforms.dm
@@ -57,6 +57,8 @@
 
 	dress_extra = list(/obj/item/clothing/accessory/solgov/ec_scarf)
 
+// Commented out because it overrides modular's uniform system in some places.
+/*
 /decl/hierarchy/mil_uniform/fleet
 	name = "Master fleet outfit"
 	hierarchy_type = /decl/hierarchy/mil_uniform/fleet
@@ -84,6 +86,7 @@
 	dress_gloves = /obj/item/clothing/gloves/white
 
 	dress_extra = list(/obj/item/clothing/head/beret/solgov/fleet/dress)
+*/
 
 /decl/hierarchy/mil_uniform/civilian
 	name = "Master civilian outfit"		//Basically just here for the rent-a-tux, ahem, I mean... dress uniform.

--- a/maps/torch/datums/uniforms_exp_fleet.dm
+++ b/maps/torch/datums/uniforms_exp_fleet.dm
@@ -813,11 +813,22 @@
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/senior
 
+	service_hat_alt = /obj/item/clothing/head/solgov/dress/fleet
+	service_over_alt = /obj/item/clothing/suit/storage/solgov/service/fleet
+
+	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet
+
 /decl/hierarchy/mil_uniform/fleet/sci/chief
 	name = "NTEF science chief"
 	min_rank = 7
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/chief
+
+	service_hat_alt = /obj/item/clothing/head/solgov/dress/fleet
+	service_over_alt = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
+
+	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
+	dress_extra_alt = list(/obj/item/weapon/material/sword/replica/officersword/pettyofficer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/sci/officer
 	name = "NTEF science CO"

--- a/maps/torch/items/clothing/boh_accessory.dm
+++ b/maps/torch/items/clothing/boh_accessory.dm
@@ -28,9 +28,15 @@
 	name = "\improper NANOTRASEN patch"
 	desc = "An armor tag with the words NANOTRASEN printed in bottle green lettering on it."
 
-// Modular override of dog tags badge string
+// Dog Tags badge string rename, plus added for SMC and NTEF.
 /obj/item/clothing/accessory/badge/solgov/tags
-	badge_string = "Spaceman"
+	badge_string = "NTSS Dagon"
+
+/obj/item/clothing/accessory/badge/solgov/tags/fleet
+	badge_string = "NTEF"
+
+/obj/item/clothing/accessory/badge/solgov/tags/marine
+	badge_string = "SMC"
 
 // ranks and spec pin - expeditionary fleet
 /obj/item/clothing/accessory/solgov/specialty/enlisted/explorer

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -37,16 +37,16 @@
 #define SERVICE_ROLES list(/datum/job/janitor, /datum/job/chef, /datum/job/crew, /datum/job/bartender, /datum/job/chaplain)
 
 //For members of the exploration department
-#define EXPLORATION_ROLES list(/datum/job/pathfinder, /datum/job/nt_pilot, /datum/job/explorer)
+#define EXPLORATION_ROLES list(/datum/job/pathfinder, /datum/job/nt_pilot, /datum/job/explorer, /datum/job/grunt, /datum/job/combat_tech, /datum/job/squad_lead)
 
 //For members of the research department and jobs that are scientific
 #define RESEARCH_ROLES list(/datum/job/rd, /datum/job/scientist, /datum/job/mining, /datum/job/scientist_assistant, /datum/job/assistant, /datum/job/nt_pilot, /datum/job/senior_scientist, /datum/job/roboticist)
 
 //For jobs that spawn with weapons in their lockers
-#define ARMED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/sea, /datum/job/sea/marine, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/merchant, /datum/job/bodyguard)
+#define ARMED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/sea, /datum/job/sea/marine, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/merchant, /datum/job/bodyguard, /datum/job/grunt, /datum/job/combat_tech, /datum/job/squad_lead)
 
 //For jobs that spawn with armor in their lockers
-#define ARMORED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/qm, /datum/job/sea, /datum/job/sea/marine, /datum/job/bridgeofficer, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/merchant, /datum/job/bodyguard, /datum/job/submap/skrellscoutship_crew, /datum/job/submap/skrellscoutship_crew/leader)
+#define ARMORED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/qm, /datum/job/sea, /datum/job/sea/marine, /datum/job/bridgeofficer, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/merchant, /datum/job/bodyguard, /datum/job/submap/skrellscoutship_crew, /datum/job/submap/skrellscoutship_crew/leader, /datum/job/grunt, /datum/job/combat_tech, /datum/job/squad_lead)
 
 #define UNIFORMED_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/marine_corps)
 

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -2,7 +2,7 @@
 	display_name = "major award selection"
 	description = "A medal or ribbon awarded to military and paramilitary personnel for significant accomplishments."
 	path = /obj/item/clothing/accessory
-	cost = 8
+	cost = 4
 	allowed_branches = TACTICOOL_BRANCHES
 
 /datum/gear/accessory/solawardmajor/New()
@@ -22,7 +22,7 @@
 	display_name = "minor award selection"
 	description = "A medal or ribbon awarded to military and paramilitary personnel for minor accomplishments."
 	path = /obj/item/clothing/accessory
-	cost = 5
+	cost = 2
 	allowed_branches = TACTICOOL_BRANCHES
 
 /datum/gear/accessory/solawardminor/New()
@@ -42,6 +42,7 @@
 	display_name = "Surveyor Corps scarf"
 	path = /obj/item/clothing/accessory/solgov/ec_scarf
 	description = "A section-specific scarf for Survey Corps uniforms."
+	cost = 0
 	flags = GEAR_HAS_TYPE_SELECTION
 	allowed_branches = NT_BRANCHES
 
@@ -49,6 +50,7 @@
 	display_name = "Surveyor Corps patch"
 	path = /obj/item/clothing/accessory/solgov/ec_patch
 	description = "A shoulder patch representing the Survey Corps."
+	cost = 0
 	flags = GEAR_HAS_TYPE_SELECTION
 	allowed_branches = NT_BRANCHES
 
@@ -67,6 +69,7 @@
 	display_name = "fleet patch"
 	path = /obj/item/clothing/accessory/solgov/fleet_patch
 	flags = GEAR_HAS_TYPE_SELECTION
+	cost = 0
 	allowed_branches = list(/datum/mil_branch/fleet)
 
 /datum/gear/accessory/armband_ma

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -120,20 +120,20 @@
 						/datum/job/mining, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/engineer_trainee, /datum/job/explorer, /datum/job/nt_pilot, /datum/job/pathfinder)
 
 /datum/gear/storage/black_vest
-	allowed_roles = list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/merchant)
+	allowed_roles = list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/merchant, /datum/job/grunt, /datum/job/combat_tech, /datum/job/squad_lead)
 
 /datum/gear/storage/white_vest
-	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/medical_trainee, /datum/job/chemist, /datum/job/merchant, /datum/job/medical_trainee)
+	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/medical_trainee, /datum/job/chemist, /datum/job/merchant, /datum/job/grunt, /datum/job/combat_tech, /datum/job/squad_lead)
 
 /datum/gear/storage/brown_drop_pouches
 	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/roboticist, /datum/job/qm, /datum/job/cargo_tech,
 						/datum/job/mining, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/merchant, /datum/job/engineer_trainee)
 
 /datum/gear/storage/black_drop_pouches
-	allowed_roles = list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/merchant)
+	allowed_roles = list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/merchant, /datum/job/grunt, /datum/job/combat_tech, /datum/job/squad_lead)
 
 /datum/gear/storage/white_drop_pouches
-	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/medical_trainee, /datum/job/chemist, /datum/job/merchant, /datum/job/medical_trainee)
+	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/medical_trainee, /datum/job/chemist, /datum/job/merchant, /datum/job/grunt, /datum/job/combat_tech, /datum/job/squad_lead)
 
 /datum/gear/tactical/holster
 	allowed_roles = ARMED_ROLES

--- a/maps/torch/loadout/loadout_accessories_boh.dm
+++ b/maps/torch/loadout/loadout_accessories_boh.dm
@@ -29,6 +29,20 @@
 	display_name = "Medical tag, alt"
 	path = /obj/item/clothing/accessory/armor/tag/civ/med
 
+/datum/gear/accessory/tags/marine
+	display_name = "dog tags, solar marine corps"
+	description = "Plain identification tags made from a durable metal. This one is issued to marines."
+	path = /obj/item/clothing/accessory/badge/solgov/tags/marine
+	allowed_branches = list(/datum/mil_branch/marine_corps)
+	cost = 0
+
+/datum/gear/accessory/tags/fleet
+	display_name = "dog tags, expeditionary fleet"
+	description = "Plain identification tags made from a durable metal. This one is issued to fleet."
+	path = /obj/item/clothing/accessory/badge/solgov/tags/fleet
+	allowed_branches = list(/datum/mil_branch/fleet)
+	cost = 0
+
 // Separating main's certain armor customization items.
 /datum/gear/tactical/blood_patch
 	display_name = "blood patch selection"

--- a/maps/torch/loadout/loadout_accessories_boh.dm
+++ b/maps/torch/loadout/loadout_accessories_boh.dm
@@ -8,11 +8,13 @@
 	display_name = "Marine Corps patch"
 	path = /obj/item/clothing/accessory/solgov/smc_patch
 	allowed_branches = list(/datum/mil_branch/marine_corps)
+	cost = 0
 	whitelisted = list(SPECIES_HUMAN, SPECIES_IPC)
 
 /datum/gear/accessory/smc_patch_xenos
 	display_name = "Marine Corps patch (xenoic division)"
 	path = /obj/item/clothing/accessory/solgov/smc_patch/xeno
+	cost = 0
 	allowed_branches = list(/datum/mil_branch/marine_corps)
 
 /datum/gear/tactical/civ_tag

--- a/maps/torch/loadout/loadout_gloves.dm
+++ b/maps/torch/loadout/loadout_gloves.dm
@@ -25,5 +25,5 @@
 /datum/gear/gloves/duty
 	display_name = "gloves, duty"
 	path = /obj/item/clothing/gloves/thick/duty
-	cost = 3
+	cost = 2
 	allowed_branches = UNIFORMED_BRANCHES

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -23,7 +23,7 @@
 
 	#include "datums/uniforms.dm"
 	#include "datums/uniforms_expedition.dm"
-	#include "datums/uniforms_fleet.dm"
+	//#include "datums/uniforms_fleet.dm"
 	#include "datums/uniforms_exp_fleet.dm"
 	#include "datums/uniforms_marine-corps.dm"
 	#include "datums/reports/command.dm"


### PR DESCRIPTION
:cl: Anonymous
tweak: Decreases loadout costs: gloves 2->1, spec gloves 3->2, boot selection 2->1, minor awards 5->2, major awards 8->4. Patches and some other military accessories are made free.
tweak: Places infantry into `ARMED` and `ARMORED` defines, meaning they can use corresponding loadout stuff. Also allows them to use black and white webbings.
tweak: Changes dog tags string to read "NTSS Dagon"
rscadd: Dog tags for fleet and marine. Nothing special other than corresponding string.
bugfix: Fixes NTEF uniform system sometimes replacing some non-alt uniforms with alts.
tweak: Allows science guys to use fleet's alt service uniform, dress and extras.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->