### PR TITLE
Biodegrade begone

### DIFF
--- a/code/game/objects/items/weapons/implants/implants/explosive.dm
+++ b/code/game/objects/items/weapons/implants/implants/explosive.dm
@@ -23,28 +23,6 @@
 	<b>Function:</b> Contains a compact, electrically detonated explosive that detonates upon receiving a specially encoded signal or upon host death.<BR>
 	<b>Special Features:</b> Explodes<BR>
 	<b>Integrity:</b> Implant will occasionally be degraded by the body's immune system and thus will occasionally malfunction."}
-	if(!malfunction)
-		. += {"
-		<HR><B>Explosion yield mode:</B><BR>
-		<A href='byond://?src=\ref[src];mode=1'>[elevel ? elevel : "NONE SET"]</A><BR>
-		<B>Activation phrase:</B><BR>
-		<A href='byond://?src=\ref[src];phrase=1'>[phrase ? phrase : "NONE SET"]</A><BR>
-		<B>Frequency:</B><BR>
-		<A href='byond://?src=\ref[src];freq=-10'>-</A>
-		<A href='byond://?src=\ref[src];freq=-2'>-</A>
-		[format_frequency(src.frequency)]
-		<A href='byond://?src=\ref[src];freq=2'>+</A>
-		<A href='byond://?src=\ref[src];freq=10'>+</A><BR>
-		<B>Code:</B><BR>
-		<A href='byond://?src=\ref[src];code=-5'>-</A>
-		<A href='byond://?src=\ref[src];code=-1'>-</A>
-		<A href='byond://?src=\ref[src];code=set'>[src.code]</A>
-		<A href='byond://?src=\ref[src];code=1'>+</A>
-		<A href='byond://?src=\ref[src];code=5'>+</A><BR>
-		<B>Tampering warning message:</B><BR>
-		This will be broadcasted on radio if implant is exposed during surgery.<BR>
-		<A href='byond://?src=\ref[src];msg=1'>[warning_message ? warning_message : "NONE SET"]</A>
-		"}
 
 /obj/item/weapon/implant/explosive/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/implants/implants/explosive.dm
+++ b/code/game/objects/items/weapons/implants/implants/explosive.dm
@@ -22,7 +22,7 @@
 	<b>Implant Details:</b><BR>
 	<b>Function:</b> Contains a compact, electrically detonated explosive that detonates upon receiving a specially encoded signal or upon host death.<BR>
 	<b>Special Features:</b> Explodes<BR>
-	<b>Integrity:</b> Implant will occasionally be degraded by the body's immune system and thus will occasionally malfunction."}
+	<b>Integrity:</b> Implant has been made degradation resistant and will not biodegrade under any circumstances."}
 
 /obj/item/weapon/implant/explosive/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/implants/implants/explosive.dm
+++ b/code/game/objects/items/weapons/implants/implants/explosive.dm
@@ -22,7 +22,7 @@
 	<b>Implant Details:</b><BR>
 	<b>Function:</b> Contains a compact, electrically detonated explosive that detonates upon receiving a specially encoded signal or upon host death.<BR>
 	<b>Special Features:</b> Explodes<BR>
-	<b>Integrity:</b> Implant has been made degradation resistant and will not biodegrade under any circumstances."}
+	<b>Integrity:</b> Implant has been made highly degradation resistant and will not biodegrade under any circumstances."}
 
 /obj/item/weapon/implant/explosive/Initialize()
 	. = ..()


### PR DESCRIPTION
Removes biodegradation from bomb implants. Because rolling for RNG death is such a fun and engaging mechanic when its being used to make you compliant. Or when you roll merc, get the implant to prevent capture and it biodegrades in the middle of the Desperado. Hopefully it works because otherwise Hailey will be a really sad looking GAS and that is sad.

It should work though. It removes the malfunction proc from the explosive implant which scrambles activation phrase, frequency and all that stuff.

