### PR TITLE
changed description, sprite of cryptographic sequencer

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -93,16 +93,16 @@
  */
 
 /obj/item/weapon/card/emag_broken
-	desc = "It's a card with a magnetic strip attached to some circuitry. It looks too busted to be used for anything but salvage."
-	name = "broken cryptographic sequencer"
+	desc = "It's a card with a magnetic strip and shorted RFID circuitry. It looks too busted to be used for anything but salvage."
+	name = "broken ID card"
 	icon_state = "emag"
 	item_state = "card-id"
 	origin_tech = list(TECH_MAGNET = 2, TECH_ESOTERIC = 2)
 
 /obj/item/weapon/card/emag
-	desc = "It's a card with a magnetic strip attached to some circuitry."
-	name = "cryptographic sequencer"
-	icon_state = "emag"
+	desc = "It's a boring old ID card. It looks blank and broken."
+	name = "blank ID"
+	icon_state = "data_1"
 	item_state = "card-id"
 	origin_tech = list(TECH_MAGNET = 2, TECH_ESOTERIC = 2)
 	var/uses = 15


### PR DESCRIPTION
a

**Why this is good for the game:**

please stop meta'ing the cryptographic sequencer.

this just changes the description of the default form and makes it apparent you're not supposed to meta it.

you're still able to detect it through RP/mechanical complex devices or IT skills.