### PR TITLE
Fixes anti-boarding turrets killing people with apostrophes

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -542,7 +542,7 @@ proc/is_blind(A)
 		if(id)
 			perpname = id.registered_name
 
-		var/datum/computer_file/report/crew_record/CR = get_crewmember_record(perpname)
+		var/datum/computer_file/report/crew_record/CR = get_crewmember_record(sanitize(perpname))//Sanitization usually not needed, but causes consistency issues otherwise.
 		if(check_records && !CR && !isMonkey())
 			threatcount += 4
 


### PR DESCRIPTION
:cl:
bugfix: Fixes a bug where things that use get_crewmember_record do not work with unsanitized names. This caused beepskys and turrets to erroneously target people with apostrophes in their name.
/:cl:

First time using DM and git.