### PR TITLE
Dylovene counters sleeping chems

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -93,6 +93,8 @@
 	var/remove_generic = 1
 	var/list/remove_toxins = list(
 		/datum/reagent/toxin/zombiepowder
+		/datum/reagent/soporific,
+		/datum/reagent/chloralhydrate
 	)
 
 /datum/reagent/dylovene/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -92,7 +92,7 @@
 	value = 2.1
 	var/remove_generic = 1
 	var/list/remove_toxins = list(
-		/datum/reagent/toxin/zombiepowder
+		/datum/reagent/toxin/zombiepowder,
 		/datum/reagent/soporific,
 		/datum/reagent/chloralhydrate
 	)


### PR DESCRIPTION
Now Dylovene will remove soporific and chloral hydrate from the bloodstream, same as it does with zombie powder. Counters sleeping meds, makes them less of a pain once you're in a doctor's hands.