### PR TITLE
Removes the low Yield EMP grenade from the equipment kits.

### DIFF
--- a/code/modules/boh_misc/boxes.dm
+++ b/code/modules/boh_misc/boxes.dm
@@ -53,7 +53,7 @@
 /obj/item/gunbox/attack_self(mob/living/user)
 	var/list/options = list()
 	options["Ballistic"] = list(/obj/item/weapon/gun/projectile/pistol/military/alt/solar,/obj/item/ammo_magazine/pistol/double/rubber,/obj/item/weapon/gun/projectile/shotgun/pump/beanbag,/obj/item/weapon/storage/box/ammo/beanbags/eight,/obj/item/clothing/accessory/storage/bandolier)
-	options["Energy"] = list(/obj/item/weapon/gun/energy/gun/secure,/obj/item/weapon/grenade/empgrenade/low_yield,/obj/item/weapon/gun/energy/taser/carbine/ext,/obj/item/weapon/cell/device/high)
+	options["Energy"] = list(/obj/item/weapon/gun/energy/gun/secure,/obj/item/weapon/gun/energy/taser/carbine/ext,/obj/item/weapon/cell/device/high)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)
 		var/list/things_to_spawn = options[choice]
@@ -76,7 +76,7 @@
 /obj/item/gunboxsmall/attack_self(mob/living/user)
 	var/list/options = list()
 	options["Ballistic"] = list(/obj/item/weapon/gun/projectile/pistol/military/alt/solar,/obj/item/ammo_magazine/pistol/double/rubber)
-	options["Energy"] = list(/obj/item/weapon/gun/energy/gun/secure,/obj/item/weapon/grenade/empgrenade/low_yield)
+	options["Energy"] = list(/obj/item/weapon/gun/energy/gun/secure)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)
 		var/list/things_to_spawn = options[choice]


### PR DESCRIPTION
Does what it says on the tin. Removes those grenades from both energy kits.

Why it's good for the game:

First off, there's far too much friendly fire potential on these things. There's IPC crew men, borgs, random machines, and people with prosthetic organs walking around, and you're telling me it's a good idea to throw robo killer nades? Yeah, no. Secondly, makes dealing with IPC antags a little harder than just "Lemme throw my memenades out."