### PR TITLE
Navy Blue Marine Uniforms, Fixes One Letter Mistake

### DIFF
--- a/maps/torch/items/clothing/boh_accessory.dm
+++ b/maps/torch/items/clothing/boh_accessory.dm
@@ -207,7 +207,7 @@
 	desc = "Insignia denoting the rank of Master Gunnery Sergeant."
 
 /obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e9_alt
-	icon_state = "ME9"
+	icon_state = "ME9A"
 	name = "ranks (E-9 sergeant major)"
 	desc = "Insignia denoting the rank of Sergeant Major."
 

--- a/maps/torch/items/clothing/solgov-head.dm
+++ b/maps/torch/items/clothing/solgov-head.dm
@@ -49,6 +49,11 @@
 	name = "fleet utility cover"
 	desc = "A navy blue utility cover bearing the crest of NT's Private Fleet."
 	icon_state = "navyutility"
+	
+/obj/item/clothing/head/solgov/utility/fleet/marine
+	name = "navy utility cover"
+	desc = "A navy blue utility cover bearing the crest of the SCG Army."
+	icon_state = "navyutility"
 
 /obj/item/clothing/head/solgov/utility/army
 	name = "army utility cover"

--- a/maps/torch/items/clothing/solgov-under.dm
+++ b/maps/torch/items/clothing/solgov-under.dm
@@ -181,6 +181,12 @@
 
 /obj/item/clothing/under/solgov/utility/fleet/combat/exploration
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/fleet)
+	
+/obj/item/clothing/under/solgov/utility/fleet/combat/marine
+	name = "navy fatigues"
+	desc = "Alternative Marine utility uniform, made for ship use."
+	icon_state = "navycombat"
+	worn_state = "navycombat"
 
 /obj/item/clothing/under/solgov/utility/fleet/officer
 	name = "fleet officer's coveralls"

--- a/maps/torch/loadout/loadout_head_boh.dm
+++ b/maps/torch/loadout/loadout_head_boh.dm
@@ -11,7 +11,7 @@
 	cover += /obj/item/clothing/head/solgov/utility/army
 	cover += /obj/item/clothing/head/solgov/utility/army/urban
 	cover += /obj/item/clothing/head/solgov/utility/army/tan
-	cover += /obj/item/clothing/head/solgov/utility/fleet
+	cover += /obj/item/clothing/head/solgov/utility/fleet/marine
 	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(cover)
 
 /datum/gear/head/self_protection_helmet

--- a/maps/torch/loadout/loadout_head_boh.dm
+++ b/maps/torch/loadout/loadout_head_boh.dm
@@ -11,6 +11,7 @@
 	cover += /obj/item/clothing/head/solgov/utility/army
 	cover += /obj/item/clothing/head/solgov/utility/army/urban
 	cover += /obj/item/clothing/head/solgov/utility/army/tan
+	cover += /obj/item/clothing/head/solgov/utility/fleet
 	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(cover)
 
 /datum/gear/head/self_protection_helmet

--- a/maps/torch/loadout/loadout_uniform_boh.dm
+++ b/maps/torch/loadout/loadout_uniform_boh.dm
@@ -10,7 +10,7 @@
 	var/uniform = list()
 	uniform += /obj/item/clothing/under/solgov/utility/army/urban
 	uniform += /obj/item/clothing/under/solgov/utility/army/tan
-	uniform += /obj/item/clothing/under/solgov/utility/fleet/combat
+	uniform += /obj/item/clothing/under/solgov/utility/fleet/combat/marine
 	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(uniform)
 
 /datum/gear/uniform/fleet

--- a/maps/torch/loadout/loadout_uniform_boh.dm
+++ b/maps/torch/loadout/loadout_uniform_boh.dm
@@ -10,6 +10,7 @@
 	var/uniform = list()
 	uniform += /obj/item/clothing/under/solgov/utility/army/urban
 	uniform += /obj/item/clothing/under/solgov/utility/army/tan
+	uniform += /obj/item/clothing/under/solgov/utility/fleet/combat
 	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(uniform)
 
 /datum/gear/uniform/fleet


### PR DESCRIPTION
A few tweaks and one correction. 

- Fixes Sergeant Major ranks sprite to use the Sergeant Major one instead of the Master Gunnery Sergeant.
- Adds navy blue marine uniform and cover variant, and adds to loadout options since marines can already pick a navy blue carrier.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->