### PR TITLE
Normalize air alarm access on Gaunt between the Gaunt cargobay and the rest of the shuttle

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -1205,7 +1205,8 @@
 /obj/machinery/alarm{
 	dir = 1;
 	icon_state = "alarm0";
-	pixel_y = -22
+	pixel_y = -22;
+	req_access = list(list("ACCESS_ATMOS","ACCESS_ENGINE_EQUIP","ACCESS_EXPLO_HELM"))
 	},
 /obj/machinery/camera/network/exploration_shuttle{
 	icon_state = "camera";
@@ -1326,7 +1327,8 @@
 /obj/machinery/alarm{
 	dir = 1;
 	icon_state = "alarm0";
-	pixel_y = -22
+	pixel_y = -22;
+	req_access = list(list("ACCESS_ATMOS","ACCESS_ENGINE_EQUIP","ACCESS_EXPLO_HELM"))
 	},
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/crew)
@@ -1651,7 +1653,8 @@
 /obj/item/device/radio,
 /obj/item/device/radio,
 /obj/machinery/alarm{
-	pixel_y = 32
+	pixel_y = 32;
+	req_access = list(list("ACCESS_ATMOS","ACCESS_ENGINE_EQUIP","ACCESS_EXPLO_HELM"))
 	},
 /obj/machinery/light{
 	dir = 4
@@ -2421,7 +2424,8 @@
 	dir = 4;
 	pixel_x = -21;
 	pixel_y = 0;
-	rcon_setting = 2
+	rcon_setting = 2;
+	req_access = list(list("ACCESS_ATMOS","ACCESS_ENGINE_EQUIP","ACCESS_EXPLO_HELM"))
 	},
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -2713,7 +2717,8 @@
 	dir = 4;
 	pixel_x = -21;
 	pixel_y = 0;
-	rcon_setting = 2
+	rcon_setting = 2;
+	req_access = list(list("ACCESS_ATMOS","ACCESS_ENGINE_EQUIP","ACCESS_EXPLO_HELM"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/airlock)
@@ -12895,7 +12900,7 @@
 	icon_state = "alarm0";
 	pixel_x = 0;
 	pixel_y = 24;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_EXPLO_HELM"))
+	req_access = list(list("ACCESS_ATMOS","ACCESS_ENGINE_EQUIP","ACCESS_EXPLO_HELM"))
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/outline,
@@ -16362,7 +16367,8 @@
 /obj/machinery/alarm{
 	dir = 1;
 	icon_state = "alarm0";
-	pixel_y = -22
+	pixel_y = -22;
+	req_access = list(list("ACCESS_ATMOS","ACCESS_ENGINE_EQUIP","ACCESS_EXPLO_HELM"))
 	},
 /obj/structure/handrai{
 	icon_state = "handrail";


### PR DESCRIPTION
This adds IDs with ACCESS_EXPLO_HELM to all air alarms within the Gaunt.  This will allow the shuttle pilot (or those with that access) to do neat things like equalizing the pressure between the gaunt and the outside environment,  or restarting the atmospherics system after repairing damage.

This was already enabled in the cargo bay, however it looks like something strange happened during a map merge that left the rest of the air alarms behind.  (based on the differences between line formatting)

🆑 Alffd
maptweak: Adds "ACCESS_ATMOS" to Gaunt cargo bay air alarm.
maptweak: Adds "ACCESS_EXPLO_HELM" to Gaunt air alarms that were missing it.
/🆑