### PR TITLE
Tweaks away site and overmap spawns.

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -41,7 +41,7 @@
 	//Flags deciding what features to pick
 	var/ruin_tags_whitelist
 	var/ruin_tags_blacklist
-	var/features_budget = 4
+	var/features_budget = 5
 	var/list/possible_features = list()
 	var/list/spawned_features
 
@@ -411,14 +411,14 @@
 
 	for(var/datum/exoplanet_theme/theme in themes)
 		skybox_image.overlays += theme.get_planet_image_extra()
-	
+
 	if(water_color) //TODO: move water levels out of randommap into exoplanet
 		var/image/water = image('icons/skybox/planet.dmi', "water")
 		water.color = water_color
 		water.appearance_flags = PIXEL_SCALE
 		water.transform = water.transform.Turn(rand(0,360))
 		skybox_image.overlays += water
-	
+
 	if(atmosphere && atmosphere.return_pressure() > SOUND_MINIMUM_PRESSURE)
 
 		var/atmo_color = get_atmosphere_color()
@@ -435,7 +435,7 @@
 
 		var/image/atmo = image('icons/skybox/planet.dmi', "atmoring")
 		skybox_image.underlays += atmo
-		
+
 	var/image/shadow = image('icons/skybox/planet.dmi', "shadow")
 	shadow.blend_mode = BLEND_MULTIPLY
 	skybox_image.overlays += shadow

--- a/code/modules/overmap/exoplanets/planet_types/shrouded.dm
+++ b/code/modules/overmap/exoplanets/planet_types/shrouded.dm
@@ -6,7 +6,6 @@
 	rock_colors = list(COLOR_INDIGO, COLOR_DARK_BLUE_GRAY, COLOR_NAVY_BLUE)
 	plant_colors = list("#3c5434", "#2f6655", "#0e703f", "#495139", "#394c66", "#1a3b77", "#3e3166", "#52457c", "#402d56", "#580d6d")
 	map_generators = list(/datum/random_map/noise/exoplanet/shrouded, /datum/random_map/noise/ore/poor)
-	ruin_tags_blacklist = RUIN_HABITAT
 	lightlevel = -0.15
 	surface_color = "#3e3960"
 	water_color = "#2b2840"

--- a/code/modules/overmap/exoplanets/planet_types/volcanic.dm
+++ b/code/modules/overmap/exoplanets/planet_types/volcanic.dm
@@ -7,7 +7,7 @@
 	plant_colors = list("#a23c05","#3f1f0d","#662929","#ba6222","#7a5b3a","#120309")
 	possible_themes = list()
 	map_generators = list(/datum/random_map/automata/cave_system/mountains/volcanic, /datum/random_map/noise/exoplanet/volcanic, /datum/random_map/noise/ore/filthy_rich)
-	ruin_tags_blacklist = RUIN_HABITAT|RUIN_WATER
+	ruin_tags_blacklist = RUIN_WATER
 	surface_color = "#261e19"
 	water_color = "#c74d00"
 

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -34,8 +34,8 @@
 
 	default_law_type = /datum/ai_laws/solgov
 	use_overmap = 1
-	num_exoplanets = 1
+	num_exoplanets = 2
 
-	away_site_budget = 3
+	away_site_budget = 5
 	//id_hud_icons = 'maps/torch/icons/assignment_hud.dmi'
 	id_hud_icons = 'maps/torch/icons/assignment_hud_boh.dmi'

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -34,7 +34,7 @@
 
 	default_law_type = /datum/ai_laws/solgov
 	use_overmap = 1
-	num_exoplanets = 2
+	num_exoplanets = 1
 
 	away_site_budget = 5
 	//id_hud_icons = 'maps/torch/icons/assignment_hud.dmi'


### PR DESCRIPTION
🆑Roland410
:tweak:Raises exoplanet and overmap feature budget which means more away sites and ruins (not necessarily joinable ones) CAN spawn. Nothing is guaranteed.
:tweak:Except now two planets will spawn, go ham and explore those.
:tweak:Inhabited colony can now spawn on shrouded and volcanic planets. You asked for this, but suffer the consequences.
/🆑

For the love of god, please testmerge this as this will surely mean a longer startup time and can cause performance issues with the two planets in the long run.