### PR TITLE
Updates Makeshift WO Rank Tabs

### DIFF
--- a/maps/torch/items/clothing/solgov-accessory.dm
+++ b/maps/torch/items/clothing/solgov-accessory.dm
@@ -687,7 +687,7 @@ ranks - fleet
 
 /obj/item/clothing/accessory/solgov/rank/fleet/officer/wo1_monkey
 	name = "makeshift ranks (WO-1 warrant officer 1)"
-	desc = "Insignia denoting the mythical rank of Warrant Officer. Too bad it's obviously fake."
+	desc = "Insignia denoting the  rank of Warrant Officer. It looks to be upside down."
 
 /obj/item/clothing/accessory/solgov/rank/fleet/officer/o2
 	name = "ranks (O-2 sub-lieutenant)"


### PR DESCRIPTION
Changes the description to state the rank tabs are upside down, as befitting the Monkey Officer.

![funitelli](https://user-images.githubusercontent.com/12451752/73112008-90347f00-3f04-11ea-955d-ea4f82a5d2b7.jpg)