### PR TITLE
Removes Black Tar from Uplink

### DIFF
--- a/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
+++ b/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
@@ -44,10 +44,3 @@
 	desc = "One of the most dangerous chemicals you could think of, easily vialed up. Be extra careful not to drink it!"
 	item_cost = 64
 	path = /obj/item/weapon/reagent_containers/glass/beaker/vial/hfc
-
-/datum/uplink_item/item/stealthy_weapons/zombie
-	name = "Vial of Black Tar"
-	desc = "Supposedly, ingesting this would cause someone to become a little less alive, though still alive. How does it make sense? \
-	Well, it doesn't. That's the fun of it!"
-	item_cost = 190 //Needs two traitors collaborating, and even then, it burns a lot of your TCs. Zombies are overdone, mmkay?
-	path = /obj/item/weapon/reagent_containers/glass/beaker/vial/zombie


### PR DESCRIPTION
Might aswell gut one of the biggest salt mines currently in the game:

Black Tar. What it does: You basicly dripple it into somebodies eyes via dropper or syringe it or put it into food and they turn into a zombie. Sounds cool on paper? Here is why it isnt.

Zero Cure, meta protected item that has wonky mechanics for spread and doesnt give the victim anything interesting to play with other than "me zombie now". I have seen people get infected through hardsuits with internals at times. Its inconsistent. People dont want to play the zombies in the current state they are in. They are unfun. You dont get any cool fun to play powers with or any gimmicks. Nope. The only difference is that you have the husked sprite and that you have a special attack verb called breath death. You can still get stunned and cuffed. And considering its sitting at a range of 190 TC, which means discounts can easily drop it to a comfortable 100 TC or even less it isnt really too uncommon for a traitor to roll it without having to collab. And if they get a discount they could even get other gear. 

TGs Rommerol works because TG is fast paced, violent. The zombies feel strong. Their transmission vector is clear. And they are simple. They are simple here aswell but this entire item just does not fit the environment in its current form.

Yes give traitors all more interesting gear. Black Tar is none of that. Not in its current form.

The entire thing needs a massive rework. It already has a neat CDDA reference in its name, why not go with this theme at a later point. But the way Black Tar is currently implemented is just awful and I rather have it gone from the uplink for the time being. Doesnt change that explo can still find it. Its just completly gone from the Traitor uplink.