### PR TITLE
Reverts Crewman Rank Changes

### DIFF
--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -393,10 +393,14 @@
 		/datum/mil_rank/fleet/e2_exp,
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
+		/datum/mil_rank/fleet/e5,
+		/datum/mil_rank/fleet/e6,
 		/datum/mil_rank/marine_corps/e1,
 		/datum/mil_rank/marine_corps/e2,
 		/datum/mil_rank/marine_corps/e3,
-		/datum/mil_rank/marine_corps/e4
+		/datum/mil_rank/marine_corps/e4,
+		/datum/mil_rank/marine_corps/e5,
+		/datum/mil_rank/marine_corps/e6
 	)
 /***/
 


### PR DESCRIPTION
Reverts removal of certain Crewman ranks snuck into [this PR](https://github.com/BoHBranch/BoH-Bay/pull/380). Putting multiple unrelated changes in the same PR isn't really that good conduct, and this snuck by without any feedback as a result. These crewman ranks allow people to play certain characters as Crewman outside of the department, if the usual job slot is full.

You, sneaking unrelated changes into the same PR
![farquaad](https://user-images.githubusercontent.com/12451752/74859482-04fdac00-533f-11ea-8c91-46c54a433762.jpg)

Me, fixing your bad conduct
![charming](https://user-images.githubusercontent.com/12451752/74859510-10e96e00-533f-11ea-8a64-5d7b95c180bc.jpg)

🆑
Edit: Reverts Crewman rank changes snuck into a seperate PR.
/🆑