### PR TITLE
An Offship Crew To Surpass Metal Gear

### DIFF
--- a/code/modules/submaps/submap_job.dm
+++ b/code/modules/submaps/submap_job.dm
@@ -11,11 +11,10 @@
 	available_by_default = FALSE
 	allowed_ranks = null
 	allowed_branches = null
-	skill_points = 34
+	skill_points = 36
 	give_psionic_implant_on_join = FALSE
-	min_skill = list(   SKILL_EVA         = SKILL_BASIC,
-	                    SKILL_COMBAT      = SKILL_BASIC,
-	                    SKILL_HAULING     = SKILL_BASIC)
+	min_skill = list(   SKILL_EVA         = SKILL_ADEPT,	       
+	                    SKILL_HAULING     = SKILL_ADEPT)
 						
 	max_skill = list(   SKILL_BUREAUCRACY = SKILL_MAX,
 	                    SKILL_FINANCE = SKILL_MAX,

--- a/code/modules/submaps/submap_job.dm
+++ b/code/modules/submaps/submap_job.dm
@@ -11,8 +11,12 @@
 	available_by_default = FALSE
 	allowed_ranks = null
 	allowed_branches = null
-	skill_points = 25
+	skill_points = 34
 	give_psionic_implant_on_join = FALSE
+	min_skill = list(   SKILL_EVA         = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_BASIC,
+	                    SKILL_HAULING     = SKILL_BASIC)
+						
 	max_skill = list(   SKILL_BUREAUCRACY = SKILL_MAX,
 	                    SKILL_FINANCE = SKILL_MAX,
 	                    SKILL_EVA = SKILL_MAX,


### PR DESCRIPTION
Every single offship human away mission/event is tied to the same one job skill variable, and it wasn't high enough for them to really even specialize in one high tier profession. All offship event human jobs have been boosted in points, and given trained EVA/Athletics. They are still worse overall than Skrellian and Ascent which is intended, but not astronomically so. 