### PR TITLE
Traitor item rebalance + Small additions.

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -31,73 +31,73 @@
 /datum/uplink_item/item/ammo/speedloader
 	name = "Standard Speedloader"
 	desc = "A speedloader for standard revolvers. Contains 6 rounds."
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/ammo_magazine/speedloader
 
 /datum/uplink_item/item/ammo/rifle
 	name = "Rifle Magazine"
 	desc = "A magazine for assault rifles. Contains 20 rounds."
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/ammo_magazine/rifle
 
 /datum/uplink_item/item/ammo/bullpup //for zipguns
 	name = "Bullpup Rifle Magazine"
 	desc = "A magazine for bullpup assault rifles. Contains 15 rounds."
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/ammo_magazine/mil_rifle
 
 /datum/uplink_item/item/ammo/sniperammo
 	name = "Ammobox of Sniper Rounds"
 	desc = "A container of rounds for the anti-materiel rifle. Contains 7 rounds."
-	item_cost = 8
+	item_cost = 7
 	path = /obj/item/weapon/storage/box/ammo/sniperammo
 
 /datum/uplink_item/item/ammo/sniperammo/apds
 	name = "Ammobox of APDS Sniper Rounds"
 	desc = "A container of armor piercing rounds for the anti-materiel rifle. Contains 3 rounds."
-	item_cost = 12
+	item_cost = 10
 	path = /obj/item/weapon/storage/box/ammo/sniperammo/apds
 
 /datum/uplink_item/item/ammo/shotgun_shells
 	name = "Ammobox of Shotgun Shells"
 	desc = "An ammobox with 2 sets of shell holders. Contains 8 buckshot shells total."
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/weapon/storage/box/ammo/shotgunshells
 
 /datum/uplink_item/item/ammo/shotgun_slugs
 	name = "Ammobox of Shotgun Slugs"
 	desc = "An ammobox with 2 sets of shell holders. Contains 8 slugs total."
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/weapon/storage/box/ammo/shotgunammo
 
 /datum/uplink_item/item/ammo/machine_pistol
 	name = "Standard Stick Magazine"
 	desc = "A magazine for standard machine pistols. Contains 16 rounds."
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/ammo_magazine/machine_pistol
 
 /datum/uplink_item/item/ammo/smg
 	name = "Standard Box Magazine"
 	desc = "A magazine for standard SMGs. Contains 20 rounds."
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/ammo_magazine/smg
 
 /datum/uplink_item/item/ammo/pistol
 	name = "Standard Doublestack Magazine"
 	desc = "A magazine for standard military pistols. Contains 15 rounds."
-	item_cost = 9
+	item_cost = 6
 	path = /obj/item/ammo_magazine/pistol/double
 
 /datum/uplink_item/item/ammo/magnum
 	name = "Magnum Magazine"
 	desc = "A magazine for magnum pistols. Contains 7 rounds."
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/ammo_magazine/magnum
 
 /datum/uplink_item/item/ammo/speedloader_magnum
 	name = "Magnum Speedloader"
 	desc = "A speedloader for magnum revolvers. Contains 6 rounds."
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/ammo_magazine/speedloader/magnum
 
 /datum/uplink_item/item/ammo/flechette
@@ -110,13 +110,13 @@
 /datum/uplink_item/item/ammo/pistol_emp
 	name = "Standard EMP Ammo Box"
 	desc = "A box of EMP ammo for standard pistols. Contains 15 rounds."
-	item_cost = 8
+	item_cost = 4
 	path = /obj/item/ammo_magazine/box/emp/pistol
 
 /datum/uplink_item/item/ammo/holdout_emp
 	name = "Small EMP Ammo Box"
 	desc = "A box of EMP ammo for small pistols and revolvers. Contains 8 rounds."
-	item_cost = 6
+	item_cost = 4
 	path = /obj/item/ammo_magazine/box/emp/smallpistol
 
 /datum/uplink_item/item/ammo/stripperclip

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -19,9 +19,9 @@
 
 /datum/uplink_item/item/tools/handcuffs
 	name = "Handcuffs"
-	desc = "A pair of.... fuzzy cuffs? Don't ask."
+	desc = "A pair of handcuffs, for restraining people."
 	item_cost = 2
-	path = /obj/item/weapon/handcuffs/fuzzy
+	path = /obj/item/weapon/handcuffs
 
 /datum/uplink_item/item/tools/money
 	name = "Operations Funding"

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -40,7 +40,7 @@
 /datum/uplink_item/item/tools/plastique
 	name = "C-4"
 	desc = "Set this on a wall to put a hole exactly where you need it, without too much extra hole."
-	item_cost = 14
+	item_cost = 10
 	path = /obj/item/weapon/plastique
 
 /datum/uplink_item/item/tools/heavy_armor

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -20,7 +20,7 @@
 /datum/uplink_item/item/tools/handcuffs
 	name = "Handcuffs"
 	desc = "A pair of handcuffs, for restraining people."
-	item_cost = 2
+	item_cost = 1
 	path = /obj/item/weapon/handcuffs
 
 /datum/uplink_item/item/tools/money

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -36,14 +36,14 @@
 /datum/uplink_item/item/tools/plastique
 	name = "C-4"
 	desc = "Set this on a wall to put a hole exactly where you need it, without too much extra hole."
-	item_cost = 16
+	item_cost = 14
 	path = /obj/item/weapon/plastique
 
 /datum/uplink_item/item/tools/heavy_armor
 	name = "Heavy Armor Vest and Helmet"
 	desc = "This satchel holds a combat helmet and fully equipped plate carrier. \
 	Suit up, and strap in, things are about to get hectic."
-	item_cost = 16
+	item_cost = 10
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/armor
 
 /datum/uplink_item/item/tools/encryptionkey_radio
@@ -143,7 +143,7 @@
 /datum/uplink_item/item/tools/camera_mask
 	name = "Camera MIU"
 	desc = "Wearing this mask allows you to remotely view any cameras you currently have access to. Take the mask off to stop viewing."
-	item_cost = 60
+	item_cost = 55
 	antag_costs = list(MODE_MERCENARY = 30)
 	path = /obj/item/clothing/mask/ai
 

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -11,13 +11,17 @@
 	item_cost = 8
 	path = /obj/item/weapon/storage/toolbox/syndicate
 
-/*
 /datum/uplink_item/item/tools/ductape
 	name = "Duct Tape"
 	desc = "A roll of duct tape. Changes \"HELP\" into sexy \"mmm\"."
-	item_cost = 2
+	item_cost = 1
 	path = /obj/item/weapon/tape_roll
-*/
+
+/datum/uplink_item/item/tools/handcuffs
+	name = "Handcuffs"
+	desc = "A pair of.... fuzzy cuffs? Don't ask."
+	item_cost = 2
+	path = /obj/item/weapon/handcuffs/fuzzy
 
 /datum/uplink_item/item/tools/money
 	name = "Operations Funding"

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -95,7 +95,7 @@
 /datum/uplink_item/item/visible_weapons/assaultrifle
 	name = "Assault Rifle"
 	desc = "A common rifle with three togglable fire modes."
-	item_cost = 68
+	item_cost = 72
 	path = /obj/item/weapon/gun/projectile/automatic/assault_rifle
 
 /datum/uplink_item/item/visible_weapons/advanced_energy_gun

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -7,7 +7,7 @@
 /datum/uplink_item/item/visible_weapons/zipgun
 	name = "Zip Gun"
 	desc = "A pipe attached to crude wooden stock with firing mechanism, holds one round."
-	item_cost = 8
+	item_cost = 4
 	path = /obj/item/weapon/gun/projectile/pirate
 
 /datum/uplink_item/item/visible_weapons/smallenergy_gun
@@ -64,7 +64,7 @@
 /datum/uplink_item/item/visible_weapons/ionpistol
 	name = "Ion Pistol"
 	desc = "Ion rifle in compact form."
-	item_cost = 40
+	item_cost = 20
 	path = /obj/item/weapon/gun/energy/ionrifle/small
 
 /datum/uplink_item/item/visible_weapons/revolver
@@ -83,7 +83,7 @@
 /datum/uplink_item/item/visible_weapons/submachinegun
 	name = "Black Market Submachine Gun"
 	desc = "A quick-firing weapon with three togglable fire modes. Much newer than the older C-20b, and featuring more advanced features."
-	item_cost = 76
+	item_cost = 64
 	path = /obj/item/weapon/gun/projectile/automatic/merc_smg
 
 /datum/uplink_item/item/visible_weapons/submachinegun/hacked
@@ -95,7 +95,7 @@
 /datum/uplink_item/item/visible_weapons/assaultrifle
 	name = "Assault Rifle"
 	desc = "A common rifle with three togglable fire modes."
-	item_cost = 80
+	item_cost = 68
 	path = /obj/item/weapon/gun/projectile/automatic/assault_rifle
 
 /datum/uplink_item/item/visible_weapons/advanced_energy_gun
@@ -119,20 +119,20 @@
 /datum/uplink_item/item/visible_weapons/machine_pistol
 	name = "Standard Machine Pistol"
 	desc = "A high rate of fire weapon in a smaller form factor, able to sling standard ammunition almost as quick as a submachine gun."
-	item_cost = 45
+	item_cost = 37
 	path = /obj/item/weapon/gun/projectile/automatic/machine_pistol
 
 /datum/uplink_item/item/visible_weapons/combat_shotgun
 	name = "Combat Shotgun"
 	desc = "A high compacity, pump-action shotgun regularly used for repelling boarding parties in close range scenarios. \
 	For your use? Well, just pray you've enough shells, and don't stop firing."
-	item_cost = 52
+	item_cost = 34
 	path = /obj/item/weapon/gun/projectile/shotgun/pump/combat
 
 /datum/uplink_item/item/visible_weapons/sawnoff
 	name = "Sawnoff Shotgun"
 	desc = "A shortened double-barrel shotgun, able to fire either one, or both, barrels at once."
-	item_cost = 45
+	item_cost = 34
 	path = /obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawn
 
 /datum/uplink_item/item/visible_weapons/deagle
@@ -192,7 +192,7 @@
 	name = "Incendiary Laser Blaster"
 	desc = "A laser weapon developed and subsequently banned in Sol space, it sets its targets on fire with dispersed laser technology. \
 			Most of these blasters were swiftly bought back and destroyed - but not this one."
-	item_cost = 40
+	item_cost = 32
 	path = /obj/item/weapon/gun/energy/incendiary_laser
 
 /datum/uplink_item/item/visible_weapons/boltaction

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -126,7 +126,7 @@
 	name = "Combat Shotgun"
 	desc = "A high compacity, pump-action shotgun regularly used for repelling boarding parties in close range scenarios. \
 	For your use? Well, just pray you've enough shells, and don't stop firing."
-	item_cost = 34
+	item_cost = 52
 	path = /obj/item/weapon/gun/projectile/shotgun/pump/combat
 
 /datum/uplink_item/item/visible_weapons/sawnoff

--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -21,7 +21,7 @@
 	name = "Explosive Implant (DANGER!)"
 	desc = "An explosive impant activated with a vocal trigger or radio signal. \
 	Use the included pad to adjust the settings before implanting."
-	item_cost = 40
+	item_cost = 16
 	path = /obj/item/weapon/storage/box/syndie_kit/imp_explosive
 
 /datum/uplink_item/item/implants/imp_uplink

--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -13,7 +13,7 @@
 /datum/uplink_item/item/medical/stabilisation
 	name = "Stabilisation First Aid Kit"
 	desc = "Contains variety of emergency medical pouches."
-	item_cost = 16
+	item_cost = 10
 	path = /obj/item/weapon/storage/firstaid/stab
 
 /datum/uplink_item/item/medical/stasis
@@ -31,13 +31,13 @@
 /datum/uplink_item/item/medical/surgery
 	name = "Surgery Kit"
 	desc = "Contains all the tools needed for on the spot surgery, assuming you actually know what you're doing with them. Floor sterilization not included."
-	item_cost = 40
+	item_cost = 10
 	path = /obj/item/weapon/storage/firstaid/surgery
 
 /datum/uplink_item/item/medical/combat
 	name = "Combat Medical Kit"
 	desc = "Contains most medicines you need to recover from injuries and illnesses, all in a convenient pill form. Splints for broken bones also included!"
-	item_cost = 38
+	item_cost = 22
 	path = /obj/item/weapon/storage/firstaid/combat
 
 /datum/uplink_item/item/medical/stimpack

--- a/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
+++ b/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
@@ -42,12 +42,12 @@
 /datum/uplink_item/item/stealthy_weapons/hfc
 	name = "Vial of HFC"
 	desc = "One of the most dangerous chemicals you could think of, easily vialed up. Be extra careful not to drink it!"
-	item_cost = 84
+	item_cost = 64
 	path = /obj/item/weapon/reagent_containers/glass/beaker/vial/hfc
 
 /datum/uplink_item/item/stealthy_weapons/zombie
 	name = "Vial of Black Tar"
 	desc = "Supposedly, ingesting this would cause someone to become a little less alive, though still alive. How does it make sense? \
 	Well, it doesn't. That's the fun of it!"
-	item_cost = 220 //Needs two traitors collaborating, and even then, it burns a lot of your TCs. Zombies are overdone, mmkay?
+	item_cost = 190 //Needs two traitors collaborating, and even then, it burns a lot of your TCs. Zombies are overdone, mmkay?
 	path = /obj/item/weapon/reagent_containers/glass/beaker/vial/zombie


### PR DESCRIPTION
Just lowers the prices on some traitor items that seemed a wee bit too expensive. Feel free to argue with these, but I think most of these prices are solid. Additionally, this PR adds two incredibly small but potentially useful items for antagonists to buy.

Adjusted prices on various antagonist items.

Explosive implant (40 TC). New price 16 TC. 
Surgery kit (40 TC). Reduced to 10. 
Combat medical kit (38 TC). Reduced to 22. 
Stabilization medical kit (16). Reduced to 10 TC. 
HFC. (84 TC) New price 64 TC. 
Ion pistol (40 TC) new price 20 TC. 
Assault rifle (80 TC) new price 72 TC. 
Advanced SMG (76 TC) New price 64 TC. 
Double barrel shotgun (45 TC) New price 34 TC 
Black tar (220) new price 190 TC. 
Armor (16 TC) new price 10 TC. 
MIU (60 TC) new prices 55 TC. 
Ammo (Mainly 8 TC.) new prices 4-7 TC. Will vary depending on ammo, but most types will receive a reduction. 
Zipgun (8 TC) new price 4 TC. 
Incendiary laser (40 TC) New price 32 TC. 
Machine pistol (45 TC) New price 38 TC. 
C-4 (16 TC). Reduced to 10 TC. 

Additions:
Duct tape (1 TC). For when you want them to SHUT UP, or need a ghetto blindfold.
Hand cuffs (1 TC). ~~There's something.... odd about these ones.~~ You know how these works.