### PR TITLE
Balances IPCs and FPB damage.

### DIFF
--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -110,6 +110,7 @@
 
 /obj/item/organ/internal/eyes/robot
 	name = "optical sensor"
+	relative_size = 10
 
 /obj/item/organ/internal/eyes/robot/New()
 	..()

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -11,6 +11,11 @@
 	//at 0.8 completely depleted after 60ish minutes of constant walking or 130 minutes of standing still
 	var/servo_cost = 0.8
 
+	min_broken_damage = 5
+	max_damage = 30
+
+	relative_size = 70
+
 /obj/item/organ/internal/cell/New()
 	robotize()
 	if(ispath(cell))
@@ -39,7 +44,7 @@
 		return 0
 	return cell && cell.use(amount)
 
-/obj/item/organ/internal/cell/proc/get_power_drain()	
+/obj/item/organ/internal/cell/proc/get_power_drain()
 	var/damage_factor = 1 + 10 * damage/max_damage
 	return servo_cost * damage_factor
 

--- a/code/modules/species/station/machine.dm
+++ b/code/modules/species/station/machine.dm
@@ -83,6 +83,9 @@
 		TAG_FACTION = FACTION_POSITRONICS
 	)
 
+	brute_mod =      1.1
+	burn_mod =       1.5
+
 /datum/species/machine/handle_death(var/mob/living/carbon/human/H)
 	..()
 	if(istype(H.wear_mask,/obj/item/clothing/mask/monitor))

--- a/html/changelogs/burgerbb-ipcnerf.yml
+++ b/html/changelogs/burgerbb-ipcnerf.yml
@@ -34,4 +34,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Nerfed IPCS by giving them a 50% weakness to burn damage, a 10% weakness to brute damage, and a higher chance for their battery to get hit."
+  - rscadd: "Nerfed IPCS by giving them a 50% weakness to burn damage, a 10% weakness to brute damage, and a higher chance for their battery to get hit. Also upped the relative chance for the sensor array to get hit from 5% to 10%."

--- a/html/changelogs/burgerbb-ipcnerf.yml
+++ b/html/changelogs/burgerbb-ipcnerf.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Nerfed IPCS by giving them a 50% weakness to burn damage, a 10% weakness to brute damage, and a higher chance for their battery to get hit."


### PR DESCRIPTION
Okay. I did some investigating and it turned out that the IPC species was heavily reliant on RNG on whether or not they take damage to their internal organs.

Since they don't take pain or anything, an IPC can only get fucked if their battery is damaged. This is a very rare event because the chance to hit a battery is around the 5%-10% chance range compared to a human which is about a 80-110% chance range.

I balanced it so that their batteries have a much higher chance to be hit given that they lack other organs inside their chest, as well as gave them a 10% weakness to brute damage and a 50% chance weakness to burn damage, as burn damage has a 50% lower chance to damage their organs.

Also increased the chance from 5% to 10% because Bear is a little bitch.