### PR TITLE
Makes Skipjack Thrusters visible again

### DIFF
--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -205,8 +205,8 @@
 	},
 /obj/item/weapon/soap,
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "aI" = (
@@ -214,8 +214,8 @@
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "aJ" = (
@@ -224,8 +224,8 @@
 	},
 /obj/random/trash,
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "aK" = (
@@ -321,15 +321,15 @@
 /area/map_template/syndicate_mothership/raider_base)
 "aS" = (
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "aT" = (
 /obj/effect/decal/cleanable/blood,
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "aU" = (
@@ -390,8 +390,8 @@
 /area/map_template/syndicate_mothership/raider_base)
 "ba" = (
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -400,8 +400,8 @@
 	pixel_y = 0
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "bb" = (
@@ -507,8 +507,8 @@
 /area/map_template/syndicate_mothership/raider_base)
 "bl" = (
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -518,8 +518,8 @@
 	pixel_y = 0
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "bm" = (
@@ -536,8 +536,8 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "bo" = (
@@ -590,8 +590,8 @@
 /area/map_template/syndicate_mothership/raider_base)
 "bt" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 6
+	dir = 6;
+	icon_state = "intact"
 	},
 /turf/unsimulated/floor{
 	icon_state = "plating";
@@ -1191,13 +1191,13 @@
 /area/map_template/skipjack_station/start)
 "cJ" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "vox_west_vent";
-	tag_exterior_door = "vox_northwest_lock";
 	frequency = 1331;
 	id_tag = "vox_west_control";
-	tag_interior_door = "vox_southwest_lock";
 	pixel_x = 24;
-	tag_chamber_sensor = "vox_west_sensor"
+	tag_airpump = "vox_west_vent";
+	tag_chamber_sensor = "vox_west_sensor";
+	tag_exterior_door = "vox_northwest_lock";
+	tag_interior_door = "vox_southwest_lock"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -1212,16 +1212,16 @@
 	dir = 8
 	},
 /obj/machinery/computer/station_alert/all{
-	icon_state = "computer";
-	dir = 4
+	dir = 4;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "cL" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 8;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (WEST)"
 	},
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
@@ -1254,8 +1254,8 @@
 "cO" = (
 /obj/machinery/constructable_frame/computerframe,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
@@ -1398,8 +1398,8 @@
 /obj/random/voidhelmet,
 /obj/random/maintenance,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
@@ -1667,8 +1667,8 @@
 /area/map_template/skipjack_station/start)
 "dP" = (
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -1769,14 +1769,6 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/map_template/skipjack_station/start)
-"eg" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced/crescent{
-	dir = 1
-	},
-/obj/effect/paint/black,
-/turf/simulated/wall/voxshuttle,
-/area/map_template/skipjack_station/start)
 "eh" = (
 /obj/random/trash,
 /turf/simulated/floor/shuttle/black,
@@ -1798,11 +1790,6 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/shuttle/white,
-/area/map_template/skipjack_station/start)
-"el" = (
-/obj/structure/shuttle/engine/propulsion,
-/obj/effect/paint/black,
-/turf/simulated/wall/voxshuttle,
 /area/map_template/skipjack_station/start)
 "em" = (
 /obj/structure/table/standard,
@@ -1958,6 +1945,17 @@
 	name = "plating"
 	},
 /area/map_template/syndicate_mothership/raider_base)
+"Mm" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced/crescent{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/map_template/skipjack_station/start)
+"Vz" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/airless,
+/area/map_template/skipjack_station/start)
 
 (1,1,1) = {"
 aa
@@ -3949,8 +3947,8 @@ dl
 dz
 dz
 dS
-eg
-el
+Mm
+Vz
 aa
 aa
 aa
@@ -4021,8 +4019,8 @@ du
 dm
 dJ
 dT
-eg
-el
+Mm
+Vz
 aa
 aa
 aa
@@ -4459,8 +4457,8 @@ cR
 cR
 cR
 cw
-eg
-el
+Mm
+Vz
 aa
 aa
 aa
@@ -4531,8 +4529,8 @@ cR
 ev
 eA
 eF
-eg
-el
+Mm
+Vz
 aa
 aa
 aa
@@ -4603,8 +4601,8 @@ dp
 cU
 cU
 eG
-eg
-el
+Mm
+Vz
 aa
 aa
 aa
@@ -4675,8 +4673,8 @@ cR
 ew
 eB
 eH
-eg
-el
+Mm
+Vz
 aa
 aa
 aa
@@ -4747,8 +4745,8 @@ cR
 cR
 cR
 cw
-eg
-el
+Mm
+Vz
 aa
 aa
 aa
@@ -5173,8 +5171,8 @@ du
 dG
 dQ
 ee
-eg
-el
+Mm
+Vz
 aa
 aa
 aa
@@ -5245,8 +5243,8 @@ dl
 dH
 dR
 ef
-eg
-el
+Mm
+Vz
 aa
 aa
 aa


### PR DESCRIPTION
The thrusters on the Skipjack were bugged and would be put under the walls, making them invisible. This fixes that.

- Replaces walls that are over the Thrusters on the Raider Skipjack with Airless plating to fix them being  covered by the walls.