### PR TITLE
MAA access to guards vendor

### DIFF
--- a/code/modules/boh_misc/vending.dm
+++ b/code/modules/boh_misc/vending.dm
@@ -11,7 +11,7 @@
 	icon_vend = "sec-vend"
 	vend_delay = 14
 	base_type = /obj/machinery/vending/security
-	req_access = list(access_armory)
+	req_access = list(access_security)
 	products = list(
 		/obj/item/clothing/accessory/armguards = 12,
 		/obj/item/clothing/accessory/armguards/navy = 8,


### PR DESCRIPTION
:cl: 
tweak: Allows MAAs to access the arms/legs guard vendor inside of armory.
/:cl:
It allows them to color match their guards to their plate carrier instead of being given random colors.