### PR TITLE
Removes jam Chance on Z9 Bulldog/nulls it

### DIFF
--- a/code/modules/boh/infantry/firearms.dm
+++ b/code/modules/boh/infantry/firearms.dm
@@ -21,7 +21,6 @@
 	auto_eject = 0
 	starts_loaded = 0
 	one_hand_penalty = 6 //lower power rounds
-	jam_chance = 0 //frangible rounds might shatter if they're chambered improperly.
 	req_access = list(access_infantry)
 	authorized_modes = list(UNAUTHORIZED)
 	firemodes = list(
@@ -34,7 +33,6 @@
 /obj/item/weapon/gun/projectile/automatic/bullpup_rifle/sec/b
 	desc = "The Hephaestus Industries Z9b Bulldog is an experimental design of the standard Z9. Having an enforced fire-rate for use aboard civilian heavy areas, it does away with some of the use. \
 	Because of the limited fire-rate, and how the mechanism functions, it has a much higher jam rate."
-	jam_chance = 35
 	firemodes = list(
 		list(mode_name="semi auto",       burst=1,    fire_delay=null,    move_delay=null, use_launcher=null, one_hand_penalty=8, burst_accuracy=null, dispersion=null),
 		list(mode_name="fire grenades",  burst=null, fire_delay=null, move_delay=null, use_launcher=1,    one_hand_penalty=10, burst_accuracy=null, dispersion=null)

--- a/code/modules/boh/infantry/firearms.dm
+++ b/code/modules/boh/infantry/firearms.dm
@@ -21,7 +21,7 @@
 	auto_eject = 0
 	starts_loaded = 0
 	one_hand_penalty = 6 //lower power rounds
-	jam_chance = 5 //frangible rounds might shatter if they're chambered improperly.
+	jam_chance = 0 //frangible rounds might shatter if they're chambered improperly.
 	req_access = list(access_infantry)
 	authorized_modes = list(UNAUTHORIZED)
 	firemodes = list(


### PR DESCRIPTION
The jam chance, while having a bit of realism to is way too high for a weapon thats supposed to be used by marines. This effectively translate to a 5% chance. The gun got like what? 20 rounds? On twenty rounds your gun would jam once.

Why and how this gun would have made it to be used widely is a mystery. Since its older model is currently far superior. I do understand its supposed to avoid infantry validing people but currently this thing is simply just feeling off. This removes the jam chance making it slightly more viable. It does not alter damage, burst size or the fact it can only load hollow points. 

Ah right.. should actually change my outdated GitHub name to my current name at some point..
Eh no need anymore. 