### PR TITLE
PR that could split space, time, and the community (Augments)

### DIFF
--- a/maps/torch/loadout/loadout_augments.dm
+++ b/maps/torch/loadout/loadout_augments.dm
@@ -1,18 +1,3 @@
-/datum/gear/augmentation/mil
-	display_name = "tactical computer"
-	path = /obj/item/organ/internal/augment/boost/shooting
-	cost = 6
-	allowed_branches = MILITARY_BRANCHES
-
-/datum/gear/augmentation/mil/cqc_booster
-	display_name = "close combat reflex booster"
-	path = /obj/item/organ/internal/augment/boost/reflex
-	cost = 8
-
-/datum/gear/augmentation/mil/subdural_armor
-	display_name = "subdural armor"
-	path = /obj/item/organ/internal/augment/armor
-
 /datum/gear/augmentation/implanted_surgical
 	display_name = "surgical polytool - left arm (ROBOTIC)"
 	path = /obj/item/organ/internal/augment/active/polytool/surgical/left
@@ -40,9 +25,3 @@
 	display_name = "circuit augment - right arm (ROBOTIC)"
 	path = /obj/item/organ/internal/augment/active/simple/circuit/right
 	cost = 4
-
-/datum/gear/augmentation/nanite_unit
-	display_name = "nanite MCU"
-	path = /obj/item/organ/internal/augment/active/nanounit
-	cost = 10
-	allowed_roles = ARMORED_ROLES

--- a/maps/torch/loadout/loadout_augments.dm
+++ b/maps/torch/loadout/loadout_augments.dm
@@ -17,11 +17,12 @@
 	display_name = "mechanical polytool - right arm (ROBOTIC)"
 	path = /obj/item/organ/internal/augment/active/polytool/engineer/right
 
-/datum/gear/augmentation/implanted_circuitkit/
+/datum/gear/augmentation/implanted_circuitkit
 	display_name = "circuit augment - left arm (ROBOTIC)"
 	path = /obj/item/organ/internal/augment/active/simple/circuit/left
+	cost = 4
 
 /datum/gear/augmentation/implanted_circuitkit/right
 	display_name = "circuit augment - right arm (ROBOTIC)"
 	path = /obj/item/organ/internal/augment/active/simple/circuit/right
-	cost = 4
+	


### PR DESCRIPTION
Hear me now, brave men - brave Hestialanders - hear me! The Antag Wizards read the portents true. Shitsec/LRPers land on Dagon shores. We have maneuvered many miles, but there is no distance so great that I would not gladly go to face this - our ultimate foe! I have refused the honor of wielding the coding power of our forebears thus far. I was not worthy. But should we survive this PR, should we drive the min maxing tribes back across the Byond Hub - then, with your blessing - I will pick up the non-powergame security role and use it to bleed our foes - to carve my way through Hestia's enemies! Are you with me, Men of the Spess? For when the LRP trash come, they will attack hard, as their despicable gods demand. We must be ready to push them back, thrust them into the void in defense of the Dagon!

### tl;dr
I am removing the essentially free combat augments at roundstart for a good chunk of roles as, in my humble and 17% retarded opinion, it was never at any point a good idea to add significant advantages to a mostly cosmetic/minor influences loadout menu.

I am open to suggestions for (existing) augments to add to the augment category of the loadout that aren't so...impactful.

:cl:
rscdel: Removes unbalanced and significantly impactful combat augments that you get for unimportant loadout points at roundstart. 
/:cl: