### PR TITLE
Removes Species Restrictions for Most Hairstyles, Beardstyles, and Body Markings.

### DIFF
--- a/code/modules/sprite_accessories/_accessory_facial.dm
+++ b/code/modules/sprite_accessories/_accessory_facial.dm
@@ -14,7 +14,6 @@
 	name = "Shaved"
 	icon_state = "bald"
 	gender = NEUTER
-	species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI,SPECIES_SKRELL,SPECIES_VOX,SPECIES_IPC)
 
 /datum/sprite_accessory/facial_hair/watson
 	name = "Watson Mustache"
@@ -55,7 +54,6 @@
 /datum/sprite_accessory/facial_hair/elvis
 	name = "Elvis Sideburns"
 	icon_state = "facial_elvis"
-	species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 
 /datum/sprite_accessory/facial_hair/abe
 	name = "Abraham Lincoln Beard"

--- a/code/modules/sprite_accessories/_accessory_hair.dm
+++ b/code/modules/sprite_accessories/_accessory_hair.dm
@@ -13,8 +13,6 @@
 /datum/sprite_accessory/hair/bald
 	name = "Bald"
 	icon_state = "bald"
-
-	species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI,SPECIES_VOX,SPECIES_SERGAL,SPECIES_IPC)
 	flags = VERY_SHORT | HAIR_BALD
 
 /datum/sprite_accessory/hair/short
@@ -82,7 +80,6 @@
 /datum/sprite_accessory/hair/ponytail2
 	name = "Ponytail 2"
 	icon_state = "hair_pa"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/ponytail3
@@ -93,25 +90,21 @@
 /datum/sprite_accessory/hair/ponytail4
 	name = "Ponytail 4"
 	icon_state = "hair_ponytail4"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/ponytail5
 	name = "Ponytail 5"
 	icon_state = "hair_ponytail5"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/ponytail6
 	name = "Ponytail 6"
 	icon_state = "hair_ponytail6"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/sideponytail
 	name = "Side Ponytail"
 	icon_state = "hair_stail"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/parted
@@ -122,7 +115,6 @@
 	name = "Pompadour"
 	icon_state = "hair_pompadour"
 
-
 /datum/sprite_accessory/hair/sleeze
 	name = "Sleeze"
 	icon_state = "hair_sleeze"
@@ -131,7 +123,6 @@
 /datum/sprite_accessory/hair/quiff
 	name = "Quiff"
 	icon_state = "hair_quiff"
-
 
 /datum/sprite_accessory/hair/bedhead
 	name = "Bedhead"
@@ -149,33 +140,25 @@
 /datum/sprite_accessory/hair/beehive
 	name = "Beehive"
 	icon_state = "hair_beehive"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/beehive2
 	name = "Beehive 2"
 	icon_state = "hair_beehive2"
 
-
 /datum/sprite_accessory/hair/bobcurl
 	name = "Bobcurl"
 	icon_state = "hair_bobcurl"
-
-	species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/bob
 	name = "Bob"
 	icon_state = "hair_bobcut"
-
-	species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/bobcutalt
 	name = "Chin Length Bob"
 	icon_state = "hair_bobcutalt"
-
-	species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/bowl
@@ -186,30 +169,24 @@
 /datum/sprite_accessory/hair/buzz
 	name = "Buzzcut"
 	icon_state = "hair_buzzcut"
-
-	species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/crew
 	name = "Crewcut"
 	icon_state = "hair_crewcut"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/combover
 	name = "Combover"
 	icon_state = "hair_combover"
 
-
 /datum/sprite_accessory/hair/father
 	name = "Father"
 	icon_state = "hair_father"
 
-
 /datum/sprite_accessory/hair/reversemohawk
 	name = "Reverse Mohawk"
 	icon_state = "hair_reversemohawk"
-
 
 /datum/sprite_accessory/hair/devillock
 	name = "Devil Lock"
@@ -236,7 +213,6 @@
 	name = "Big Afro"
 	icon_state = "hair_bigafro"
 
-
 /datum/sprite_accessory/hair/rows
 	name = "Rows"
 	icon_state = "hair_rows1"
@@ -250,7 +226,6 @@
 /datum/sprite_accessory/hair/sargeant
 	name = "Flat Top"
 	icon_state = "hair_sargeant"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/emo
@@ -264,7 +239,6 @@
 /datum/sprite_accessory/hair/longemo
 	name = "Long Emo"
 	icon_state = "hair_emolong"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/shortovereye
@@ -290,21 +264,17 @@
 	name = "Hitop"
 	icon_state = "hair_hitop"
 
-
 /datum/sprite_accessory/hair/mohawk
 	name = "Mohawk"
 	icon_state = "hair_d"
-	species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 
 /datum/sprite_accessory/hair/jensen
 	name = "Adam Jensen Hair"
 	icon_state = "hair_jensen"
 
-
 /datum/sprite_accessory/hair/gelled
 	name = "Gelled Back"
 	icon_state = "hair_gelled"
-
 
 /datum/sprite_accessory/hair/gentle
 	name = "Gentle"
@@ -315,7 +285,6 @@
 /datum/sprite_accessory/hair/spiky
 	name = "Spiky"
 	icon_state = "hair_spikey"
-	species_allowed = list(SPECIES_HUMAN,SPECIES_UNATHI)
 
 /datum/sprite_accessory/hair/kusangi
 	name = "Kusanagi Hair"
@@ -324,55 +293,46 @@
 /datum/sprite_accessory/hair/kagami
 	name = "Pigtails"
 	icon_state = "hair_kagami"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/himecut
 	name = "Hime Cut"
 	icon_state = "hair_himecut"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/shorthime
 	name = "Short Hime Cut"
 	icon_state = "hair_shorthime"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/grandebraid
 	name = "Grande Braid"
 	icon_state = "hair_grande"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/mbraid
 	name = "Medium Braid"
 	icon_state = "hair_shortbraid"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/braid2
 	name = "Long Braid"
 	icon_state = "hair_hbraid"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/odango
 	name = "Odango"
 	icon_state = "hair_odango"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/ombre
 	name = "Ombre"
 	icon_state = "hair_ombre"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/updo
 	name = "Updo"
 	icon_state = "hair_updo"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/skinhead
@@ -383,72 +343,59 @@
 /datum/sprite_accessory/hair/balding
 	name = "Balding Hair"
 	icon_state = "hair_e"
- // turnoff!
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/familyman
 	name = "The Family Man"
 	icon_state = "hair_thefamilyman"
 
-
 /datum/sprite_accessory/hair/mahdrills
 	name = "Drillruru"
 	icon_state = "hair_drillruru"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/fringetail
 	name = "Fringetail"
 	icon_state = "hair_fringetail"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/dandypomp
 	name = "Dandy Pompadour"
 	icon_state = "hair_dandypompadour"
 
-
 /datum/sprite_accessory/hair/poofy
 	name = "Poofy"
 	icon_state = "hair_poofy"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/crono
 	name = "Chrono"
 	icon_state = "hair_toriyama"
 
-
 /datum/sprite_accessory/hair/vegeta
 	name = "Vegeta"
 	icon_state = "hair_toriyama2"
-
 
 /datum/sprite_accessory/hair/cia
 	name = "CIA"
 	icon_state = "hair_cia"
 
-
 /datum/sprite_accessory/hair/mulder
 	name = "Mulder"
 	icon_state = "hair_mulder"
-
 
 /datum/sprite_accessory/hair/scully
 	name = "Scully"
 	icon_state = "hair_scully"
 
-
 /datum/sprite_accessory/hair/nitori
 	name = "Nitori"
 	icon_state = "hair_nitori"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/joestar
 	name = "Joestar"
 	icon_state = "hair_joestar"
-
 
 /datum/sprite_accessory/hair/volaju
 	name = "Volaju"
@@ -502,7 +449,6 @@
 /datum/sprite_accessory/hair/lowfade
 	name = "Low Fade"
 	icon_state = "hair_lowfade"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/medfade
@@ -513,132 +459,110 @@
 /datum/sprite_accessory/hair/highfade
 	name = "High Fade"
 	icon_state = "hair_highfade"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/baldfade
 	name = "Balding Fade"
 	icon_state = "hair_baldfade"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/nofade
 	name = "Regulation Cut"
 	icon_state = "hair_nofade"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/trimflat
 	name = "Trimmed Flat Top"
 	icon_state = "hair_trimflat"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/shaved
 	name = "Shaved"
 	icon_state = "hair_shaved"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/trimmed
 	name = "Trimmed"
 	icon_state = "hair_trimmed"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/tightbun
 	name = "Tight Bun"
 	icon_state = "hair_tightbun"
-
 	flags = VERY_SHORT | HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/coffeehouse
 	name = "Coffee House Cut"
 	icon_state = "hair_coffeehouse"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/undercut
 	name = "Undercut"
 	icon_state = "hair_undercut"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/partfade
 	name = "Parted Fade"
 	icon_state = "hair_shavedpart"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/hightight
 	name = "High and Tight"
 	icon_state = "hair_hightight"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/rowbun
 	name = "Row Bun"
 	icon_state = "hair_rowbun"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/rowdualbraid
 	name = "Row Dual Braid"
 	icon_state = "hair_rowdualtail"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/rowbraid
 	name = "Row Braid"
 	icon_state = "hair_rowbraid"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/regulationmohawk
 	name = "Regulation Mohawk"
 	icon_state = "hair_shavedmohawk"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/topknot
 	name = "Topknot"
 	icon_state = "hair_topknot"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/ronin
 	name = "Ronin"
 	icon_state = "hair_ronin"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/bowlcut2
 	name = "Bowl2"
 	icon_state = "hair_bowlcut2"
 
-
 /datum/sprite_accessory/hair/thinning
 	name = "Thinning"
 	icon_state = "hair_thinning"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/thinningfront
 	name = "Thinning Front"
 	icon_state = "hair_thinningfront"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/thinningback
 	name = "Thinning Back"
 	icon_state = "hair_thinningrear"
-
 	flags = VERY_SHORT
 
 /datum/sprite_accessory/hair/manbun
 	name = "Manbun"
 	icon_state = "hair_manbun"
-
 	flags = HAIR_TIEABLE
 
 /datum/sprite_accessory/hair/leftsidecut

--- a/code/modules/sprite_accessories/accessory_booster.dm
+++ b/code/modules/sprite_accessories/accessory_booster.dm
@@ -1,6 +1,4 @@
 /datum/sprite_accessory/marking/booster
-	species_allowed = list(SPECIES_HUMAN)
-	subspecies_allowed = list(SPECIES_BOOSTER)
 	icon = 'icons/mob/human_races/species/human/subspecies/booster_mods.dmi'
 
 /datum/sprite_accessory/marking/booster/ears

--- a/html/changelogs/burgerbb-species_restriction.yml
+++ b/html/changelogs/burgerbb-species_restriction.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Removed species restrictions for most hairstyle, beardstyle, and body marking types."


### PR DESCRIPTION
Most SPECIFIC hairstyles/beardstyles/bodymarkings were species locked even though they had no reason to be species locked. This fixes this, and also fixes the empty lines in my previous PR because coding standards.