### PR TITLE
Forgot literally a single letter.

### DIFF
--- a/maps/torch/items/clothing/boh_accessory.dm
+++ b/maps/torch/items/clothing/boh_accessory.dm
@@ -207,7 +207,7 @@
 	desc = "Insignia denoting the rank of Master Gunnery Sergeant."
 
 /obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e9_alt
-	icon_state = "ME9"
+	icon_state = "ME9A"
 	name = "ranks (E-9 sergeant major)"
 	desc = "Insignia denoting the rank of Sergeant Major."
 


### PR DESCRIPTION
The smallest, most embarassing oversight. Literally one letter was forgotten in assigning the Sergeant Major sprite to the rank tab. 

- Makes the Sergeant Major use the proper rank sprite by assigning icon_state ME9A instead of ME9.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->