### PR TITLE
Balance Tweaks

### DIFF
--- a/code/modules/boh_misc/munitions.dm
+++ b/code/modules/boh_misc/munitions.dm
@@ -153,7 +153,7 @@
 //casing
 /obj/item/ammo_casing/sabot
 	name = "sabot shell"
-	desc = "APFSDS in a neat little package."
+	desc = "APFSDS in a neat little package. It's prone to over penetrating, and as such does little damage to targets without armor." //even though it does little damage overall, being a niche round.
 	icon = 'icons/boh/ammo.dmi'
 	icon_state = "sabshell"
 	spent_icon = "sabshell-spent"
@@ -166,8 +166,10 @@
 	name = "sabot"
 	icon_state= "rod"
 	fire_sound = 'sound/weapons/gunshot/shotgun.ogg'
-	damage = 45
-	armor_penetration = 95
+	damage = 15
+	armor_penetration = 60
+	penetration_modifier = 0.1
+	penetrating = 1
 	damage_flags = DAM_EDGE
 
 //holder

--- a/code/modules/fabrication/designs/general/designs_arms_ammo.dm
+++ b/code/modules/fabrication/designs/general/designs_arms_ammo.dm
@@ -130,3 +130,7 @@
 /datum/fabricator_recipe/arms_ammo/hidden/sabot
 	name = "ammunition (12g Sabot)"
 	path = /obj/item/ammo_magazine/shotholder/sabot
+
+/datum/fabricator_recipe/arms_ammo/hidden/magrub
+	name = "ammunition (L-L Magnum Magazine)"
+	path = /obj/item/ammo_magazine/magnum/rubber

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -64,7 +64,7 @@
 	. = ..()
 	if(.)
 		custom_emote(1,"nashes at [.]")
-
+/*
 /mob/living/simple_animal/hostile/carp/AttackingTarget()
 	. =..()
 	var/mob/living/L = .
@@ -72,3 +72,4 @@
 		if(prob(15))
 			L.Weaken(3)
 			L.visible_message("<span class='danger'>\the [src] knocks down \the [L]!</span>")
+*/

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -41,7 +41,7 @@
 	. = ..()
 	if(.)
 		audible_emote("wails at [.]")
-
+/*
 /mob/living/simple_animal/hostile/faithless/AttackingTarget()
 	. =..()
 	var/mob/living/L = .
@@ -49,7 +49,7 @@
 		if(prob(12))
 			L.Weaken(3)
 			L.visible_message("<span class='danger'>\the [src] knocks down \the [L]!</span>")
-
+*/
 /mob/living/simple_animal/hostile/faithless/cult
 	faction = "cult"
 

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -125,7 +125,7 @@ var/global/list/protected_objects = list(/obj/machinery,
 /mob/living/simple_animal/hostile/mimic/DestroySurroundings()
 	if(destroy_objects)
 		..()
-
+/*
 /mob/living/simple_animal/hostile/mimic/AttackingTarget()
 	. =..()
 	if(knockdown_people)
@@ -134,7 +134,7 @@ var/global/list/protected_objects = list(/obj/machinery,
 			if(prob(15))
 				L.Weaken(1)
 				L.visible_message("<span class='danger'>\the [src] knocks down \the [L]!</span>")
-
+*/
 /mob/living/simple_animal/hostile/mimic/Destroy()
 	copy_of = null
 	creator = null


### PR DESCRIPTION
- - -
Tweaks:
 - Carp, Faithless and Mimics can no longer shove you over, effectively stunlocking you into deathcrit.
 - Sabot has been reworked.
 - You can now print the magnum's less-lethal round.
