### PR TITLE
Rebalances the XO and CO gun options.

### DIFF
--- a/code/modules/boh_misc/boxes.dm
+++ b/code/modules/boh_misc/boxes.dm
@@ -97,7 +97,7 @@
 	var/list/options = list()
 	options["Ballistic - .454 Revolver"] = list(/obj/item/weapon/gun/projectile/revolver/medium/captain/large,/obj/item/weapon/storage/fancy/cigar,/obj/item/ammo_magazine/speedloader/large)
 	options["Ballistic - SA Lumoco P3"] = list(/obj/item/weapon/gun/projectile/pistol/holdout/cap,/obj/item/ammo_magazine/pistol/small,/obj/item/clothing/mask/smokable/ecig/deluxe)
-	options["Ballistic - Mk58"] = list(/obj/item/weapon/gun/projectile/pistol/sec/solar,/obj/item/ammo_magazine/pistol,/obj/item/weapon/storage/fancy/cigar)
+	options["Ballistic - ID locked Mk58"] = list(/obj/item/weapon/gun/projectile/pistol/command,/obj/item/ammo_magazine/pistol,/obj/item/weapon/storage/fancy/cigar)
 	options["Energy - EPP"] = list(/obj/item/weapon/gun/energy/pulse_rifle/pistol/epp,/obj/item/documents/epp)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)

--- a/code/modules/boh_misc/boxes.dm
+++ b/code/modules/boh_misc/boxes.dm
@@ -97,6 +97,7 @@
 	var/list/options = list()
 	options["Ballistic - .454 Revolver"] = list(/obj/item/weapon/gun/projectile/revolver/medium/captain/large,/obj/item/weapon/storage/fancy/cigar,/obj/item/ammo_magazine/speedloader/large)
 	options["Ballistic - SA Lumoco P3"] = list(/obj/item/weapon/gun/projectile/pistol/holdout/cap,/obj/item/ammo_magazine/pistol/small,/obj/item/clothing/mask/smokable/ecig/deluxe)
+	options["Ballistic - Mk58"] = list(/obj/item/weapon/gun/projectile/pistol/sec/solar,/obj/item/ammo_magazine/pistol,/obj/item/weapon/storage/fancy/cigar)
 	options["Energy - EPP"] = list(/obj/item/weapon/gun/energy/pulse_rifle/pistol/epp,/obj/item/documents/epp)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)
@@ -117,6 +118,7 @@
 /obj/item/gunbox/executive/attack_self(mob/living/user)
 	var/list/options = list()
 	options["Ballistic - Mk58"] = list(/obj/item/weapon/gun/projectile/pistol/sec/solar,/obj/item/ammo_magazine/pistol,/obj/item/weapon/storage/fancy/cigar)
+	options["Ballistic - SA Lumoco P3"] = list(/obj/item/weapon/gun/projectile/pistol/holdout/cap,/obj/item/ammo_magazine/pistol/small,/obj/item/clothing/mask/smokable/ecig/deluxe)
 	options["Ballistic - Custom Revolver"] = list(/obj/item/weapon/gun/projectile/revolver/medium/captain/xo,/obj/item/weapon/storage/fancy/cigar,/obj/item/ammo_magazine/speedloader)
 	options["Energy - EPP"] = list(/obj/item/weapon/gun/energy/pulse_rifle/pistol/epp,/obj/item/documents/epp)
 	var/choice = input(user,"What type of equipment?") as null|anything in options

--- a/code/modules/boh_misc/firearms.dm
+++ b/code/modules/boh_misc/firearms.dm
@@ -200,3 +200,23 @@
 /obj/item/weapon/gun/projectile/revolver/medium/captain/xo
 	name = "Final Argument"
 	desc = "A shiny al-Maliki & Mosley Autococker automatic revolver, with black accents. Marketed as the 'Revolver for the Modern Era'. This one has 'To the Executive of the NTSS Dagon' engraved on the grip."
+
+/////////
+// ID locked Mk58
+/////////
+
+/obj/item/weapon/gun/projectile/pistol/command
+	name = "pistol"
+	desc = "The NT Mk58 is a cheap, ubiquitous sidearm, produced by a NanoTrasen subsidiary. Found pretty much everywhere humans are. This one appears to be ID locked."
+	icon = 'icons/obj/guns/pistol.dmi'
+	icon_state = "secguncomp"
+	safety_icon = "safety"
+	magazine_type = /obj/item/ammo_magazine/pistol/rubber
+	accuracy = -1
+	fire_delay = 6
+	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
+	has_firing_pin = TRUE
+	firing_pin_type = /obj/item/firing_pin/id_locked/commanding_officer
+
+/obj/item/weapon/gun/projectile/pistol/sec/lethal
+	magazine_type = /obj/item/ammo_magazine/pistol

--- a/code/modules/boh_misc/firearms.dm
+++ b/code/modules/boh_misc/firearms.dm
@@ -181,7 +181,7 @@
 	desc = "A weapon that uses advanced pulse-based beam generation technology to emit powerful laser blasts. It's fitted with an incredibly tiny self-contained reactor. \
 	This provides the weapon, in theory, an infinite power source, but a horrible munition count in practice. Additionally, it cannot fire a concentrated beam, having been modified to be less-than-lethal."
 	projectile_type = /obj/item/projectile/beam/pulse/epp
-	max_shots = 2
+	max_shots = 3
 	self_recharge = 1
 	burst = 1
 
@@ -193,8 +193,6 @@
 	desc = "A shiny al-Maliki & Mosley Autococker automatic revolver, with black accents. Up-chambered for a .454 calibre round. This one has 'To the Captain of the NTSS Dagon' engraved on the grip."
 	ammo_type = /obj/item/ammo_casing/pistol/magnum/large
 	caliber = CALIBER_PISTOL_MAGNUM_LARGE
-	has_firing_pin = TRUE
-	firing_pin_type = /obj/item/firing_pin/id_locked/commanding_officer
 
 /////////
 // XO Revolver

--- a/code/modules/boh_misc/munitions.dm
+++ b/code/modules/boh_misc/munitions.dm
@@ -93,7 +93,7 @@
 /obj/item/projectile/beam/pulse/epp
 	damage = 12
 	damage_type = ELECTROCUTE
-	agony = 25
+	agony = 35
 
 /////////
 // .454
@@ -106,9 +106,8 @@
 
 //projectile
 /obj/item/projectile/bullet/pistol/large
-	damage = 65
-	armor_penetration = 15
-	agony = 25
+	damage = 50
+	armor_penetration = 10
 
 //mag
 /obj/item/ammo_magazine/speedloader/large


### PR DESCRIPTION
This PR does four things. First off, it nerfs the CO's "Final Judgement" revolver. The thing was firing rifle tier bullets as a handgun, along with dealing agony damage for some reason, not to mention the fact that It was locked to any one using the captain's ID. The damage has been lowered to 50, the agony has been removed, and you no longer require the captain's ID to fire it.

Secondly, the EPP has been buffed. For those of you who don't know, the EPP is an automatically recharging self defense taser. Unfortunately, the thing had a whopping two shots as it's max clip, along with rather pathetic agony damage. I've buffed both the agony, and increased the shot count by one. It should be pretty reliable against a single target now, but being rushed by multiple people is a threat.

Thirdly, the captain has been given an ID locked Mk38. It's a carbon copy of the regular one, but it comes with an ID lock that only those with the captain's ID can fire. It also comes with an extra clip now ~~Because that totally wasn't me screwing up and being too lazy to figure out how to remove the clip from spawning~~ to help in a prolonged fire fight.

Finally, I've allowed the XO to take the SA Lumico P3, and the captain has been given the already mentioned ID locked Mk38. These two guns were fairly balanced, but now you can have a tiny pocket pistol as an XO if you'd like, and a regular handgun as the CO.

These should hopefully give the CO and XO players a good reason to use the other guns in their arsenal, and making the CO's revolver less absurd.