### PR TITLE
Removes total blackout effect from unconsciousness

### DIFF
--- a/code/modules/boh/culture_descriptor/culture/cultures_sergal.dm
+++ b/code/modules/boh/culture_descriptor/culture/cultures_sergal.dm
@@ -2,7 +2,7 @@
 	name = CULTURE_SERGAL
 	description = "WIP ask the lore team to work on this some time"
 	economic_power = 1
-	name_language = LANGUAGE_SERGAL
+	language = LANGUAGE_SERGAL
 	secondary_langs = list(
 		LANGUAGE_SIGN,
 		LANGUAGE_GUTTER,

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -174,8 +174,6 @@
 		set_fullscreen(eye_blurry, "blurry", /obj/screen/fullscreen/blurry)
 		set_fullscreen(druggy, "high", /obj/screen/fullscreen/high)
 
-	set_fullscreen(stat == UNCONSCIOUS, "blackout", /obj/screen/fullscreen/blackout)
-
 	if(machine)
 		var/viewflags = machine.check_eye(src)
 		if(viewflags < 0)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -536,7 +536,6 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 		return 1
 
 	H.set_fullscreen(H.eye_blind && !H.equipment_prescription, "blind", /obj/screen/fullscreen/blind)
-	H.set_fullscreen(H.stat == UNCONSCIOUS, "blackout", /obj/screen/fullscreen/blackout)
 
 	if(config.welder_vision)
 		H.set_fullscreen(H.equipment_tint_total, "welder", /obj/screen/fullscreen/impaired, H.equipment_tint_total)


### PR DESCRIPTION
Changelog 
Instead of being a pure black screen, now you can see your tile and a haze of the ones adjacent. 
[https://cdn.discordapp.com/attachments/589275442171740160/671187578887864350/unknown.png](url)
/Changelog

Are we getting dragged to medical to be forgotten in a cryo bay, or dragged into maint to become the next to find the light of our lord Tower?