### PR TITLE
Makes Prosthetics Render Properly On Custom Species/Genemodders

### DIFF
--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -80,7 +80,7 @@ var/list/limb_icon_cache = list()
 
 	//BastionStation edit - START
 
-	if(species.selects_bodytype)
+	if(species.selects_bodytype && !BP_IS_ROBOTIC(src))
 		icon_cache_key = "[icon_state]_[custom_species_override]"
 	else
 		icon_cache_key = "[icon_state]_[species ? species.name : SPECIES_HUMAN]"

--- a/modular_mithra/code/modules/species/station/custom.dm
+++ b/modular_mithra/code/modules/species/station/custom.dm
@@ -113,7 +113,7 @@
 			RELIGION_UNATHI_PRECURSOR,
 			RELIGION_UNATHI_STRATAGEM,
 			RELIGION_UNATHI_LIGHTS
-		),		
+		),
 		TAG_HOMEWORLD = list(
 			HOME_SYSTEM_MARS,
 			HOME_SYSTEM_EARTH,
@@ -140,8 +140,8 @@
 			HOME_SYSTEM_SKRELLSPACE,
 			HOME_SYSTEM_ROOT
 		)
-	)				
-	
+	)
+
 /datum/species/custom/get_bodytype()
 	var/datum/species/real = all_species[base_species]
 	return real.name
@@ -159,7 +159,8 @@
 	if(H && istype(E))
 		E.custom_species_override = H.species.base_species
 		E.species = H.species
-		E.force_icon = H.species.get_icobase()
+		if(!BP_IS_ROBOTIC(E))	//Check if the limb is robotic
+			E.force_icon = H.species.get_icobase()
 
 /datum/species/custom/proc/produceCopy(var/datum/species/to_copy,var/list/traits,var/mob/living/carbon/human/H)
 	ASSERT(to_copy)


### PR DESCRIPTION
:cl: Toriate
fix: Genemodders can now use prosthetic limbs properly
/:cl:

I had not realized that the game rejuvenates all characters on generation, and custom species' rejuvenation code forces any limbs to have the same iconstates as their iconbases. The rejuvenation code (for custom species only) now checks if a limb is robotic before force changing their iconstates.

![BhF0eQUYno](https://user-images.githubusercontent.com/31995558/77059277-a5fc8700-6a11-11ea-821e-dc0a926ef7ec.png)
