### PR TITLE
Removes the meteor gamemode from being votable

### DIFF
--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -8,7 +8,7 @@
 	extended_round_description = "We are on an unavoidable collision course with an asteroid field. You have only a moment to prepare before you are barraged by dust and meteors. As if it was not enough, all kinds of negative events seem to happen more frequently. Good Luck."
 	config_tag = "meteor"
 	required_players = 15				// Definitely not good for low-pop
-	votable = 1
+	votable = 0
 	shuttle_delay = 2
 	var/next_wave = INFINITY			// Set in post_setup() correctly to take into account potential longer pre-start times.
 	var/alert_sent = 0


### PR DESCRIPTION
🆑Roland410
:rscdel:Removes the meteor gamemode from being votable (meteors still exist otherwise).
/🆑
Updated the PR to only make this not be votable and as such can't roll in secret, as seemingly Carl and Mazian want to bus this round in or sth, idk. I just don't want this to be ever played, and if this is the compromise I must take, so be it.