### PR TITLE
Revert "Removes Ascent Whitelists"

### DIFF
--- a/code/modules/species/mantid/mantid.dm
+++ b/code/modules/species/mantid/mantid.dm
@@ -152,8 +152,6 @@
 	push_flags =              ALLMOBS
 	swap_flags =              ALLMOBS
 
-	spawn_flags = SPECIES_NO_FBP_CONSTRUCTION | SPECIES_NO_FBP_CHARGEN
-
 	override_limb_types = list(
 		BP_HEAD = /obj/item/organ/external/head/insectoid/mantid,
 		BP_GROIN = /obj/item/organ/external/groin/insectoid/mantid/gyne


### PR DESCRIPTION
Because of constant requests, it's being re-introduced. Too many new players, though we'll remain with the old system of 'just ask'.