### PR TITLE
Voting and Time fixes part 105

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -92,6 +92,8 @@ var/global/round_start_time = 0
 var/global/round_start_time_real = 0
 
 /proc/get_real_round_duration() //RETURNS DECISECONDS
+	if(!round_start_time_real)
+		return 0
 	return REALTIMEOFDAY - round_start_time_real
 
 /proc/roundduration2text()

--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -12,8 +12,7 @@ var/datum/controller/transfer_controller/transfer_controller
 	. = ..()
 
 /datum/controller/transfer_controller/Process()
-	if (time_till_transfer_vote() <= 0)
-		SSvote.initiate_vote(/datum/vote/transfer, automatic = 1)
+	if (time_till_transfer_vote() < 0 && SSvote.initiate_vote(/datum/vote/transfer, automatic = 1))
 		timerbuffer += config.vote_autotransfer_interval
 
 /datum/controller/transfer_controller/proc/time_till_transfer_vote()


### PR DESCRIPTION
Time until autovote for transfer was extended to 8 hours every shift because of an oversight in the voting code that called voting twice, which caused both to fail and extend the time until the next vote.

My changes fix that and any other similar errors.