### PR TITLE
Veteris'Unathi maxage adjustment

### DIFF
--- a/modular_mithra/code/modules/species/station/humanathi.dm
+++ b/modular_mithra/code/modules/species/station/humanathi.dm
@@ -35,7 +35,7 @@
 	taste_sensitivity = TASTE_SENSITIVE
 
 	min_age = 18
-	max_age = 110
+	max_age = 260
 
 	body_temperature = null // cold-blooded, implemented the same way nabbers do it
 


### PR DESCRIPTION
Since Veteris'Unathi are considered a subspecies of Unathi their maxage should be set accordingly.
Unathi maxage is currently 260. Really a minor change thats purely cosmetic.