### PR TITLE
NSFW Flavor Text is only displayed when your torso and legs are exposed.

### DIFF
--- a/code/modules/client/preference_setup/general/04_flavor.dm
+++ b/code/modules/client/preference_setup/general/04_flavor.dm
@@ -16,6 +16,7 @@
 	S["flavor_texts_hands"]		>> pref.flavor_texts["hands"]
 	S["flavor_texts_legs"]		>> pref.flavor_texts["legs"]
 	S["flavor_texts_feet"]		>> pref.flavor_texts["feet"]
+	S["flavor_texts_naked"]		>> pref.flavor_texts["naked"]
 	S["flavor_texts_NSFW/OOC"]	>> pref.flavor_texts["NSFW/OOC"]
 
 	//Flavour text for robots.
@@ -33,6 +34,7 @@
 	S["flavor_texts_hands"]		<< pref.flavor_texts["hands"]
 	S["flavor_texts_legs"]		<< pref.flavor_texts["legs"]
 	S["flavor_texts_feet"]		<< pref.flavor_texts["feet"]
+	S["flavor_texts_naked"]		>> pref.flavor_texts["naked"]
 	S["flavor_texts_NSFW/OOC"]	<< pref.flavor_texts["NSFW/OOC"]
 
 	S["flavour_texts_robot_Default"] << pref.flavour_texts_robot["Default"]
@@ -53,11 +55,15 @@
 		switch(href_list["flavor_text"])
 			if("open")
 			if("general")
-				var/msg = sanitize(input(usr,"Give a general description of your character. This will be shown regardless of clothing. Do not include OOC information here.","Flavor Text",html_decode(pref.flavor_texts[href_list["flavor_text"]])) as message, extra = 0)
+				var/msg = sanitize(input(usr,"Give a general description of your character. This will be shown regardless of clothing. Do not include OOC or NSFW information here.","Flavor Text",html_decode(pref.flavor_texts[href_list["flavor_text"]])) as message, extra = 0)
 				if(CanUseTopic(user))
 					pref.flavor_texts[href_list["flavor_text"]] = msg
 			if("NSFW/OOC")
-				var/msg = sanitize(input(usr,"Update your NSFW/OOC description.", "Flavor Text",html_decode(pref.flavor_texts[href_list["flavor_text"]])) as message, extra = 0)
+				var/msg = sanitize(input(usr,"Update your OOC description. Please don't put NSFW information here.", "Flavor Text",html_decode(pref.flavor_texts[href_list["flavor_text"]])) as message, extra = 0)
+				if(CanUseTopic(user))
+					pref.flavor_texts[href_list["flavor_text"]] = msg
+			if("naked")
+				var/msg = sanitize(input(usr,"Update your naked description. Feel free to put OOC and NSFW information here.", "Flavor Text",html_decode(pref.flavor_texts[href_list["flavor_text"]])) as message, extra = 0)
 				if(CanUseTopic(user))
 					pref.flavor_texts[href_list["flavor_text"]] = msg
 			else
@@ -115,7 +121,10 @@
 	HTML += "<a href='?src=\ref[src];flavor_text=feet'>Feet:</a> "
 	HTML += TextPreview(pref.flavor_texts["feet"])
 	HTML += "<br>"
-	HTML += "<a href='?src=\ref[src];flavor_text=NSFW/OOC'>NSFW/OOC:</a> "
+	HTML += "<a href='?src=\ref[src];flavor_text=naked'>Naked (NSFW):</a> "
+	HTML += TextPreview(pref.flavor_texts["naked"])
+	HTML += "<br>"
+	HTML += "<a href='?src=\ref[src];flavor_text=NSFW/OOC'>OOC:</a> "
 	HTML += TextPreview(pref.flavor_texts["NSFW/OOC"])
 	HTML += "<br>"
 	HTML += "<hr />"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -308,8 +308,8 @@
 		msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>\n"
 		msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a>\n"
 
-
-	if(print_flavor_text()) msg += "[print_flavor_text()]\n"
+	var/flavor = print_flavor_text()
+	if(flavor) msg += "[flavor]<br>"
 
 	if(mind && user.mind && name == real_name)
 		var/list/relations = matchmaker.get_relationships_between(user.mind, mind, TRUE)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -553,6 +553,8 @@
 			msg = sanitize(input(src,"Update the general description of your character. This will be shown regardless of clothing. Do not include OOC information here.","Flavor Text",html_decode(flavor_texts[key])) as message, extra = 0)
 		if("NSFW/OOC")
 			msg = sanitize(input(src,"Update your NSFW/OOC description.", "Flavor Text",html_decode(flavor_texts[key])) as message, extra = 0)
+		if("naked")
+			msg = sanitize(input(src,"Update your naked description. This text is NSFW, and will be shown when naked.", "Flavor Text",html_decode(flavor_texts[key])) as message, extra = 0)
 		else
 			if(!(key in flavor_texts))
 				return
@@ -1344,48 +1346,48 @@
 
 
 /mob/living/carbon/human/print_flavor_text(var/shrink = 1)
-	var/list/equipment = list(src.head,src.wear_mask,src.glasses,src.w_uniform,src.wear_suit,src.gloves,src.shoes)
-	var/head_exposed = 1
-	var/face_exposed = 1
-	var/eyes_exposed = 1
-	var/torso_exposed = 1
-	var/arms_exposed = 1
-	var/legs_exposed = 1
-	var/hands_exposed = 1
-	var/feet_exposed = 1
 
+	var/list/covered = list()
+	var/list/equipment = list(src.head,src.wear_mask,src.glasses,src.w_uniform,src.wear_suit,src.gloves,src.shoes)
 	for(var/obj/item/clothing/C in equipment)
 		if(C.body_parts_covered & HEAD)
-			head_exposed = 0
+			covered["head"] = TRUE
 		if(C.body_parts_covered & FACE)
-			face_exposed = 0
+			covered["face"] = TRUE
 		if(C.body_parts_covered & EYES)
-			eyes_exposed = 0
+			covered["eyes"] = TRUE
 		if(C.body_parts_covered & UPPER_TORSO)
-			torso_exposed = 0
+			covered["torso"] = TRUE
+			covered["naked"] = TRUE
 		if(C.body_parts_covered & ARMS)
-			arms_exposed = 0
+			covered["arms"] = TRUE
 		if(C.body_parts_covered & HANDS)
-			hands_exposed = 0
+			covered["hands"] = TRUE
 		if(C.body_parts_covered & LEGS)
-			legs_exposed = 0
+			covered["legs"] = TRUE
+			covered["naked"] = TRUE
 		if(C.body_parts_covered & FEET)
-			feet_exposed = 0
+			covered["feet"] = TRUE
 
 	flavor_text = ""
+
 	for (var/T in flavor_texts)
-		if(flavor_texts[T] && flavor_texts[T] != "")
-			if((T == "general") || (T == "NSFW/OOC") || (T == "head" && head_exposed) || (T == "face" && face_exposed) || (T == "eyes" && eyes_exposed) || (T == "torso" && torso_exposed) || (T == "arms" && arms_exposed) || (T == "hands" && hands_exposed) || (T == "legs" && legs_exposed) || (T == "feet" && feet_exposed))
-				if(length(flavor_texts["NSFW/OOC"]) >= 1)
-					NSFW = 1
-				else
-					NSFW = 0 //make sure if text gets added/removed that we update.
-				flavor_text += flavor_texts[T]
-				flavor_text += "\n\n"
-	if(!shrink)
-		return flavor_text
-	else
+		if(!flavor_texts[T] || flavor_texts[T] == "")
+			continue
+		if(covered[T])
+			continue
+		if(T == "naked")
+			flavor_text += "(NSFW): "
+			NSFW = TRUE
+		if(T == "NSFW/OOC")
+			flavor_text += "(OOC): "
+
+		flavor_text += "[flavor_texts[T]]<br>"
+
+	if(shrink)
 		return ..()
+
+	return flavor_text
 
 /mob/living/carbon/human/getDNA()
 	if(species.species_flags & SPECIES_FLAG_NO_SCAN)

--- a/code/modules/mob/living/silicon/pai/examine.dm
+++ b/code/modules/mob/living/silicon/pai/examine.dm
@@ -9,7 +9,8 @@
 		if(DEAD)			msg += "\n<span class='deadsay'>It looks completely unsalvageable.</span>"
 	msg += "\n*---------*"
 
-	if(print_flavor_text()) msg += "\n[print_flavor_text()]\n"
+	var/flavor = print_flavor_text()
+	if(flavor) msg += "[flavor]<br>"
 
 	if (pose)
 		if( findtext(pose,".",length(pose)) == 0 && findtext(pose,"!",length(pose)) == 0 && findtext(pose,"?",length(pose)) == 0 )

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -394,12 +394,14 @@
 /mob/proc/print_flavor_text()
 	if (flavor_text && flavor_text != "")
 		var/msg = replacetext(flavor_text, "\n", " ")
-		if(NSFW == 1)
-			return "<span><a href='byond://?src=\ref[src];flavor_more=1'>Read Description (NSFW/OOC)...</a></span>"
-		else if(length(msg) <= 40)
+		if(NSFW)
+			return "<span><a href='byond://?src=\ref[src];flavor_more=1'>Read Description (NSFW)...</a></span>"
+		else if(length(msg) <= 64)
 			return "<span class='notice'>[msg]</span>"
 		else
-			return "<span class='notice'>[copytext_preserve_html(msg, 1, 37)]... <a href='byond://?src=\ref[src];flavor_more=1'>More...</a></span>"
+			var/find_tag = "<br>"
+			var/next_br = findtext(msg,find_tag)
+			return "<span class='notice'>[copytext_preserve_html(msg, 1, next_br ? min(next_br,60) : 60)]... <a href='byond://?src=\ref[src];flavor_more=1'>More...</a></span>"
 
 /client/verb/changes()
 	set name = "Changelog"


### PR DESCRIPTION
## What this PR does.
This PR makes it so that a new flavortext category is created, called "Naked (NSFW)", and also renamed the NSFW/OOC flavor text to just OOC. The naked flavor text only shows if you are nude and can contain NSFW information such as character refs if you're that degenerated.

This PR also fixes various code oversights with the flavortext and generally improves the performance of it, as well as adds proper spacing so flavortext isn't one big paragraph.

## Why this is good for the game.
I never liked the idea that players can see other player's cock size or whatever the fuck by examining them while in full service uniform. While Hestia allows ERP, this is not an ERP server and we shouldn't give people the ability to look for furry characters they want to fuck. It's also poor design choice to bunch of OOC information with NSFW information as well.