### PR TITLE
Vox Pariahs!

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -291,7 +291,7 @@
 #define SPECIES_DIONA       "Diona"
 #define SPECIES_VOX         "Vox"
 #define SPECIES_VOX_ARMALIS "Vox Armalis"
-#define SPECIES_VOXPARIAH "Vox Pariah"
+#define SPECIES_VOXPARIAH 	"Vox Pariah"
 #define SPECIES_IPC         "Machine"
 #define SPECIES_UNATHI      "Unathi"
 #define SPECIES_SERGAL      "Sergal"

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -291,6 +291,7 @@
 #define SPECIES_DIONA       "Diona"
 #define SPECIES_VOX         "Vox"
 #define SPECIES_VOX_ARMALIS "Vox Armalis"
+#define SPECIES_VOXPARIAH "Vox Pariah"
 #define SPECIES_IPC         "Machine"
 #define SPECIES_UNATHI      "Unathi"
 #define SPECIES_SERGAL      "Sergal"

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -291,7 +291,7 @@
 #define SPECIES_DIONA       "Diona"
 #define SPECIES_VOX         "Vox"
 #define SPECIES_VOX_ARMALIS "Vox Armalis"
-#define SPECIES_VOXPARIAH 	"Vox Pariah"
+#define SPECIES_VOXPARIAH   "Vox Pariah"
 #define SPECIES_IPC         "Machine"
 #define SPECIES_UNATHI      "Unathi"
 #define SPECIES_SERGAL      "Sergal"

--- a/code/modules/mob/living/carbon/human/descriptors/descriptors_vox.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/descriptors_vox.dm
@@ -33,3 +33,34 @@
 
 /datum/mob_descriptor/vox_markings/get_third_person_message_start(var/datum/gender/my_gender)
 	. = "[my_gender.His] neck markings are"
+
+datum/mob_descriptor/pariah_stink
+	name = "stink"
+	chargen_label = "smell (rank)"
+	skip_species_mention = TRUE
+	standalone_value_descriptors = list(
+		"musky",
+		"smelly",
+		"malodorous",
+		"reeking",
+		"disgusting"
+		)
+	chargen_value_descriptors = list(
+		"musky"  =      1,
+		"smelly" =      2,
+		"malodorous" =  3,
+		"reeking" =     4,
+		"disgusting" =  5
+		)
+	comparative_value_descriptor_equivalent = "smells fine, like you."
+	comparative_value_descriptors_smaller = list(
+		"smells decent",
+		"smells good",
+		"smells great"
+		)
+	comparative_value_descriptors_larger = list(
+		"smells a bit",
+		"sort of stinks",
+		"smells bad"
+		)
+

--- a/code/modules/mob/living/carbon/human/descriptors/descriptors_vox.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/descriptors_vox.dm
@@ -39,16 +39,16 @@ datum/mob_descriptor/pariah_stink
 	chargen_label = "smell (rank)"
 	skip_species_mention = TRUE
 	standalone_value_descriptors = list(
-		"musky",
-		"smelly",
+		"strong-smelling",
 		"malodorous",
+		"fetid",
 		"reeking",
 		"disgusting"
 		)
 	chargen_value_descriptors = list(
-		"musky"  =      1,
-		"smelly" =      2,
-		"malodorous" =  3,
+		"strong-smelling"  =      1,
+		"malodorous" =      2,
+		"fetid" =  3,
 		"reeking" =     4,
 		"disgusting" =  5
 		)

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -266,3 +266,12 @@
 
 /obj/item/organ/internal/brain/get_mechanical_assisted_descriptor()
 	return "machine-interface [name]"
+
+/obj/item/organ/internal/pariah_brain
+	name = "brain remnants"
+	desc = "Did someone tread on this? It looks useless for cloning or cyborgification."
+	organ_tag = BP_BRAIN
+	parent_organ = BP_HEAD
+	icon = 'icons/obj/alien.dmi'
+	icon_state = "chitin"
+	vital = 1

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -165,7 +165,7 @@
 		/datum/mob_descriptor/pariah_stink = 0
 	)
 
-	spawn_flags = SPECIES_IS_WHITELISTED | SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_NO_FBP_CHARGEN
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION
 	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
 
 /datum/species/vox/pariah/get_bodytype(var/mob/living/carbon/human/H)

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -134,6 +134,13 @@
 	rarity_value = 0.1
 	speech_chance = 60        // No volume control.
 	siemens_coefficient = 0.5 // Ragged scaleless patches.
+	unarmed_types = list(
+		/datum/unarmed_attack/stomp,
+		/datum/unarmed_attack/kick,
+		/datum/unarmed_attack/claws/,
+		/datum/unarmed_attack/punch,
+		/datum/unarmed_attack/bite/
+	)
 
 	oxy_mod = 1.4
 	brute_mod = 1.3

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -125,6 +125,56 @@
 /datum/species/vox/skills_from_age(age)
 	. = 8
 
+/datum/species/vox/pariah
+	name = SPECIES_VOXPARIAH
+	description = "Sickly biproducts of Vox society, these creatures are vilified by their own kind \
+	and taken advantage of by enterprising companies for cheap, disposable labor. \
+	They aren't very smart, smell worse than a vox, and vomit constantly, \
+	earning them the true title of 'shitbird'."
+	rarity_value = 0.1
+	speech_chance = 60        // No volume control.
+	siemens_coefficient = 0.5 // Ragged scaleless patches.
+
+	oxy_mod = 1.4
+	brute_mod = 1.3
+	burn_mod = 1.4
+	toxins_mod = 1.3
+
+	cold_level_1 = 130
+	cold_level_2 = 100
+	cold_level_3 = 60
+
+	warning_low_pressure = WARNING_LOW_PRESSURE
+	hazard_low_pressure = HAZARD_LOW_PRESSURE
+
+	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick,  /datum/unarmed_attack/claws, /datum/unarmed_attack/bite)
+
+	// Pariahs have no stack.
+	has_organ = list(
+		BP_STOMACH =    /obj/item/organ/internal/stomach/vox,
+		BP_HEART =      /obj/item/organ/internal/heart/vox,
+		BP_LUNGS =      /obj/item/organ/internal/lungs/vox,
+		BP_LIVER =      /obj/item/organ/internal/liver/vox,
+		BP_KIDNEYS =    /obj/item/organ/internal/kidneys/vox,
+		BP_BRAIN =      /obj/item/organ/internal/pariah_brain,
+		BP_EYES =       /obj/item/organ/internal/eyes/vox,
+		BP_HINDTONGUE = /obj/item/organ/internal/hindtongue
+		)
+
+	descriptors = list(
+		/datum/mob_descriptor/pariah_stink = 0
+	)
+
+	spawn_flags = SPECIES_IS_WHITELISTED | SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_NO_FBP_CHARGEN
+	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
+
+/datum/species/vox/pariah/get_bodytype(var/mob/living/carbon/human/H)
+	return SPECIES_VOX
+
+// No combat skills for you.
+/datum/species/vox/pariah/can_shred(var/mob/living/carbon/human/H, var/ignore_intent)
+	return 0
+
 /datum/species/vox/armalis
 	name = SPECIES_VOX_ARMALIS
 	name_plural = SPECIES_VOX_ARMALIS

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -5,7 +5,8 @@
 										/datum/job/mining),
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
 									 /datum/job/roboticist, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender),
-		/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
+		/datum/species/vox/ = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
+		/datum/species/vox/pariah = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/cargo_tech),
 		/datum/species/human/mule = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
 	)
 

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -73,6 +73,7 @@
 		/datum/species/customhuman	= list(UNRESTRICTED, SEMIRESTRICTED),
 		//datum/species/tesh/		= list(UNRESTRICTED),
 		/datum/species/vox			= list(/datum/mil_branch/alien),
+		/datum/species/vox/pariah	= list(/datum/mil_branch/civilian),
 		/datum/species/vox/armalis	= list(/datum/mil_branch/alien)
 	)
 


### PR DESCRIPTION
:cl: Eonoc
tag: Adds Vox Pariah back in as a crew species for some low level jobs.
/:cl:
Re-adds the ol' Vox Pariahs as a crew species. Due to old hatred of the spammed smell messages, I changed their stink to just be a reskinned variant of neck markings available on examine.
Otherwise, they're essentially the same as they were. Non-vacuum resistant, shittier at melee, take increased damage from everything Vox. 
The jobs they're allowed are janitor, cargo technician, and test subjec--research assistant

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->