### PR TITLE
Removes point buffs and nerfs from age.

### DIFF
--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -783,9 +783,9 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 
 /datum/species/proc/skills_from_age(age)	//Converts an age into a skill point allocation modifier. Can be used to give skill point bonuses/penalities not depending on job.
 	switch(age)
-		if(0 to 22) 	. = -4
-		if(23 to 30) 	. = 0
-		if(31 to 45)	. = 4
+		if(0 to 22) 	. = 8
+		if(23 to 30) 	. = 8
+		if(31 to 45)	. = 8
 		else			. = 8
 
 /datum/species/proc/post_organ_rejuvenate(var/obj/item/organ/org, var/mob/living/carbon/human/H)

--- a/code/modules/species/station/adherent.dm
+++ b/code/modules/species/station/adherent.dm
@@ -147,9 +147,9 @@
 
 /datum/species/adherent/skills_from_age(age)
 	switch(age)
-		if(0 to 1000)    . = -4
-		if(1000 to 2000) . =  0
-		if(2000 to 8000) . =  4
+		if(0 to 1000)    . =  8
+		if(1000 to 2000) . =  8
+		if(2000 to 8000) . =  8
 		else             . =  8
 
 /datum/species/adherent/get_additional_examine_text(var/mob/living/carbon/human/H)

--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -393,6 +393,6 @@
 /datum/species/nabber/skills_from_age(age)	//Converts an age into a skill point allocation modifier. Can be used to give skill point bonuses/penalities not depending on job.
 	switch(age)
 		if(0 to 18) 	. = 8
-		if(19 to 27) 	. = 2
-		if(28 to 40)	. = -2
-		else			. = -4
+		if(19 to 27) 	. = 8
+		if(28 to 40)	. = 8
+		else			. = 8


### PR DESCRIPTION
What is does:

This PR removes the point removal or gain from age. All players gain eight points, regardless of age.

Why it's good for the game:

Tying points to age really only hurt people who played in the system. You could easily powergame it by simply increasing your age. Now, age is fully cosmetic, so you won't be losing out because you chose to play a slightly younger character.

🆑

Tweak: Removes point gains and losses from age. If you already used your max age points, this won't effect you at all. If you don't have the maximum age points, you get a few extra points to spend.

/🆑