### PR TITLE
Balance Tweaks

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1373,16 +1373,11 @@ Unlike what normally spawns, this material will be dangerous, or just outright b
 /obj/random/illegal/spawn_choices()
 	return list(/obj/item/weapon/gun/projectile/manualcycle/imprifle/impriflesawn = 1,
 				/obj/item/weapon/gun/projectile/manualcycle/imprifle = 1,
-				/obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawn/empty = 14,
 				/obj/item/weapon/reagent_containers/glass/beaker/vial/random/toxin = 14,
 				/obj/item/weapon/reagent_containers/glass/beaker/sulphuric = 14,
-				/obj/item/weapon/reagent_containers/glass/beaker/vial/zombie = 0.1,
 				/obj/item/weapon/reagent_containers/glass/beaker/vial/hfc = 1,
 				/obj/item/weapon/storage/box/ammo/shotgunammo/birdshot/full = 3,
 				/obj/item/weapon/melee/baton/cattleprod = 6,
-				/obj/item/weapon/gun/energy/retro = 1,
-				/obj/item/weapon/gun/energy/taser = 1,
-				/obj/item/weapon/gun/launcher/crossbow = 6,
 				/obj/item/weapon/arrow = 16,
 				/obj/item/weapon/gun/magnetic = 1,
 				/obj/item/weapon/gun/projectile/pirate/unloaded = 14,
@@ -1392,21 +1387,17 @@ Unlike what normally spawns, this material will be dangerous, or just outright b
 				/obj/item/weapon/storage/mre/menu11 = 24,
 				/obj/item/weapon/reagent_containers/pill/cyanide = 16,
 				/obj/item/weapon/reagent_containers/glass/bottle/cyanide = 12,
-				/obj/item/weapon/gun/projectile/automatic/machine_pistol/usi = 1,
 				/obj/item/weapon/gun/projectile/pistol/sec/MK = 4,
 				/obj/item/weapon/material/knife/combat = 12,
 				/obj/item/weapon/material/knife/table/unathi = 12,
 				/obj/item/weapon/material/knife/kitchen/cleaver = 2,
-				/obj/item/weapon/material/knife/folding/combat/balisong = 1,
 				/obj/item/weapon/material/shard/nullglass = 1,
 				/obj/item/weapon/material/twohanded/baseballbat = 14,
 				/obj/item/weapon/material/twohanded/spear = 18,
-				/obj/item/weapon/material/harpoon/bomb = 1,
 				/obj/item/weapon/material/hatchet/machete/steel = 12,
 				/obj/item/weapon/reagent_containers/pill/three_eye = 1,
 				/obj/item/weapon/storage/lockbox/vials/random = 1,
 				/obj/item/weapon/storage/toolbox/syndicate = 6,
-				/obj/item/weapon/gun/projectile/revolver/holdout = 2,
 				/obj/item/weapon/reagent_containers/food/snacks/egg/lizard = 1)
 
 //100% Illegal
@@ -1417,15 +1408,6 @@ Unlike what normally spawns, this material will be dangerous, or just outright b
 	icon_state = "coffee_dispenser2db"
 
 /obj/random/illegaltwo/spawn_choices()
-	return list(/obj/item/weapon/gun/energy/retro = 1,
-				/obj/item/weapon/gun/magnetic = 1,
-				/obj/item/weapon/gun/projectile/automatic/machine_pistol/usi = 1,
-				/obj/item/weapon/gun/energy/xray = 1,
-				/obj/item/weapon/gun/energy/xray/pistol = 1,
-				/obj/item/weapon/gun/energy/charge = 1,
-				/obj/item/weapon/gun/energy/mindflayer = 1,
-				/obj/item/weapon/gun/energy/sniperrifle = 1,
-				/obj/item/weapon/gun/energy/incendiary_laser = 1,
-				/obj/item/weapon/gun/projectile/automatic/merc_smg/hacked = 1,
-				/obj/item/weapon/gun/projectile/shotgun/pump/combat = 1,
-				/obj/item/weapon/gun/projectile/heavysniper = 1)
+	return list(/obj/item/weapon/gun/magnetic = 1,
+				/obj/item/weapon/gun/projectile/pirate/unloaded = 4,
+				/obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawn/empty = 2)

--- a/code/modules/fabrication/designs/general/designs_arms_ammo.dm
+++ b/code/modules/fabrication/designs/general/designs_arms_ammo.dm
@@ -134,11 +134,3 @@
 /datum/fabricator_recipe/arms_ammo/hidden/magrub
 	name = "ammunition (L-L Magnum Magazine)"
 	path = /obj/item/ammo_magazine/magnum/rubber
-
-/datum/fabricator_recipe/arms_ammo/hidden/atrifle
-	name = "ammunition (AT Rifle Shell)"
-	path = /obj/item/ammo_casing/shell
-
-/datum/fabricator_recipe/arms_ammo/hidden/atrifleapds
-	name = "ammunition (APDS Rifle Shell)"
-	path = /obj/item/ammo_casing/shell/apds

--- a/code/modules/species/mantid/mantid.dm
+++ b/code/modules/species/mantid/mantid.dm
@@ -34,7 +34,7 @@
 	toxins_mod =            0.4 // Not as biologically fragile as meatboys.
 	radiation_mod =         0.4 // Not as biologically fragile as meatboys.
 	flash_mod =               2 // Highly photosensitive.
-	brute_mod =             2.5 // Incredibly fragile.
+	brute_mod =             1.5 // Incredibly fragile.
 
 	min_age =                18
 	max_age =                38

--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -95,12 +95,8 @@
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o1,
 		/datum/mil_rank/fleet/o2,
-		/datum/mil_rank/fleet/o3,
-		/datum/mil_rank/fleet/o4,
 		/datum/mil_rank/marine_corps/o1,
-		/datum/mil_rank/marine_corps/o2,
-		/datum/mil_rank/marine_corps/o3_alt,
-		/datum/mil_rank/marine_corps/o4
+		/datum/mil_rank/marine_corps/o2
 	)
 /***/
 

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -363,7 +363,6 @@
 /obj/structure/closet/crate,
 /obj/random/powercell,
 /obj/random/illegal,
-/obj/random/illegaltwo,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/auxillary/starboard)
 "aY" = (
@@ -373,7 +372,6 @@
 /obj/structure/closet/crate,
 /obj/random/junk,
 /obj/random/illegal,
-/obj/random/illegaltwo,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/auxillary/port)
 "ba" = (
@@ -1259,7 +1257,6 @@
 	dir = 8;
 	health = 1e+006
 	},
-/obj/random/illegaltwo,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/gear)
 "cI" = (
@@ -2407,25 +2404,13 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "eH" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
-	frequency = 1331;
-	id_tag = "rescue_shuttle_dock_pump"
+	frequency = 1380;
+	id_tag = "admin_shuttle_dock_pump"
 	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 4;
-	display_name = "Port Dock C";
-	frequency = 1331;
-	id_tag = "rescue_shuttle_dock_airlock";
-	pixel_x = -24;
-	req_access = list(list("ACCESS_EXTERNAL","ACCESS_TORCH_CREW"));
-	tag_airpump = "rescue_shuttle_dock_pump";
-	tag_chamber_sensor = "rescue_shuttle_dock_sensor";
-	tag_exterior_door = "rescue_shuttle_dock_outer";
-	tag_interior_door = "rescue_shuttle_dock_inner"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
@@ -2471,25 +2456,13 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/fourthdeck/port)
 "eK" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
-	frequency = 1380;
-	id_tag = "admin_shuttle_dock_pump"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 4;
-	display_name = "Starboard Dock C";
-	frequency = 1380;
-	id_tag = "admin_shuttle_dock_airlock";
-	pixel_x = -24;
-	req_access = list(list("ACCESS_EXTERNAL","ACCESS_TORCH_CREW"));
-	tag_airpump = "admin_shuttle_dock_pump";
-	tag_chamber_sensor = "admin_shuttle_dock_sensor";
-	tag_exterior_door = "admin_shuttle_dock_outer";
-	tag_interior_door = "admin_shuttle_dock_inner"
+	frequency = 1331;
+	id_tag = "rescue_shuttle_dock_pump"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
@@ -41116,7 +41089,7 @@ aa
 aa
 Yj
 tG
-eK
+eH
 LA
 aJ
 Mx
@@ -41158,7 +41131,7 @@ uj
 Jx
 eI
 LA
-eH
+eK
 Ms
 Yj
 aa

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -10074,8 +10074,8 @@
 	name = "Weapons locker"
 	},
 /obj/structure/window/reinforced,
-/obj/random/illegaltwo,
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/random/ammo,
 /turf/simulated/floor/tiled/techfloor,
 /area/vacant/armory)
 "so" = (
@@ -10101,8 +10101,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/random/illegaltwo,
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/random/ammo,
 /turf/simulated/floor/tiled/techfloor,
 /area/vacant/armory)
 "sq" = (
@@ -10248,7 +10248,7 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
-/obj/random/illegaltwo,
+/obj/random/ammo,
 /turf/simulated/floor/tiled/techfloor,
 /area/vacant/armory)
 "sI" = (
@@ -10351,9 +10351,6 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo,
 /obj/random/ammo,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techfloor,

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -8902,7 +8902,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/gunnery/ammo)
 "aoG" = (
-/obj/random/illegaltwo,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/gunnery/ammo)
 "aoH" = (
@@ -10004,7 +10003,6 @@
 "aqG" = (
 /obj/structure/closet/crate/solar,
 /obj/random/tech_supply,
-/obj/random/illegaltwo,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
 "aqJ" = (

--- a/modular_mithra/code/modules/species/station/tajaran.dm
+++ b/modular_mithra/code/modules/species/station/tajaran.dm
@@ -53,3 +53,14 @@
 			CULTURE_UNATHI,
 		)
 	)
+
+/datum/species/tajaran/proc/handle_coco(var/mob/living/carbon/human/M, var/datum/reagent/nutriment/coco, var/efficiency = 1)
+	var/effective_dose = efficiency * M.chem_doses[coco.type]
+	if(effective_dose < 5)
+		return
+	M.druggy = max(M.druggy, 10)
+	M.add_chemical_effect(CE_PULSE, -1)
+	if(effective_dose > 15 && prob(7))
+		M.emote(pick("twitch", "drool"))
+	if(effective_dose > 20 && prob(10))
+		M.SelfMove(pick(GLOB.cardinal))

--- a/modular_mithra/code/modules/species/station/vulpkanin.dm
+++ b/modular_mithra/code/modules/species/station/vulpkanin.dm
@@ -48,3 +48,14 @@
 			CULTURE_UNATHI,
 		)
 	)
+
+/datum/species/vulpkanin/proc/handle_coco(var/mob/living/carbon/human/M, var/datum/reagent/nutriment/coco, var/efficiency = 1)
+	var/effective_dose = efficiency * M.chem_doses[coco.type]
+	if(effective_dose < 5)
+		return
+	M.druggy = max(M.druggy, 10)
+	M.add_chemical_effect(CE_PULSE, -1)
+	if(effective_dose > 15 && prob(7))
+		M.emote(pick("twitch", "drool"))
+	if(effective_dose > 20 && prob(10))
+		M.SelfMove(pick(GLOB.cardinal))


### PR DESCRIPTION
- - -
Tweaks:
 - AMR ammo is only available, once again, through antag purchases.
 - Mantid brute multiplier reduced.
 - Random maint spawns pruned. They no longer feature a massive number of incredibly dangerous items, and are primarily for flavor over gameplay.
 - Bridge Officer can only be O1 to O2, rather than O1 to O4 as prior. This is due to abuse of the increased ranks by inexperienced players, and this may return in the future.
 - Maint spawn locations pruned.
 - - -
 Species:
 - Vulp and Taj SHOULD now react adversely to coco, same as the Unathi reacts to sugar. If it doesn't, that's due to my coffee-less state of mind not realising how stupid I am with such an edit.
