### PR TITLE
Fixes a few things in the uplink. Makes zombie tar require 2 traitors.

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -14,7 +14,7 @@
 /*
 /datum/uplink_item/item/tools/ductape
 	name = "Duct Tape"
-	desc = "A roll of duct tape. changes \"HELP\" into sexy \"mmm\"."
+	desc = "A roll of duct tape. Changes \"HELP\" into sexy \"mmm\"."
 	item_cost = 2
 	path = /obj/item/weapon/tape_roll
 */
@@ -35,7 +35,7 @@
 
 /datum/uplink_item/item/tools/plastique
 	name = "C-4"
-	desc = "Set this on a wall to put a hole exactly where you need it."
+	desc = "Set this on a wall to put a hole exactly where you need it, without too much extra hole."
 	item_cost = 16
 	path = /obj/item/weapon/plastique
 

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -12,7 +12,7 @@
 
 /datum/uplink_item/item/visible_weapons/smallenergy_gun
 	name = "Small Energy Gun"
-	desc = "A pocket-sized energy based sidearm with three different lethality settings."
+	desc = "A pocket-sized energy based sidearm with three different lethality settings, stun, shock, kill."
 	item_cost = 16
 	path = /obj/item/weapon/gun/energy/gun/small
 
@@ -57,7 +57,7 @@
 
 /datum/uplink_item/item/visible_weapons/energy_gun
 	name = "Energy Gun"
-	desc = "A energy based sidearm with three different lethality settings, Stun, Shock, Kill."
+	desc = "A energy based sidearm with three different lethality settings, stun, shock, kill."
 	item_cost = 32
 	path = /obj/item/weapon/gun/energy/gun
 

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -57,7 +57,7 @@
 
 /datum/uplink_item/item/visible_weapons/energy_gun
 	name = "Energy Gun"
-	desc = "A energy based sidearm with three different lethality settings."
+	desc = "A energy based sidearm with three different lethality settings, Stun, Shock, Kill."
 	item_cost = 32
 	path = /obj/item/weapon/gun/energy/gun
 

--- a/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
+++ b/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
@@ -49,5 +49,5 @@
 	name = "Vial of Black Tar"
 	desc = "Supposedly, ingesting this would cause someone to become a little less alive, though still alive. How does it make sense? \
 	Well, it doesn't. That's the fun of it!"
-	item_cost = 120
+	item_cost = 220 //Needs two traitors collaborating, and even then, it burns a lot of your TCs. Zombies are overdone, mmkay?
 	path = /obj/item/weapon/reagent_containers/glass/beaker/vial/zombie


### PR DESCRIPTION
<CL>
Fixes some spelling, flavortext, descriptions in the uplink. Bumped zombie black tar TC cost up to 220. Meaning that two traitors must combine their telecrystals in order to purchase it. Think of a unique gimmick instead of zombifying everybody again, mm'kay?
</CL>

