### PR TITLE
Various Rank Changes

### DIFF
--- a/code/modules/boh_misc/boxes.dm
+++ b/code/modules/boh_misc/boxes.dm
@@ -75,7 +75,7 @@
 
 /obj/item/gunboxsmall/attack_self(mob/living/user)
 	var/list/options = list()
-	options["Ballistic"] = list(/obj/item/weapon/gun/projectile/pistol/military/alt/solar,/obj/item/ammo_magazine/pistol/double)
+	options["Ballistic"] = list(/obj/item/weapon/gun/projectile/pistol/military/alt/solar,/obj/item/ammo_magazine/pistol/double/rubber)
 	options["Energy"] = list(/obj/item/weapon/gun/energy/gun/secure,/obj/item/weapon/grenade/empgrenade/low_yield)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)

--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -16,7 +16,9 @@
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/XO/marine
 	)
 	allowed_ranks = list(
+		/datum/mil_rank/fleet/o4,
 		/datum/mil_rank/fleet/o5,
+		/datum/mil_rank/marine_corps/o4,
 		/datum/mil_rank/marine_corps/o5
 	)
 
@@ -25,6 +27,7 @@
 		/datum/mil_branch/fleet
 	)
 	allowed_ranks = list(
+		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o4
 	)
 
@@ -315,8 +318,7 @@
 	)
 	allowed_branches = list(
 		/datum/mil_branch/fleet,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/security/maa/marine,
-		/datum/mil_branch/private_security
+		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/security/maa/marine
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e2,
@@ -326,9 +328,7 @@
 		/datum/mil_rank/marine_corps/e2,
 		/datum/mil_rank/marine_corps/e3,
 		/datum/mil_rank/marine_corps/e4,
-		/datum/mil_rank/marine_corps/e5,
-		/datum/mil_rank/private_security/pcrc = /decl/hierarchy/outfit/job/torch/crew/security/maa/pcrc,
-		/datum/mil_rank/private_security/saare = /decl/hierarchy/outfit/job/torch/crew/security/maa/saare
+		/datum/mil_rank/marine_corps/e5
 	)
 /***/
 
@@ -390,6 +390,7 @@
 		/datum/mil_rank/fleet/e2,
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
+		/datum/mil_rank/marine_corps/e1,
 		/datum/mil_rank/marine_corps/e2,
 		/datum/mil_rank/marine_corps/e3,
 		/datum/mil_rank/marine_corps/e4


### PR DESCRIPTION
**Some issues arose with my fork, going to delete the fork and recreate rather than hassle with fixing it. Comments have been noted, contractorsec section of this PR will be removed, will add O-2 Pathfinder.**

Allows XO to be O-4, as Bridge Officers have been restricted from higher ranks which allows for some variation.

Allows RD to be O-3, in keeping with other Head ranks.

Allows Crewman to be E-1, not sure why this was removed when other crew can be E-1.

Removes Contractors from Security, due to rampant misuse of the title. This is a bit of a sticky issue and I'm happy to take feedback regarding this, but the majority of Contractor Security grossly misuse the role as "I'm not in the military, you can't tell me what to do, I'm going to validhunt/by edgy", with most of the time it not being particularly ahelpable. I'd rather have the possibility of that gone until similar behaviour has settled down. This impacts the few players who play the Contractor side well, but it also means no more red flag PCRC/SAARE.

🆑
Tweak: Various joinable rank changes.
/🆑