### PR TITLE
Ballistics Sidearm / CO Revolver Tweaks

### DIFF
--- a/code/modules/boh_misc/munitions.dm
+++ b/code/modules/boh_misc/munitions.dm
@@ -116,7 +116,7 @@
 	icon_state = "spdloader_magnum"
 	caliber = CALIBER_PISTOL_MAGNUM_LARGE
 	ammo_type = /obj/item/ammo_casing/pistol/magnum/large
-	matter = list(MATERIAL_STEEL = 40000) //Same as the RCD, retardedly high, for good reason.
+	matter = list(MATERIAL_STEEL = 40000)
 	max_ammo = 6
 	multiple_sprites = 1
 

--- a/code/modules/boh_misc/munitions.dm
+++ b/code/modules/boh_misc/munitions.dm
@@ -106,7 +106,7 @@
 
 //projectile
 /obj/item/projectile/bullet/pistol/large
-	damage = 85
+	damage = 65
 	armor_penetration = 15
 	agony = 25
 
@@ -116,7 +116,7 @@
 	icon_state = "spdloader_magnum"
 	caliber = CALIBER_PISTOL_MAGNUM_LARGE
 	ammo_type = /obj/item/ammo_casing/pistol/magnum/large
-	matter = list(MATERIAL_STEEL = 50000) //Same as the RCD, retardedly high, for good reason.
+	matter = list(MATERIAL_STEEL = 40000) //Same as the RCD, retardedly high, for good reason.
 	max_ammo = 6
 	multiple_sprites = 1
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -140,8 +140,8 @@
 /obj/item/projectile/bullet/pistol/rubber //"rubber" bullets
 	name = "rubber bullet"
 	damage_flags = 0
-	damage = 5
-	agony = 30
+	damage = 10
+	agony = 35
 	embed = 0
 
 /obj/item/projectile/bullet/pistol/rubber/holdout


### PR DESCRIPTION
Raises standard Security sidearm rubbers damage from 5->10, raises agony from 30->35. Works fine in local tests, will see how this changes on-server and tweak as necessary to bring them fully into line with smartguns.

Lowers CO revolver option's damage from 85 to 65, due to it only being outclassed by the Deathsquad pulse destroyer and to make the other choices more appealing. Lowered the speedloader cost to 40000 as a result.

🆑
Tweak: Security sidearm rubbers damage and agony raised. CO revolver damage and autolathe cost lowered.
/🆑