### PR TITLE
Restores Dark Vision Traits for Custom Species

### DIFF
--- a/modular_mithra/code/modules/mithra/traits_positive.dm
+++ b/modular_mithra/code/modules/mithra/traits_positive.dm
@@ -8,6 +8,32 @@
 	cost = 4
 	var_changes = list("slowdown" = -0.5)
 
+/datum/trait/darksight
+	name = "Tapeta Lucida"
+	desc = "Your eyes have a marginally retroreflective layer within their strucuture, allowing you to see slightly better in the dark."
+	cost = 1
+	var_changes = list("darksight_range" = 3, "darksight_tint" = DARKTINT_MODERATE)
+
+/datum/trait/darksight/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	var/obj/item/organ/internal/eyes/I = H.internal_organs_by_name[S.vision_organ]
+	if(istype(I))
+		I.darksight_range = 3
+		I.darksight_tint = DARKTINT_MODERATE
+
+/datum/trait/darksight_plus
+	name = "Tapeta Lucida Majoris"
+	desc = "Your eyes have a retroreflective layer within their strucuture, allowing you to see much better in the dark."
+	cost = 2
+	var_changes = list("darksight_range" = 6, "darksight_tint" = DARKTINT_GOOD)
+
+/datum/trait/darksight_plus/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	var/obj/item/organ/internal/eyes/I = H.internal_organs_by_name[S.vision_organ]
+	if(istype(I))
+		I.darksight_range = 6
+		I.darksight_tint = DARKTINT_GOOD
+
 /datum/trait/nonconductive
 	name = "Resistive Skin"
 	desc = "Your skin has a higher electrical resistivity than normal, making you less conductive."


### PR DESCRIPTION
:cl: Toriate
bugfix: darkvision traits have been restored to working order
/:cl:

Closes #112.

No darkvision: (Ignore the mysteriously glowing mob)
![dreamseeker_KPPrLlFE5Z](https://user-images.githubusercontent.com/31995558/75606256-ea3ceb80-5b25-11ea-836e-48ac6be1410b.png)

With max darkvision:
![dreamseeker_3mY4sIAntG](https://user-images.githubusercontent.com/31995558/75606270-fe80e880-5b25-11ea-821b-46fab386ea8f.png)