### PR TITLE
Removes Wizard LRP Spell

### DIFF
--- a/code/modules/spells/spellbook/cleric.dm
+++ b/code/modules/spells/spellbook/cleric.dm
@@ -16,7 +16,6 @@
 				/spell/targeted/heal_target/area = 					1,
 				/spell/targeted/heal_target/sacrifice = 			1,
 				/spell/targeted/genetic/blind = 					1,
-				/spell/targeted/shapeshift/baleful_polymorph = 		1,
 				/spell/targeted/projectile/dumbfire/stuncuff = 		1,
 				/spell/targeted/ethereal_jaunt = 					2,
 				/spell/aoe_turf/knock = 							1,


### PR DESCRIPTION
Apparently somebody was faster than me and theres no single instance of energy/staff left in the wizards obtainable spellbooks. If the Staff of Change is still obtainable by other means please let me know because that kind of thing is bottom tier LRP and just a grief tool.

However Polymorph was missed. This removes polymorph from the clerics arsenal. Reason: Transformation spells/staffs/whatever are very bottom LRP and are almost exclusively used as griff tools.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->