### PR TITLE
Limits the amount of implants per type you can implant in an external limb to 1.

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -45,11 +45,23 @@
 /obj/item/weapon/implant/proc/implanted(var/mob/source)
 	return TRUE
 
-/obj/item/weapon/implant/proc/can_implant(mob/M, mob/user, var/target_zone)
+/obj/item/weapon/implant/proc/can_implant(mob/M, mob/user, var/target_zone, var/obj/item/weapon/implant/I)
 	var/mob/living/carbon/human/H = M
-	if(istype(H) && !H.get_organ(target_zone))
-		to_chat(user, "<span class='warning'>\The [M] is missing that body part.</span>")
+	if(!istype(H))
+		to_chat(user, "<span class='warning'>You cannot implant \the [M]!</span>")
 		return FALSE
+
+	var/obj/item/organ/external/O = H.get_organ(target_zone)
+	if(!istype(O))
+		to_chat(user, "<span class='warning'>\The [H] is missing that organ!</span>")
+		return FALSE
+
+	for(var/obj/implanted_object in O.implants)
+		if(implanted_object.type != I.type)
+			continue
+		to_chat(user, "<span class='warning'>The implanter flashes red, indicating that there is already an implant of that type inside this limb!</span>")
+		return FALSE
+
 	return TRUE
 
 /obj/item/weapon/implant/proc/implant_in_mob(mob/M, var/target_zone)

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -74,13 +74,10 @@
 		user.do_attack_animation(M)
 
 		var/target_zone = user.zone_sel.selecting
-		if(src.imp.can_implant(M, user, target_zone))
-			var/imp_name = imp.name
-
-			if(do_after(user, 50, M) && src.imp.implant_in_mob(M, target_zone))
+		if(src.imp.can_implant(M, user, target_zone, src.imp))
+			if(do_after(user, 50, M) && src.imp.can_implant(M, user, target_zone, src.imp) && src.imp.implant_in_mob(M, target_zone)) //Needs to be doubled checked to prevent exploits.
 				M.visible_message("<span class='warning'>[M] has been implanted by [user].</span>")
-				admin_attack_log(user, M, "Implanted using \the [src] ([imp_name])", "Implanted with \the [src] ([imp_name])", "used an implanter, \the [src] ([imp_name]), on")
-
+				admin_attack_log(user, M, "Implanted using \the [src] ([imp.name])", "Implanted with \the [src] ([imp.name])", "used an implanter, \the [src] ([imp.name]), on")
 				src.imp = null
 				update_icon()
 


### PR DESCRIPTION
Basically prevents duplicate implants in the same limb. I mean, sure you can implant 8 microbomb implants, one in each limb, but at least it isn't 50.