### PR TITLE
Allows Genemods to be Master Sergeants

### DIFF
--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -12,6 +12,7 @@
 	/datum/mil_rank/marine_corps/e5,\
 	/datum/mil_rank/marine_corps/e6,\
 	/datum/mil_rank/marine_corps/e7,\
+	/datum/mil_rank/marine_corps/e8,\
 	/datum/mil_rank/marine_corps/e8_alt,\
 	/datum/mil_rank/marine_corps/e9,\
 	/datum/mil_rank/marine_corps/e9_alt,\


### PR DESCRIPTION
Given they have almost every other rank in the Marines, it seems like an oversight to have excluded this one. Only adds that line.