### PR TITLE
Psi Amp Acidproof

### DIFF
--- a/code/modules/psionics/equipment/cerebro_enhancers.dm
+++ b/code/modules/psionics/equipment/cerebro_enhancers.dm
@@ -9,6 +9,7 @@
 		slot_l_hand_str = "helmet",
 		slot_r_hand_str = "helmet"
 		)
+	unacidable = 1 
 
 	var/operating = FALSE
 	var/list/boosted_faculties


### PR DESCRIPTION
As much as it was fun removing the Psi Amp via acid might be considered cheese. It still stays active while its removed via acid. By making it acid proof it also removes some rather obscure mechanics I am rather not going too much into detail because I highly highly doubt they are intended mechanics. Can explain these mechanics to devs via DM if wanted.

What it should do:

Takes the wizard clothings unacidable = 1 flag and adds it onto the Psi Amp. Should both work for the Paramount Amp and the lesser Amp since the lesser Amp is a subtype of the paramount amp and should inherit acidproofness. 

Advantages: Psi Amp users can no longer hide their crown from the Mentalist. Only way to remove it now is surgical removement/deactivation.
Drawbacks: Removes a rather interesting interaction, which is most likely unintended. 

Why is this good? Psi man can no longer hide fallout 4 reference crown.
Why is this bad? Removes some roleplay potential if somebody removes the psi amp crown this way and acts as if they had an accident. 

