### PR TITLE
Adds a use number to adrenalin

### DIFF
--- a/code/game/objects/items/weapons/implants/implants/adrenaline.dm
+++ b/code/game/objects/items/weapons/implants/implants/adrenaline.dm
@@ -16,6 +16,11 @@
 	<b>Function:</b> Contains nanobots to stimulate body to mass-produce Adrenalin.<BR>
 	<b>Special Features:</b> Will prevent and cure most forms of brainwashing.<BR>
 	<b>Integrity:</b> Implant can only be used three times before the nanobots are depleted."}
+	
+/obj/item/weapon/implant/adrenalin/New()
+	uses = rand(3, 3)
+	..()
+	return	
 
 /obj/item/weapon/implant/adrenalin/trigger(emote, mob/source)
 	if (emote == "pale")

--- a/code/game/objects/items/weapons/implants/implants/adrenaline.dm
+++ b/code/game/objects/items/weapons/implants/implants/adrenaline.dm
@@ -18,7 +18,7 @@
 	<b>Integrity:</b> Implant can only be used three times before the nanobots are depleted."}
 	
 /obj/item/weapon/implant/adrenalin/New()
-	uses = rand(3, 3)
+	uses = 3
 	..()
 	return	
 


### PR DESCRIPTION
This hopefully makes adrenalin implants functional. They currently are not working because they lack a use function. The Freedom implant has a max use function. Basicly the implant wont fire because it never got any assigned uses/charged to draw from. Probably also the reason why its not in the uplink.

This PR only adds the use function from freedom implants to Adrenalin. It does not add them to the uplink.

Might need a coder to look over this.

