### PR TITLE
Ascent Fixes! Now you can take hostages safely!

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1445,6 +1445,7 @@
 #include "code\modules\boh\ascent2\projectiles.dm"
 #include "code\modules\boh\ascent2\structures.dm"
 #include "code\modules\boh\ascent2\turf.dm"
+#include "code\modules\boh\ascent2\weapons.dm"
 #include "code\modules\boh\culture_descriptor\culture\cultures_sergal.dm"
 #include "code\modules\boh\culture_descriptor\faction\factions_human_boh.dm"
 #include "code\modules\boh\culture_descriptor\faction\factions_sergal.dm"

--- a/code/modules/ascent/ascent_outfit.dm
+++ b/code/modules/ascent/ascent_outfit.dm
@@ -2,6 +2,7 @@
 	name = "Ascent - Gyne"
 	mask =     /obj/item/clothing/mask/gas/ascent
 	uniform =  /obj/item/clothing/under/ascent
+	belt =     /obj/item/clothing/suit/storage/ascent
 	id_type =  /obj/item/weapon/card/id/ascent
 	shoes =    /obj/item/clothing/shoes/magboots/ascent
 	l_ear =    null
@@ -12,10 +13,6 @@
 /decl/hierarchy/outfit/job/ascent/attendant
 	name = "Ascent - Attendant"
 	back = /obj/item/weapon/rig/mantid
-
-/decl/hierarchy/outfit/job/ascent/tech
-	name = "Ascent - Technician"
-	suit = /obj/item/clothing/suit/storage/ascent
 
 //monarchs
 /decl/hierarchy/outfit/job/monarch

--- a/code/modules/ascent/ascent_rigs.dm
+++ b/code/modules/ascent/ascent_rigs.dm
@@ -1,7 +1,7 @@
 // Rigs and gear themselves.
 /obj/item/weapon/rig/mantid
-	name = "alate support exosuit"
-	desc = "A powerful support exosuit with integrated power supply, weapon and atmosphere. It's closer to a mech than a rig."
+	name = "alate utility exosuit"
+	desc = "An advanced utility exosuit with integrated power supply, weapon and atmosphere. It's closer to a mech than a rig."
 	icon_state = "kexosuit"
 	item_state = null
 	suit_type = "support exosuit"
@@ -15,7 +15,6 @@
 		rad = ARMOR_RAD_SHIELDED
 	)
 	armor_type = /datum/extension/armor/ablative
-	armor_degradation_speed = 0.05
 	online_slowdown = 0
 	offline_slowdown = 1
 	equipment_overlay_icon = null
@@ -48,25 +47,15 @@
 	var/mantid_caste = SPECIES_MANTID_ALATE
 
 // Renamed blade.
-/obj/item/rig_module/mounted/energy_blade/mantid
-	name = "nanoblade projector"
-	desc = "A fusion-powered blade nanofabricator of Ascent design."
-	interface_name = "nanoblade projector"
-	interface_desc = "A fusion-powered blade nanofabricator of Ascent design."
-	icon = 'icons/obj/ascent.dmi'
-	icon_state = "blade"
-	interface_name = "nanoblade"
-	usable = FALSE
-	gun = null
 
 /obj/item/rig_module/mounted/flechette_rifle
-	name = "flechette rifle"
-	desc = "A flechette nanofabricator and launch system of Ascent design."
-	interface_name = "flechette rifle"
-	interface_desc = "A flechette nanofabricator and launch system of Ascent design."
+	name = "crystal flechette rifle"
+	desc = "A crystal flechette nanofabricator and launch system of Ascent design."
+	interface_name = "crysal flechette rifle"
+	interface_desc = "A crystal flechette nanofabricator and launch system of Ascent design."
 	icon = 'icons/obj/ascent.dmi'
 	icon_state = "rifle"
-	gun = /obj/item/weapon/gun/magnetic/railgun/flechette/ascent
+	gun = /obj/item/weapon/gun/energy/particle/flechette
 
 /obj/item/rig_module/mounted/particle_rifle
 	name = "particle rifle"
@@ -76,6 +65,18 @@
 	icon = 'icons/obj/ascent.dmi'
 	icon_state = "rifle"
 	gun = /obj/item/weapon/gun/energy/particle
+
+/obj/item/rig_module/device/nanoblade
+	name = "nanoblade projector"
+	desc = "A fusion-powered blade nanofabricator of Ascent design."
+	interface_name = "nanoblade projector"
+	interface_desc = "A fusion-powered blade nanofabricator of Ascent design."
+	icon = 'icons/obj/ascent.dmi'
+	icon_state = "blade"
+	engage_string = "Toggle Nanoblade"
+	device = /obj/item/weapon/melee/energy/sword/ascent
+	usable = TRUE
+	selectable = TRUE
 
 /obj/item/rig_module/device/multitool
 	name = "mantid integrated multitool"
@@ -178,7 +179,6 @@
 /obj/item/weapon/tank/mantid/reactor
 	name = "mantid gas reactor"
 	desc = "A mantid gas processing plant that continuously synthesises 'breathable' atmosphere."
-	var/charge_cost = 12
 	var/refill_gas_type = GAS_METHYL_BROMIDE
 	var/gas_regen_amount = 0.05
 	var/gas_regen_cap = 50
@@ -194,8 +194,7 @@
 
 /obj/item/weapon/tank/mantid/reactor/Process()
 	..()
-	var/obj/item/weapon/rig/holder = loc
-	if(air_contents.total_moles < gas_regen_cap && istype(holder) && holder.cell && holder.cell.use(charge_cost))
+	if(air_contents.total_moles < gas_regen_cap)
 		air_contents.adjust_gas(refill_gas_type, gas_regen_amount)
 
 // Chem dispenser.
@@ -215,7 +214,7 @@
 
 // Rig definitions.
 /obj/item/weapon/rig/mantid/gyne
-	name = "gyne support exosuit"
+	name = "gyne utility exosuit"
 	armor = list(
 		melee = ARMOR_MELEE_VERY_HIGH,
 		bullet = ARMOR_BALLISTIC_RESISTANT,
@@ -232,7 +231,7 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/electrowarfare_suite,
 		/obj/item/rig_module/chem_dispenser/mantid,
-		/obj/item/rig_module/mounted/energy_blade/mantid,
+		/obj/item/rig_module/device/nanoblade,
 		/obj/item/rig_module/mounted/flechette_rifle,
 		/obj/item/rig_module/mounted/particle_rifle,
 		/obj/item/rig_module/device/multitool,
@@ -244,7 +243,7 @@
 	)
 
 /obj/item/weapon/rig/mantid/nabber
-	name = "serpentid support exosuit"
+	name = "serpentid utility exosuit"
 	icon_override = 'icons/mob/species/nabber/onmob_back_gas.dmi'
 	mantid_caste = SPECIES_NABBER
 	air_type =   /obj/item/weapon/tank/mantid/reactor/oxygen
@@ -262,7 +261,7 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/electrowarfare_suite,
 		/obj/item/rig_module/chem_dispenser/mantid,
-		/obj/item/rig_module/mounted/energy_blade/mantid,
+		/obj/item/rig_module/device/nanoblade,
 		/obj/item/rig_module/mounted/flechette_rifle,
 		/obj/item/rig_module/mounted/particle_rifle,
 		/obj/item/rig_module/device/multitool,

--- a/code/modules/boh/ascent2/weapons.dm
+++ b/code/modules/boh/ascent2/weapons.dm
@@ -1,0 +1,7 @@
+/obj/item/weapon/melee/energy/sword/ascent
+	name = "crystal nanoblade"
+	desc = "An extremely sharp blade of pure energy, projected from a purple crystal hilt."
+	active_force = 35
+	active_throwforce = 25
+	base_parry_chance = 0
+	blade_color = "blue"

--- a/code/modules/projectiles/guns/energy/mantid.dm
+++ b/code/modules/projectiles/guns/energy/mantid.dm
@@ -74,25 +74,9 @@
 					return overlay_image('icons/mob/species/nabber/onmob_righthand_particle_rifle.dmi', item_state_slots[slot_r_hand_str], color, RESET_COLOR)
 	. = ..(user, slot)
 
-/obj/item/weapon/gun/magnetic/railgun/flechette/ascent
-	name = "mantid flechette rifle"
-	desc = "A viciously pronged rifle-like weapon."
-	has_safety = FALSE
+/obj/item/weapon/gun/energy/particle/flechette
+	name = "crystal flechette rifle"
+	desc = "A viscious looking rifle decorated with a growth of sharp purple crystals."
 	one_hand_penalty = 6
-	var/charge_per_shot = 10
-
-/obj/item/weapon/gun/magnetic/railgun/flechette/ascent/get_cell()
-	if(isrobot(loc) || istype(loc, /obj/item/rig_module))
-		return loc.get_cell()
-
-/obj/item/weapon/gun/magnetic/railgun/flechette/ascent/show_ammo(var/mob/user)
-	var/obj/item/weapon/cell/cell = get_cell()
-	to_chat(user, "<span class='notice'>There are [cell ? Floor(cell.charge/charge_per_shot) : 0] shot\s remaining.</span>")
-
-/obj/item/weapon/gun/magnetic/railgun/flechette/ascent/check_ammo()
-	var/obj/item/weapon/cell/cell = get_cell()
-	return cell && cell.charge >= charge_per_shot
-
-/obj/item/weapon/gun/magnetic/railgun/flechette/ascent/use_ammo()
-	var/obj/item/weapon/cell/cell = get_cell()
-	if(cell) cell.use(charge_per_shot)
+	projectile_type = /obj/item/projectile/bullet/magnetic/flechette
+	firemodes = list(list(projectile_type = /obj/item/projectile/bullet/magnetic/flechette))

--- a/maps/away/ascent/ascent_jobs.dm
+++ b/maps/away/ascent/ascent_jobs.dm
@@ -154,7 +154,6 @@
 	supervisors = "the Gyne"
 	info = "You are an Alate of an independent Ascent vessel. Your Gyne has directed you to this remote sector full of crawling primitives. Follow her instructions and bring prosperity to your nest-lineage."
 	set_species_on_join = SPECIES_MANTID_ALATE
-	outfit_type = /decl/hierarchy/outfit/job/ascent/tech
 	requires_supervisor = "Ascent Gyne"
 	min_skill = list(SKILL_EVA = SKILL_ADEPT,
 					SKILL_HAULING = SKILL_ADEPT,


### PR DESCRIPTION
Ascent Code is a bit of an unfinished mess. This PR makes some improvements to the code that mostly consists of fixing oversights. There are no unique sprites for the nanoblade or crystal flechette cannon currently.

Additionally, the nanoblade does not currently light up when activated. This is likely because RIG modules don't actually show up in hands (Which they absolutely should for both balance and visibility reasons) so I'd rather that be changed, than make a hacky solution.

Anyways, enjoy.

* Gynes will now spawn with a filled gear harness in their belt slot.
* Alates will now spawn with the gear harness in their belt slot instead of their suit slot.
* The Gyne exosuit nanoblade module has been fixed and replaced with an integrated energy sword that does slightly more damage (35 instead of 30) at the cost of having no block chance.
* The Gyne Flechette module has been fixed to recharge properly, and now fires three round flechette bursts from an 18 round capacity "battery". 
* Reactor tanks now properly regenerate gas over time without the need for a power source.
* Tentative fix for exosuit armor degredation.
