### PR TITLE
makes the paintgun actually work right

### DIFF
--- a/code/game/objects/items/devices/paint_gun.dm
+++ b/code/game/objects/items/devices/paint_gun.dm
@@ -68,7 +68,7 @@
 		)
 
 
-/obj/item/device/floor_painter/resolve_attackby(var/atom/A, var/mob/user, proximity, params)
+/obj/item/device/floor_painter/afterattack(var/atom/A, var/mob/user, proximity, params)
 	if(!proximity)
 		return
 


### PR DESCRIPTION
Resolve_attackby has evidently never been fixed on Bay.

This fixes the paintgun using the user's direction for the quarter tile mode, or anything else that needs a direction.

Floor artists rejoice.