### PR TITLE
Combat Calamity 2: The Brainmed Blowup

### DIFF
--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -264,9 +264,13 @@
 			damage_mod -= armor_datum.get_blocked(BRUTE, damage_flags, W.armor_penetration, W.force*1.5)
 
 	var/total_damage = 0
+	var/obj/item/organ/external/E = affecting.get_organ(G.target_zone)
+	var/sever_prob = max(((damage_mod * 100) - 20), 0)
 	for(var/i in 1 to 3)
 		var/damage = min(W.force*1.5, 20)*damage_mod
 		affecting.apply_damage(damage, W.damtype, BP_HEAD, damage_flags, armor_pen = 100, used_weapon=W)
+		if(prob(sever_prob))
+			E.sever_artery()
 		affecting.losebreath += 25
 		affecting.adjustOxyLoss(25)
 		total_damage += damage

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -85,7 +85,7 @@ proc/getsensorlevel(A)
 
 //The base miss chance for the different defence zones
 var/list/global/base_miss_chance = list(
-	BP_HEAD = 70,
+	BP_HEAD = 75,
 	BP_CHEST = 25,
 	BP_GROIN = 25,
 	BP_L_LEG = 50,

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -205,6 +205,8 @@
 
 /obj/item/organ/internal/brain/take_internal_damage(var/damage, var/silent)
 	set waitfor = 0
+	if(damage >= 50) //should only really be triggered by executions or very big ouch weapons
+		damage *= 2
 	..()
 	if(damage >= 10) //This probably won't be triggered by oxyloss or mercury. Probably.
 		var/damage_secondary = damage * 0.20
@@ -212,7 +214,8 @@
 		owner.eye_blurry += damage_secondary
 		owner.confused += damage_secondary * 2
 		owner.Paralyse(damage_secondary)
-		owner.Weaken(round(damage, 1))
+		owner.Weaken(round((damage_secondary * 3), 1))
+		owner.adjustOxyLoss(damage)
 		if(prob(30))
 			addtimer(CALLBACK(src, .proc/brain_damage_callback, damage), rand(6, 20) SECONDS, TIMER_UNIQUE)
 

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -81,7 +81,7 @@
 			owner.emote("cough")		//respitory tract infection
 
 	if(is_bruised() && !owner.is_asystole())
-		if(prob(2))
+		if(prob(3))
 			if(active_breathing)
 				owner.visible_message(
 					"<B>\The [owner]</B> coughs up blood!",
@@ -94,8 +94,8 @@
 					"blood drips from <B>\the [owner]'s</B> [parent.name]!",
 				)
 
-			owner.drip(1)
-		if(prob(4))
+			owner.drip(rand(1,3))
+		if(prob(3))
 			if(active_breathing)
 				owner.visible_message(
 					"<B>\The [owner]</B> gasps for air!",
@@ -105,7 +105,12 @@
 			else
 				to_chat(owner, "<span class='danger'>You're having trouble getting enough [breath_type]!</span>")
 
-			owner.losebreath += round(damage/2)
+			owner.losebreath = max(owner.losebreath, round(damage/4))
+
+/obj/item/organ/internal/lungs/take_internal_damage(var/damage, var/silent)
+	..()
+	if(damage >= 15) //things which meaningfully harm the lungs in a single go-round will make it harder to breathe for a bit
+		owner.losebreath += damage
 
 /obj/item/organ/internal/lungs/proc/rupture()
 	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
@@ -123,7 +128,7 @@
 	var/int_pressure_diff = abs(last_int_pressure - breath_pressure)
 	var/ext_pressure_diff = abs(last_ext_pressure - ext_pressure) * owner.get_pressure_weakness(ext_pressure)
 	if(int_pressure_diff > max_pressure_diff && ext_pressure_diff > max_pressure_diff)
-		var/lung_rupture_prob = BP_IS_ROBOTIC(src) ? prob(30) : prob(60) //Robotic lungs are less likely to rupture.
+		var/lung_rupture_prob = BP_IS_ROBOTIC(src) ? prob(30) : prob(50) //Robotic lungs are less likely to rupture.
 		if(!is_bruised() && lung_rupture_prob) //only rupture if NOT already ruptured
 			rupture()
 
@@ -149,7 +154,7 @@
 		return 1
 
 	var/safe_pressure_min = min_breath_pressure // Minimum safe partial pressure of breathable gas in kPa
-	// Lung damage increases the minimum safe pressure.
+	// Lung damage increases the minimum safe pressure
 	safe_pressure_min *= 1 + rand(1,4) * damage/max_damage
 
 	if(!forced && owner.chem_effects[CE_BREATHLOSS] && !owner.chem_effects[CE_STABLE]) //opiates are bad mmkay

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -913,10 +913,10 @@
 		return
 
 	if(M.chem_doses[type] < 0.2)	//not that effective after initial rush
-		M.add_chemical_effect(CE_PAINKILLER, min(30*volume, 80))
+		M.add_chemical_effect(CE_PAINKILLER, min(30*volume, 60))
 		M.add_chemical_effect(CE_PULSE, 1)
 	else if(M.chem_doses[type] < 1)
-		M.add_chemical_effect(CE_PAINKILLER, min(10*volume, 20))
+		M.add_chemical_effect(CE_PAINKILLER, min(10*volume, 10))
 	M.add_chemical_effect(CE_PULSE, 2)
 	if(M.chem_doses[type] > 10)
 		M.make_jittery(1)


### PR DESCRIPTION
:cl:
tweak: Brain damage deals commensurate, temporary oxyloss giving moderate brain damage from injuries to the head a chance to tick minor damage before oxyloss recovers and major injuries a reason to be taken seriously besides bleeding.
tweak: Execution/heavy weapons-level direct brain damage increased; this should only come up under circumstances in which your life was already forfeit, and the head has been made slightly harder to hit to compensate. 
tweak: Brain damage paralysis/flooring nerfed. 
tweak: Lung damage is now more potent in the short-term and less obnoxious in the long term - speech is now permitted with some restrictions up to either serious damage, zero atmosphere, or acute breathloss ("You can't breathe!" - this happens less frequently and doesn't stack infinitely now, so watch for it.)
tweak: Base rupture chance on non-robotic lungs reduced.
tweak: Adrenaline painkiller potency nerfed at both immediate and short-term levels.
/:cl:
