### PR TITLE
Changes Security equipment box contents

### DIFF
--- a/code/modules/boh_misc/boxes.dm
+++ b/code/modules/boh_misc/boxes.dm
@@ -75,7 +75,7 @@
 
 /obj/item/gunboxsmall/attack_self(mob/living/user)
 	var/list/options = list()
-	options["Ballistic"] = list(/obj/item/weapon/gun/projectile/pistol/military/alt/solar,/obj/item/ammo_magazine/pistol/double)
+	options["Ballistic"] = list(/obj/item/weapon/gun/projectile/pistol/military/alt/solar,/obj/item/ammo_magazine/pistol/double/rubber)
 	options["Energy"] = list(/obj/item/weapon/gun/energy/gun/secure,/obj/item/weapon/grenade/empgrenade/low_yield)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)


### PR DESCRIPTION
Changes the lethal magazine that the Security box ballistics option starts with to another rubber, to bring it in line with smartguns requiring authorisation for lethals. Now you have to get someone with access to get access to lethals.

🆑
Tweak: Security box ballistics option spare magazine has been changed from lethals to rubbers, in keeping with needing authorisation to kill people.
/🆑