### PR TITLE
Genemodders get Veteris Unathi Horns

### DIFF
--- a/modular_mithra/code/modules/sprite_accessories/accessory_humanathi.dm
+++ b/modular_mithra/code/modules/sprite_accessories/accessory_humanathi.dm
@@ -4,7 +4,7 @@
 	icon = 'modular_mithra/icons/mob/human_races/species/humanathi/hair.dmi'
 	icon_state = "horns_simple"
 	blend = ICON_MULTIPLY
-	species_allowed = list(SPECIES_OLDUNATHI)
+	species_allowed = list(SPECIES_OLDUNATHI, SPECIES_CUSTOM)
 
 /datum/sprite_accessory/hair/humanathi/horns_short
 	name = "Veteris'Unathi Short Horns"


### PR DESCRIPTION
This allows genemods to have access to Verteris Unathi Hairstyles. Might not work with human sprites/causes clipping issues. Only use if your spritebase is actually Veteris.