### PR TITLE
Promethean glomp fix + QoL

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -85,6 +85,31 @@
 		to_chat(src, "<span class='alium'>You channel a message: \"[msg]\" to [M]</span>")
 	return
 
+/mob/living/carbon/human/proc/discharge_energy()
+	set name = "Discharge Energy"
+	set desc = "Releases all the energy you've stored up."
+	set category = "Abilities"
+
+	if(stored_shock_by_ref["\ref[src]"] >= 1 && src.stat == CONSCIOUS)
+		var/spark_amount = max(1, min(12, stored_shock_by_ref["\ref[src]"]/25))
+		switch(spark_amount)
+			if(1 to 4)
+				visible_message("<span class='notice'>[src] releases their stored electric energy with a few pops and arcs.</span>")
+			if(4 to 8)
+				visible_message("<span class='warning'>[src] releases their stored electric energy in a hissing aura of charged particles.</span>")
+			if(8 to 11)
+				visible_message("<span class='danger'>[src] releases their stored electric energy with a burst of jumping arcs and loud pops.</span>")
+				playsound(src, 'sound/effects/snap.ogg', 30)
+			if(11 to INFINITY)
+				visible_message("<span class='danger'>[src] releases their stored electric energy in a massive cloud of charged plasma!</span>")
+				playsound(src, 'sound/weapons/wave.ogg', 30)
+
+		var/datum/effect/effect/system/spark_spread/s = new
+		s.set_up(spark_amount, spark_amount, src.loc)
+		s.start()
+
+		stored_shock_by_ref["\ref[src]"] = 0
+
 /***********
  diona verbs
 ***********/

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -284,8 +284,8 @@
 		PN.trigger_warning(5)
 	if(istype(M,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
-		if(H.species.siemens_coefficient <= 0)
-			return
+		if(H.species.siemens_coefficient < 0)
+			to_chat(M, "<span class='notice'>You feel the electricity harmlessly flow into you.</span>")
 		if(H.gloves)
 			var/obj/item/clothing/gloves/G = H.gloves
 			if(G.siemens_coefficient == 0)	return 0		//to avoid spamming with insulated glvoes on
@@ -311,6 +311,10 @@
 		power_source = cell
 		shock_damage = cell_damage
 	var/drained_hp = M.electrocute_act(shock_damage, source, siemens_coeff) //zzzzzzap!
+	if(istype(M,/mob/living/carbon/human))
+		var/mob/living/carbon/human/H = M
+		if(H.species.siemens_coefficient < 0)
+			drained_hp = H.electrocute_act(shock_damage, source, siemens_coeff)
 	var/drained_energy = drained_hp*20
 
 	if (source_area)

--- a/code/modules/species/species_helpers.dm
+++ b/code/modules/species/species_helpers.dm
@@ -1,8 +1,8 @@
 var/list/stored_shock_by_ref = list()
 
 /mob/living/proc/apply_stored_shock_to(var/mob/living/target)
-	if(stored_shock_by_ref["\ref[src]"])
-		target.electrocute_act(stored_shock_by_ref["\ref[src]"]*0.9, src)
+	if(stored_shock_by_ref["\ref[src]"] >= 1)
+		target.electrocute_act(min(30, (stored_shock_by_ref["\ref[src]"]*0.1)), src)
 		stored_shock_by_ref["\ref[src]"] = 0
 
 /datum/species/proc/has_fine_manipulation(var/mob/living/carbon/human/H)

--- a/code/modules/species/station/prometheans.dm
+++ b/code/modules/species/station/prometheans.dm
@@ -70,7 +70,8 @@ var/datum/species/shapeshifter/promethean/prometheans
 		/mob/living/carbon/human/proc/shapeshifter_select_hair,
 		/mob/living/carbon/human/proc/shapeshifter_select_gender,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
-		/mob/living/carbon/human/proc/diona_heal_toggle
+		/mob/living/carbon/human/proc/diona_heal_toggle,
+		/mob/living/carbon/human/proc/discharge_energy
 		)
 	base_auras = list(
 		/obj/aura/regenerating/human/promethean
@@ -162,11 +163,10 @@ var/datum/species/shapeshifter/promethean/prometheans
 	..()
 	prometheans = src
 
-/datum/species/shapeshifter/promethean/hug(var/mob/living/carbon/human/H,var/mob/living/target)
+/datum/species/shapeshifter/promethean/hug(var/mob/living/carbon/human/H,var/mob/living/target) //unarmed attack already applies shock - this is just cute
 	var/datum/gender/G = gender_datums[target.gender]
 	H.visible_message("<span class='notice'>\The [H] glomps [target] to make [G.him] feel better!</span>", \
 					"<span class='notice'>You glomp [target] to make [G.him] feel better!</span>")
-	H.apply_stored_shock_to(target)
 
 /datum/species/shapeshifter/promethean/handle_environment_special(var/mob/living/carbon/human/H)
 	if(H.InStasis() || H.stat == DEAD)
@@ -194,11 +194,11 @@ var/datum/species/shapeshifter/promethean/prometheans
 	var/datum/gender/G = gender_datums[H.gender]
 
 	switch(stored_shock_by_ref["\ref[H]"])
-		if(1 to 10)
+		if(1 to 75)
 			return " [G.He] [G.is] flickering gently with a little electrical activity."
-		if(11 to 20)
+		if(75 to 150)
 			return " [G.He] [G.is] glowing gently with moderate levels of electrical activity.\n"
-		if(21 to 35)
+		if(150 to 225)
 			return "<span class='warning'> [G.He] [G.is] glowing brightly with high levels of electrical activity.</span>"
-		if(35 to INFINITY)
+		if(225 to INFINITY)
 			return "<span class='danger'> [G.He] [G.is] radiating massive levels of electrical activity!</span>"


### PR DESCRIPTION
Gives Prommies a verb to discharge electricity in a harmless ;) cloud of sparks.
Caps Prommie glomp damage.
Allows Prommies to gain charge from APCs, grilles, wires, etc.