### PR TITLE
Xeno Rank Overhaul and Other Rank Things

### DIFF
--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -42,7 +42,7 @@
 		/datum/mil_rank/marine_corps/o3,
 //		/datum/mil_rank/marine_corps/o3_alt,
 //		/datum/mil_rank/marine_corps/o3_alt2,
-		1/datum/mil_rank/marine_corps/o4
+		/datum/mil_rank/marine_corps/o4
 	)
 
 /datum/job/chief_engineer

--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -39,9 +39,10 @@
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o4,
-		/datum/mil_rank/marine_corps/o3_alt,
-		/datum/mil_rank/marine_corps/o3_alt2,
-		/datum/mil_rank/marine_corps/o4
+		/datum/mil_rank/marine_corps/o3,
+//		/datum/mil_rank/marine_corps/o3_alt,
+//		/datum/mil_rank/marine_corps/o3_alt2,
+		1/datum/mil_rank/marine_corps/o4
 	)
 
 /datum/job/chief_engineer
@@ -53,8 +54,9 @@
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/marine_corps/o2,
-		/datum/mil_rank/marine_corps/o3_alt,
-		/datum/mil_rank/marine_corps/o3_alt2
+		/datum/mil_rank/marine_corps/o3,
+//		/datum/mil_rank/marine_corps/o3_alt,
+//		/datum/mil_rank/marine_corps/o3_alt2,
 	)
 
 /datum/job/hos
@@ -66,8 +68,9 @@
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/marine_corps/o2,
-		/datum/mil_rank/marine_corps/o3_alt,
-		/datum/mil_rank/marine_corps/o3_alt2
+		/datum/mil_rank/marine_corps/o3,
+//		/datum/mil_rank/marine_corps/o3_alt,
+//		/datum/mil_rank/marine_corps/o3_alt2,
 	)
 
 /datum/job/sea

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -24,8 +24,6 @@
 	/datum/mil_rank/marine_corps/o1,\
 	/datum/mil_rank/marine_corps/o2,\
 	/datum/mil_rank/marine_corps/o3,\
-	/datum/mil_rank/marine_corps/o4,\
-	/datum/mil_rank/marine_corps/o5,\
 	)
 
 /datum/map/torch

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -3,7 +3,12 @@
 #define SEMIRESTRICTED /datum/mil_branch/marine_corps, /datum/mil_branch/private_security
 
 // Rank-specific defines
-#define SMC_TROOPERS_ONLY /datum/mil_branch/marine_corps = list(/datum/mil_rank/marine_corps/e1, /datum/mil_rank/marine_corps/e2, /datum/mil_rank/marine_corps/e3)
+#define SMC_TROOPERS_ONLY /datum/mil_branch/marine_corps = list(\
+	/datum/mil_rank/marine_corps/e1,\
+	/datum/mil_rank/marine_corps/e2,\
+	/datum/mil_rank/marine_corps/e3,\
+	/datum/mil_rank/marine_corps/e4,\
+	)
 #define SMC_LIMITED_RANKS /datum/mil_branch/marine_corps = list(\
 	/datum/mil_rank/marine_corps/e1,\
 	/datum/mil_rank/marine_corps/e2,\
@@ -18,7 +23,10 @@
 	/datum/mil_rank/marine_corps/e9_alt,\
 	/datum/mil_rank/marine_corps/o1,\
 	/datum/mil_rank/marine_corps/o2,\
+	/datum/mil_rank/marine_corps/o3_alt,\
 	/datum/mil_rank/marine_corps/o3_alt2\
+	/datum/mil_rank/marine_corps/o4,\
+	/datum/mil_rank/marine_corps/o5,\
 	)
 
 /datum/map/torch
@@ -63,15 +71,19 @@
 		/datum/species/nabber		= list(/datum/mil_branch/civilian),
 		/datum/species/skrell		= list(UNRESTRICTED, /datum/mil_branch/skrell_fleet),
 		/datum/species/unathi		= list(UNRESTRICTED, SEMIRESTRICTED),
+		/datum/species/unathi/yeosa	= list(UNRESTRICTED, SEMIRESTRICTED),
 		/datum/species/adherent		= list(UNRESTRICTED),
 		/datum/species/sergal		= list(UNRESTRICTED, /datum/mil_branch/private_security),
+		/datum/species/sergal/northern	= list(UNRESTRICTED, /datum/mil_branch/private_security),
+		/datum/species/sergal/eastern	= list(UNRESTRICTED, /datum/mil_branch/private_security),
 		/datum/species/akula		= list(UNRESTRICTED, /datum/mil_branch/private_security),
 		/datum/species/custom		= list(UNRESTRICTED, SEMIRESTRICTED),
 		/datum/species/humanathi	= list(UNRESTRICTED, SEMIRESTRICTED),
 		/datum/species/tajaran		= list(UNRESTRICTED, SEMIRESTRICTED),
-		/datum/species/vasilissan	= list(UNRESTRICTED),
+		/datum/species/vasilissan	= list(UNRESTRICTED, /datum/mil_branch/private_security),
 		/datum/species/vulpkanin	= list(UNRESTRICTED, SEMIRESTRICTED),
 		/datum/species/customhuman	= list(UNRESTRICTED, SEMIRESTRICTED),
+		/datum/species/shapeshifter/promethean	= list(/datum/mil_branch/civilian),
 		//datum/species/tesh/		= list(UNRESTRICTED),
 		/datum/species/vox			= list(/datum/mil_branch/alien),
 		/datum/species/vox/pariah	= list(/datum/mil_branch/civilian),
@@ -80,6 +92,7 @@
 
 	species_to_rank_whitelist = list(
 		/datum/species/unathi		= list(SMC_TROOPERS_ONLY),
+		/datum/species/unathi/yeosa	= list(SMC_TROOPERS_ONLY),
 		/datum/species/humanathi	= list(SMC_TROOPERS_ONLY),
 		/datum/species/tajaran		= list(SMC_TROOPERS_ONLY),
 		/datum/species/vulpkanin	= list(SMC_LIMITED_RANKS),

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -24,7 +24,7 @@
 	/datum/mil_rank/marine_corps/o1,\
 	/datum/mil_rank/marine_corps/o2,\
 	/datum/mil_rank/marine_corps/o3_alt,\
-	/datum/mil_rank/marine_corps/o3_alt2\
+	/datum/mil_rank/marine_corps/o3_alt2,\
 	/datum/mil_rank/marine_corps/o4,\
 	/datum/mil_rank/marine_corps/o5,\
 	)

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -23,8 +23,7 @@
 	/datum/mil_rank/marine_corps/e9_alt,\
 	/datum/mil_rank/marine_corps/o1,\
 	/datum/mil_rank/marine_corps/o2,\
-	/datum/mil_rank/marine_corps/o3_alt,\
-	/datum/mil_rank/marine_corps/o3_alt2,\
+	/datum/mil_rank/marine_corps/o3,\
 	/datum/mil_rank/marine_corps/o4,\
 	/datum/mil_rank/marine_corps/o5,\
 	)
@@ -183,8 +182,6 @@
 		/datum/mil_rank/marine_corps/o1,
 		/datum/mil_rank/marine_corps/o2,
 		/datum/mil_rank/marine_corps/o3,
-		/datum/mil_rank/marine_corps/o3_alt,
-		/datum/mil_rank/marine_corps/o3_alt2,
 		/datum/mil_rank/marine_corps/o4,
 		/datum/mil_rank/marine_corps/o5,
 		/datum/mil_rank/marine_corps/o6,
@@ -208,8 +205,7 @@
 		/datum/mil_rank/marine_corps/e9_alt,
 		/datum/mil_rank/marine_corps/o1,
 		/datum/mil_rank/marine_corps/o2,
-		/datum/mil_rank/marine_corps/o3_alt,
-		/datum/mil_rank/marine_corps/o3_alt2,
+		/datum/mil_rank/marine_corps/o3,
 		/datum/mil_rank/marine_corps/o4,
 		/datum/mil_rank/marine_corps/o5,
 		/datum/mil_rank/marine_corps/o6

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -94,9 +94,6 @@
 		/datum/species/unathi/yeosa	= list(SMC_TROOPERS_ONLY),
 		/datum/species/humanathi	= list(SMC_TROOPERS_ONLY),
 		/datum/species/tajaran		= list(SMC_TROOPERS_ONLY),
-		/datum/species/vulpkanin	= list(SMC_LIMITED_RANKS),
-		/datum/species/custom		= list(SMC_LIMITED_RANKS),
-		/datum/species/customhuman	= list(SMC_LIMITED_RANKS),
 	)
 
 /datum/mil_branch/fleet


### PR DESCRIPTION
I decided to go ahead and close some loopholes within the ranking system. Some subspecies weren't listed and thus had full access where the base species was restricted as one example. Genemodders, if they're to be human, are thus treated as human and removed from restriction. As well, the Marine Captain and Specialist Captain ranks are commented out for Chief of Security, Chief Medical Officer, and Chief Engineer. Annotated changes are below.

- Northern and Eastern Sergals are no longer allowed to be Marines. Base Sergals weren't allowed. Subspecies brought in line with base.
- Yeosa'Unathi no longer have access to all Marine ranks. Base Unathi and Yeteris'Unathi were restricted to Trooper ranks. Subspecies brought in line with base.
- Prometheans, due to being squishy and easily killed and destroyed, are civilian/contractor restricted pending future fixes to the species.
- TROOPER_ONLY rank restriction raised to E-4, allowing Unathi and Tajara to be Corporals instead of just Lance Corporals.
- Vasilissans allowed to be private security.
- Marine Captain and Specialist Captain O-3 alt ranks were removed. 'Captain' O-3 rank re-implemented for Chief Engineer, Chief of Security, and Chief Medical Officer.
- Genemods, if they're to be treated as humans with fur effectively, have been removed from a xenos whitelist. They have full access to all Marine ranks up to O-5.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->