### PR TITLE
Colony stuff

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
@@ -17,7 +17,8 @@
 /datum/job/submap/colonist
 	title = "Colonist"
 	info = "You are a Colonist, living on the rim of explored, let alone inhabited, space in a reconstructed shelter made from the very ship that took you here."
-	total_positions = 6
+	total_positions = 7
+	is_semi_antagonist = TRUE
 	outfit_type = /decl/hierarchy/outfit/job/colonist
 
 /decl/hierarchy/outfit/job/colonist


### PR DESCRIPTION
Gives colonists provocateur status, and increases their slots to 7 (Previously 6).

Adds more chances for conflict between the colony and the exploration team. Better watch out when trying to claim some random planet from an armed group of survivalists.