### PR TITLE
Camo variants for the uniform vendor, and further uniform system tweaks

### DIFF
--- a/maps/torch/datums/uniforms_marine-corps.dm
+++ b/maps/torch/datums/uniforms_marine-corps.dm
@@ -449,7 +449,8 @@
 		/obj/item/clothing/head/ushanka/solgov/army,
 		/obj/item/clothing/head/ushanka/solgov/army/green,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/cmd
 	)
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/command
@@ -474,10 +475,13 @@
 		/obj/item/clothing/head/ushanka/solgov/army,
 		/obj/item/clothing/head/ushanka/solgov/army/green,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov
+		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/gloves/thick/duty/solgov/cmd
 	)
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/command
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
+	utility_under_tan = /obj/item/clothing/under/solgov/utility/army/tan/command
 
 	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command

--- a/maps/torch/datums/uniforms_marine-corps.dm
+++ b/maps/torch/datums/uniforms_marine-corps.dm
@@ -1,3 +1,9 @@
+/decl/hierarchy/mil_uniform
+	var/utility_under_urban = null
+	var/utility_under_tan = null
+	var/utility_hat_urban = null
+	var/utility_hat_tan = null
+
 /decl/hierarchy/mil_uniform/marine_corps
 	name = "Master marine corps outfit"
 	hierarchy_type = /decl/hierarchy/mil_uniform/marine_corps
@@ -7,8 +13,12 @@
 	pt_shoes = /obj/item/clothing/shoes/black
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban
+	utility_under_tan = /obj/item/clothing/under/solgov/utility/army/tan
 	utility_shoes = /obj/item/clothing/shoes/dutyboots
 	utility_hat = /obj/item/clothing/head/solgov/utility/army
+	utility_hat_urban = /obj/item/clothing/under/solgov/utility/army/urban
+	utility_hat_tan = /obj/item/clothing/head/solgov/utility/army/tan
 	utility_extra = list(
 		/obj/item/clothing/head/beret/solgov,
 		/obj/item/clothing/head/ushanka/solgov/army,
@@ -38,6 +48,8 @@
 	departments = COM
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/command
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
+	utility_under_tan = /obj/item/clothing/under/solgov/utility/army/tan/command
 	utility_extra = list(
 		/obj/item/clothing/under/solgov/utility/army/command,
 		/obj/item/clothing/head/beret/solgov,
@@ -67,6 +79,8 @@
 	departments = ENG
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/engineering
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/engineering
+	utility_under_tan = /obj/item/clothing/under/solgov/utility/army/tan/engineering
 	utility_extra = list(
 		/obj/item/clothing/head/beret/solgov,
 		/obj/item/clothing/head/ushanka/solgov/army,
@@ -123,7 +137,9 @@
 /decl/hierarchy/mil_uniform/marine_corps/sec
 	name = "Marine Corps security"
 	departments = SEC
-
+	utility_under = /obj/item/clothing/under/solgov/utility/army/security
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/security
+	utility_under_tan = /obj/item/clothing/under/solgov/utility/army/tan/security
 	utility_extra = list(
 		/obj/item/clothing/head/beret/solgov,
 		/obj/item/clothing/head/ushanka/solgov/army,
@@ -180,7 +196,9 @@
 /decl/hierarchy/mil_uniform/marine_corps/med
 	name = "Marine Corps medical"
 	departments = MED
-
+	utility_under = /obj/item/clothing/under/solgov/utility/army/medical
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/medical
+	utility_under_tan = /obj/item/clothing/under/solgov/utility/army/tan/medical
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
 		/obj/item/clothing/head/ushanka/solgov/army/green,
@@ -238,6 +256,8 @@
 	departments = SUP
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/supply
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/supply
+	utility_under_tan = /obj/item/clothing/under/solgov/utility/army/tan/supply
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
 		/obj/item/clothing/head/ushanka/solgov/army/green,
@@ -307,6 +327,8 @@
 	departments = SRV
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/service
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/service
+	utility_under_tan = /obj/item/clothing/under/solgov/utility/army/tan/service
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
 		/obj/item/clothing/head/ushanka/solgov/army/green,
@@ -353,6 +375,8 @@
 	departments = EXP
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/exploration
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/exploration
+	utility_under_tan = /obj/item/clothing/under/solgov/utility/army/tan/exploration
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
 		/obj/item/clothing/head/ushanka/solgov/army/green,
@@ -399,6 +423,8 @@
 	departments = SPT
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/command
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
+	utility_under_tan = /obj/item/clothing/under/solgov/utility/army/tan/command
 
 /decl/hierarchy/mil_uniform/marine_corps/spt/noncom
 	name = "Marine Corps support NCO"
@@ -425,6 +451,8 @@
 	)
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/command
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
+	utility_under_tan = /obj/item/clothing/under/solgov/utility/army/tan/command
 
 	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command

--- a/maps/torch/datums/uniforms_marine-corps.dm
+++ b/maps/torch/datums/uniforms_marine-corps.dm
@@ -137,6 +137,7 @@
 /decl/hierarchy/mil_uniform/marine_corps/sec
 	name = "Marine Corps security"
 	departments = SEC
+
 	utility_under = /obj/item/clothing/under/solgov/utility/army/security
 	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/security
 	utility_under_tan = /obj/item/clothing/under/solgov/utility/army/tan/security
@@ -196,6 +197,7 @@
 /decl/hierarchy/mil_uniform/marine_corps/med
 	name = "Marine Corps medical"
 	departments = MED
+
 	utility_under = /obj/item/clothing/under/solgov/utility/army/medical
 	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/medical
 	utility_under_tan = /obj/item/clothing/under/solgov/utility/army/tan/medical

--- a/maps/torch/items/clothing/boh_under.dm
+++ b/maps/torch/items/clothing/boh_under.dm
@@ -1,0 +1,50 @@
+
+// Urban accessories
+/obj/item/clothing/under/solgov/utility/army/urban/command
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/army)
+
+/obj/item/clothing/under/solgov/utility/army/urban/engineering
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/engineering/army)
+
+/obj/item/clothing/under/solgov/utility/army/urban/security
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/security/army)
+
+/obj/item/clothing/under/solgov/utility/army/urban/medical
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/medical/army)
+
+/obj/item/clothing/under/solgov/utility/army/urban/medical/banded
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/medical/army, /obj/item/clothing/accessory/armband/medblue)
+
+/obj/item/clothing/under/solgov/utility/army/urban/supply
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/supply/army)
+
+/obj/item/clothing/under/solgov/utility/army/urban/service
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/service/army)
+
+/obj/item/clothing/under/solgov/utility/army/urban/exploration
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/army)
+
+// Tan accessories
+/obj/item/clothing/under/solgov/utility/army/tan/command
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/army)
+
+/obj/item/clothing/under/solgov/utility/army/tan/engineering
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/engineering/army)
+
+/obj/item/clothing/under/solgov/utility/army/tan/security
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/security/army)
+
+/obj/item/clothing/under/solgov/utility/army/tan/medical
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/medical/army)
+
+/obj/item/clothing/under/solgov/utility/army/tan/medical/banded
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/medical/army, /obj/item/clothing/accessory/armband/medblue)
+
+/obj/item/clothing/under/solgov/utility/army/tan/supply
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/supply/army)
+
+/obj/item/clothing/under/solgov/utility/army/tan/service
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/service/army)
+
+/obj/item/clothing/under/solgov/utility/army/tan/exploration
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/army)

--- a/maps/torch/items/uniform_vendor_boh.dm
+++ b/maps/torch/items/uniform_vendor_boh.dm
@@ -1,4 +1,4 @@
-// A modular rewrite to allow "alternative" uniform. Done for NTEF to allow both NTSC and NTF uniforms.
+// A modular rewrite to allow "alternative" uniform. Done for NTEF to allow both NTSC and NTF uniforms, and to allow marines for camo selection.
 // Some of those (shoes, gloves) are not really needed but hey - safe check.
 
 /obj/machinery/uniform_vendor/populate_uniforms(decl/hierarchy/mil_uniform/user_outfit)
@@ -17,14 +17,27 @@
 		user_outfit.utility_shoes,
 		user_outfit.utility_hat
 		)
+	if (user_outfit.utility_under_urban || user_outfit.utility_hat_urban)
+		res["Urban Utility"] = list(
+			user_outfit.utility_under_urban,
+			user_outfit.utility_shoes,
+			user_outfit.utility_hat_urban
+			)
+	if (user_outfit.utility_under_tan || user_outfit.utility_hat_tan)
+		res["Tan Utility"] = list(
+			user_outfit.utility_under_tan,
+			user_outfit.utility_shoes,
+			user_outfit.utility_hat_tan
+			)
 	if (user_outfit.utility_extra)
 		res["Utility Extras"] = user_outfit.utility_extra
 
-	res["Alt Utility"] = list(
-		user_outfit.utility_under_alt,
-		user_outfit.utility_shoes_alt,
-		user_outfit.utility_hat_alt
-		)
+	if (user_outfit.utility_under_alt || user_outfit.utility_shoes_alt || user_outfit.utility_hat_alt)
+		res["Alt Utility"] = list(
+			user_outfit.utility_under_alt,
+			user_outfit.utility_shoes_alt,
+			user_outfit.utility_hat_alt
+			)
 	if (user_outfit.utility_extra_alt)
 		res["Alt Utility Extras"] = user_outfit.utility_extra_alt
 
@@ -39,14 +52,15 @@
 	if(user_outfit.service_extra)
 		res["Service Extras"] = user_outfit.service_extra
 
-	res["Alt Service"] = list(
-		user_outfit.service_under_alt,
-		user_outfit.service_skirt_alt,
-		user_outfit.service_over_alt,
-		user_outfit.service_shoes_alt,
-		user_outfit.service_hat_alt,
-		user_outfit.service_gloves_alt
-		)
+	if (user_outfit.service_under_alt || user_outfit.service_skirt_alt || user_outfit.service_over_alt || user_outfit.utility_shoes_alt || user_outfit.utility_hat_alt || user_outfit.service_gloves_alt)
+		res["Alt Service"] = list(
+			user_outfit.service_under_alt,
+			user_outfit.service_skirt_alt,
+			user_outfit.service_over_alt,
+			user_outfit.service_shoes_alt,
+			user_outfit.service_hat_alt,
+			user_outfit.service_gloves_alt
+			)
 	if(user_outfit.service_extra_alt)
 		res["Alt Service Extras"] = user_outfit.service_extra_alt
 
@@ -61,14 +75,15 @@
 	if(user_outfit.dress_extra)
 		res["Dress Extras"] = user_outfit.dress_extra
 
-	res["Alt Dress"] = list(
-		user_outfit.dress_under_alt,
-		user_outfit.dress_skirt_alt,
-		user_outfit.dress_over_alt,
-		user_outfit.dress_shoes_alt,
-		user_outfit.dress_hat_alt,
-		user_outfit.dress_gloves_alt
-		)
+	if (user_outfit.dress_under_alt || user_outfit.dress_skirt_alt || user_outfit.dress_over_alt || user_outfit.dress_shoes_alt || user_outfit.dress_hat_alt || user_outfit.dress_gloves_alt)
+		res["Alt Dress"] = list(
+			user_outfit.dress_under_alt,
+			user_outfit.dress_skirt_alt,
+			user_outfit.dress_over_alt,
+			user_outfit.dress_shoes_alt,
+			user_outfit.dress_hat_alt,
+			user_outfit.dress_gloves_alt
+			)
 	if(user_outfit.dress_extra_alt)
 		res["Alt Dress Extras"] = user_outfit.dress_extra_alt
 

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -76,6 +76,7 @@
 	#include "items/clothing/terran-head.dm"
 	#include "items/clothing/terran-suit.dm"
 	#include "items/clothing/terran-under.dm"
+	#include "items/clothing/boh_under.dm"
 	#include "items/clothing/boh_accessory.dm"
 
 	#include "items/weapon/storage/wallets.dm"


### PR DESCRIPTION
:cl: Anonymous
bugfix: Uniform Vendor shall no longer show empty alternative tabs if nothing was set for it.
rscadd: Uniform Vendor will now dispense urban and tan variations for SMC, along with department line colors.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->