### PR TITLE
Minor Tweaks!

### DIFF
--- a/maps/torch/datums/supplypacks/security.dm
+++ b/maps/torch/datums/supplypacks/security.dm
@@ -128,7 +128,7 @@
 
 /decl/hierarchy/supply_pack/security/pistolammo
 	name = "Ammunition - pistol magazines"
-	contains = list(/obj/item/ammo_magazine/pistol = 4)
+	contains = list(/obj/item/ammo_magazine/pistol/double = 4)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "pistol ammunition crate"

--- a/maps/torch/language/human/euro.dm
+++ b/maps/torch/language/human/euro.dm
@@ -1,2 +1,2 @@
 /datum/language/human/euro
-	warning = "Automatically given if spawning on the Torch or Verne."
+	warning = "Automatically given if spawning on the Dagon or Verne."

--- a/maps/torch/loadout/loadout_augments.dm
+++ b/maps/torch/loadout/loadout_augments.dm
@@ -27,7 +27,6 @@
 	display_name = "mechanical polytool - left arm (ROBOTIC)"
 	path = /obj/item/organ/internal/augment/active/polytool/engineer/left
 	cost = 4
-	allowed_roles = TECHNICAL_ROLES
 
 /datum/gear/augmentation/implanted_toolkit/right
 	display_name = "mechanical polytool - right arm (ROBOTIC)"
@@ -46,4 +45,4 @@
 	display_name = "nanite MCU"
 	path = /obj/item/organ/internal/augment/active/nanounit
 	cost = 10
-	allowed_roles = SECURITY_ROLES
+	allowed_roles = ARMORED_ROLES


### PR DESCRIPTION
This PR permits the taking of the MCU Augment for anyone the company has already trusted with body armour, at the normal points cost. As such, it's available to Security and Command.

It also de-restricts the Tool-Arm augment, which makes it a competitor for limited loadout points and may help draw people away from the combat skill boosting augs by providing a viable alternative.

It also corrects an oversight that led to pistols mags that you could get from cargo not actually fitting in the pistols you could get from cargo.

:cl: InfinitelyThinRectangles
tweak: MCU Augment made available to Security/Command Roles.
tweak: Pistol Magazines from Cargo now fit in the Military Pistols from Cargo. 
tweak: Tool-Arm Augments available to everyone! 
/:cl: