### PR TITLE
Switches failed GC to to_world_log() instead of crash_at().

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -190,7 +190,7 @@ SUBSYSTEM_DEF(garbage)
 				var/type = D.type
 				var/datum/qdel_item/I = items[type]
 				if(!I.failures)
-					crash_with("GC: -- \ref[D] | [type] was unable to be GC'd --")
+					to_world_log("GC: -- \ref[D] | [type] was unable to be GC'd --")
 				I.failures++
 				fail_counts[level]++
 			if (GC_QUEUE_HARDDELETE)


### PR DESCRIPTION
`crash_at()` causes a runtime error, while failed GC is exceptionally common even when the code is performing properly. It can spam the log out, and eventually triggers automatic BYOND processes like shrinking the runtime logs (which can eat legitimate runtime errors) and to my vague recollection may eventually hit a counter that kills the server completely.

It will also involve less file I/O to write to logs, I believe. Generally seems like it could help if 30 runtimes a second are common.