### PR TITLE
Job Tweaks

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -3,8 +3,7 @@
 	supervisors = "Central Command and the Sol Code of Military Justice"
 	minimal_player_age = 14
 	economic_power = 15
-	minimum_character_age = list(SPECIES_HUMAN = 40,SPECIES_UNATHI = 40,SPECIES_SERGAL = 40, SPECIES_NORTHERN = 40, SPECIES_EASTERN = 40, SPECIES_SKRELL = 40, SPECIES_PROMETHEAN = 40, SPECIES_YEOSA = 40, SPECIES_VULP = 40, SPECIES_VASS = 40, SPECIES_TAJ = 40, SPECIES_CUSTOM = 40, SPECIES_AKULA = 40)
-	ideal_character_age = 50
+	minimum_character_age = list(SPECIES_HUMAN = 40,SPECIES_UNATHI = 40,SPECIES_SERGAL = 40, SPECIES_SKRELL = 40, SPECIES_PROMETHEAN = 40, SPECIES_YEOSA = 40, SPECIES_VULP = 40, SPECIES_VASS = 40, SPECIES_TAJ = 40, SPECIES_CUSTOM = 40, SPECIES_AKULA = 40)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/CO
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps
@@ -42,7 +41,6 @@
 	minimal_player_age = 8
 	economic_power = 12
 	minimum_character_age = list(SPECIES_HUMAN = 35,SPECIES_UNATHI = 35,SPECIES_SERGAL = 35, SPECIES_NORTHERN = 35, SPECIES_EASTERN = 35, SPECIES_SKRELL = 35, SPECIES_PROMETHEAN = 35, SPECIES_YEOSA = 35, SPECIES_VASS = 35, SPECIES_TAJ = 35, SPECIES_CUSTOM = 35, SPECIES_AKULA = 35)
-	ideal_character_age = 45
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/XO
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
@@ -99,8 +97,7 @@
 	supervisors = "the Commanding Officer"
 	economic_power = 20
 	minimal_player_age = 6
-	minimum_character_age = list(SPECIES_HUMAN = 35,SPECIES_UNATHI = 35,SPECIES_SERGAL = 35, SPECIES_NORTHERN = 35, SPECIES_EASTERN = 35, SPECIES_SKRELL = 35, SPECIES_PROMETHEAN = 35, SPECIES_YEOSA = 35, SPECIES_VASS = 35, SPECIES_TAJ = 35, SPECIES_CUSTOM = 35, SPECIES_AKULA = 35)
-	ideal_character_age = 60
+	minimum_character_age = list(SPECIES_HUMAN = 35,SPECIES_UNATHI = 35,SPECIES_SERGAL = 35, SPECIES_SKRELL = 35, SPECIES_PROMETHEAN = 35, SPECIES_YEOSA = 35, SPECIES_VASS = 35, SPECIES_TAJ = 35, SPECIES_CUSTOM = 35, SPECIES_AKULA = 35)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/research/cso
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps
@@ -146,8 +143,7 @@
 	supervisors = "the Commanding Officer and the Executive Officer"
 	economic_power = 10
 	minimal_player_age = 6
-	minimum_character_age = list(SPECIES_HUMAN = 35,SPECIES_UNATHI = 35,SPECIES_SERGAL = 35, SPECIES_NORTHERN = 35, SPECIES_EASTERN = 35, SPECIES_SKRELL = 35, SPECIES_PROMETHEAN = 35, SPECIES_YEOSA = 35, SPECIES_VASS = 35, SPECIES_TAJ = 35, SPECIES_CUSTOM = 35, SPECIES_AKULA = 35)
-	ideal_character_age = 48
+	minimum_character_age = list(SPECIES_HUMAN = 35,SPECIES_UNATHI = 35,SPECIES_SERGAL = 35, SPECIES_SKRELL = 35, SPECIES_PROMETHEAN = 35, SPECIES_YEOSA = 35, SPECIES_VASS = 35, SPECIES_TAJ = 35, SPECIES_CUSTOM = 35, SPECIES_AKULA = 35)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/cmo
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
@@ -188,8 +184,7 @@
 	title = "Chief Engineer"
 	supervisors = "the Commanding Officer and the Executive Officer"
 	economic_power = 9
-	minimum_character_age = list(SPECIES_HUMAN = 27,SPECIES_UNATHI = 27,SPECIES_SERGAL = 27, SPECIES_NORTHERN = 27, SPECIES_EASTERN = 27, SPECIES_SKRELL = 27, SPECIES_PROMETHEAN = 27, SPECIES_YEOSA = 27, SPECIES_VASS = 27, SPECIES_TAJ = 27, SPECIES_CUSTOM = 27, SPECIES_AKULA = 27)
-	ideal_character_age = 40
+	minimum_character_age = list(SPECIES_HUMAN = 27,SPECIES_UNATHI = 27,SPECIES_SERGAL = 27, SPECIES_SKRELL = 27, SPECIES_PROMETHEAN = 27, SPECIES_YEOSA = 27, SPECIES_VASS = 27, SPECIES_TAJ = 27, SPECIES_CUSTOM = 27, SPECIES_AKULA = 27)
 	minimal_player_age = 6
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/chief_engineer
 	allowed_branches = list(
@@ -245,8 +240,7 @@
 	supervisors = "the Commanding Officer and the Executive Officer"
 	economic_power = 8
 	minimal_player_age = 14
-	minimum_character_age = list(SPECIES_HUMAN = 25,SPECIES_UNATHI = 25,SPECIES_SERGAL = 25, SPECIES_NORTHERN = 25, SPECIES_EASTERN = 25, SPECIES_SKRELL = 25, SPECIES_PROMETHEAN = 25, SPECIES_YEOSA = 25, SPECIES_VASS = 25, SPECIES_TAJ = 25, SPECIES_CUSTOM = 25, SPECIES_AKULA = 25)
-	ideal_character_age = 35
+	minimum_character_age = list(SPECIES_HUMAN = 25,SPECIES_UNATHI = 25,SPECIES_SERGAL = 25, SPECIES_SKRELL = 25, SPECIES_PROMETHEAN = 25, SPECIES_YEOSA = 25, SPECIES_VASS = 25, SPECIES_TAJ = 25, SPECIES_CUSTOM = 25, SPECIES_AKULA = 25)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/cos
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
@@ -301,7 +295,7 @@
 	skill_points = 20
 	minimum_character_age = list(SPECIES_HUMAN = 27)
 
-	access = list(access_representative, access_security, access_medical,
+	access = list(access_representative, access_maint_tunnels, access_security, access_medical,
 			            access_bridge, access_cargo, access_solgov_crew, access_hangar)
 
 	software_on_spawn = list(/datum/computer_file/program/reports)
@@ -319,8 +313,7 @@
 	selection_color = "#2f2f7f"
 	minimal_player_age = 6
 	economic_power = 8
-	minimum_character_age = list(SPECIES_HUMAN = 35,SPECIES_UNATHI = 35,SPECIES_SERGAL = 35, SPECIES_NORTHERN = 35, SPECIES_EASTERN = 35, SPECIES_SKRELL = 35, SPECIES_PROMETHEAN = 35, SPECIES_YEOSA = 35, SPECIES_VASS = 35, SPECIES_TAJ = 35, SPECIES_CUSTOM = 35, SPECIES_AKULA = 35)
-	ideal_character_age = 45
+	minimum_character_age = list(SPECIES_HUMAN = 35,SPECIES_UNATHI = 35,SPECIES_SERGAL = 35, SPECIES_SKRELL = 35, SPECIES_PROMETHEAN = 35, SPECIES_YEOSA = 35, SPECIES_VASS = 35, SPECIES_TAJ = 35, SPECIES_CUSTOM = 35, SPECIES_AKULA = 35)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/sea/fleet
 	allowed_branches = list(
 		/datum/mil_branch/fleet
@@ -365,8 +358,7 @@
 	selection_color = "#2f2f7f"
 	minimal_player_age = 0
 	economic_power = 7
-	minimum_character_age = list(SPECIES_HUMAN = 22,SPECIES_UNATHI = 22,SPECIES_SERGAL = 22, SPECIES_NORTHERN = 22, SPECIES_EASTERN = 22, SPECIES_SKRELL = 22, SPECIES_PROMETHEAN = 22, SPECIES_YEOSA = 22, SPECIES_VASS = 22, SPECIES_TAJ = 22, SPECIES_CUSTOM = 22, SPECIES_AKULA = 22)
-	ideal_character_age = 24
+	minimum_character_age = list(SPECIES_HUMAN = 22,SPECIES_UNATHI = 22,SPECIES_SERGAL = 22, SPECIES_SKRELL = 22, SPECIES_PROMETHEAN = 22, SPECIES_YEOSA = 22, SPECIES_VASS = 22, SPECIES_TAJ = 22, SPECIES_CUSTOM = 22, SPECIES_AKULA = 22)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
@@ -385,7 +377,7 @@
 	skill_points = 20
 
 
-	access = list(access_security, access_medical, access_engine, access_maint_tunnels, access_emergency_storage,
+	access = list(access_security, access_medical, access_teleporter, access_engine, access_maint_tunnels, access_emergency_storage,
 			            access_bridge, access_janitor, access_kitchen, access_cargo, access_mailsorting, access_RC_announce, access_keycard_auth,
 			            access_solgov_crew, access_aquila, access_aquila_helm, access_guppy, access_guppy_helm, access_external_airlocks,
 			            access_eva, access_hangar, access_cent_creed, access_explorer, access_expedition_shuttle, access_expedition_shuttle_helm, access_gunnery)

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -21,7 +21,7 @@
 	min_skill = list(   SKILL_BUREAUCRACY	= SKILL_EXPERT,
 	                    SKILL_FINANCE		= SKILL_BASIC)
 	skill_points = 20
-	access = list(access_liaison, access_security, access_medical,
+	access = list(access_liaison, access_maint_tunnels, access_security, access_medical,
 						access_engine, access_research, access_bridge,
 						access_cargo, access_solgov_crew, access_hangar,
 						access_nanotrasen, access_commissary, access_petrov)
@@ -66,7 +66,7 @@
 		"Asset Protection Agent"
 	)
 	skill_points = 20
-	access = list(access_liaison, access_security, access_medical,
+	access = list(access_liaison, access_maint_tunnels, access_security, access_medical,
 						access_engine, access_research, access_bridge,
 						access_cargo, access_solgov_crew, access_hangar,
 						access_nanotrasen, access_commissary, access_petrov,

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -21,7 +21,7 @@
 	min_skill = list(   SKILL_BUREAUCRACY	= SKILL_EXPERT,
 	                    SKILL_FINANCE		= SKILL_BASIC)
 	skill_points = 20
-	access = list(access_liaison, access_maint_tunnels, access_security, access_medical,
+	access = list(access_liaison, access_maint_tunnels, access_medical,
 						access_engine, access_research, access_bridge,
 						access_cargo, access_solgov_crew, access_hangar,
 						access_nanotrasen, access_commissary, access_petrov)

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -9,7 +9,6 @@
 	economic_power = 6
 	minimal_player_age = 3
 	minimum_character_age = list(SPECIES_HUMAN = 27)
-	ideal_character_age = 40
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/senior_engineer
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
@@ -57,7 +56,6 @@
 	economic_power = 5
 	minimal_player_age = 0
 	minimum_character_age = list(SPECIES_HUMAN = 19)
-	ideal_character_age = 30
 	alt_titles = list(
 		"Engine Technician",
 		"Damage Control Technician",
@@ -95,7 +93,7 @@
 	skill_points = 20
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
-			            access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_janitor, access_construction,
+			            access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_construction,
 			            access_solgov_crew, access_hangar, access_tcomsat)
 	minimal_access = list()
 
@@ -119,7 +117,6 @@
 	supervisors = "the Chief Engineer and Engineering Personnel"
 	selection_color = "#5b4d20"
 	minimum_character_age = list(SPECIES_HUMAN = 18)
-	ideal_character_age = 20
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer
 	allowed_branches = list(
@@ -148,7 +145,7 @@
 	                    SKILL_ENGINES      = SKILL_MAX)
 
 	access = list(access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
-			            access_eva, access_tech_storage, access_janitor, access_construction,
+			            access_eva, access_tech_storage, access_construction,
 			            access_solgov_crew, access_hangar)
 
 	software_on_spawn = list(/datum/computer_file/program/power_monitor,
@@ -194,7 +191,7 @@
 	                    SKILL_ANATOMY      = SKILL_EXPERT)
 	skill_points = 20
 
-	access = list(access_robotics, access_robotics_engineering, access_engine, access_solgov_crew)
+	access = list(access_robotics, access_robotics_engineering, access_nanotrasen, access_engine, access_solgov_crew, access_maint_tunnels, access_research, access_petrov, access_petrov_maint, access_research,)
 	minimal_access = list()
 
 /datum/job/roboticist/get_description_blurb()

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -178,8 +178,9 @@
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
 	min_skill = list(   SKILL_COMPUTER		= SKILL_ADEPT,
 	                    SKILL_DEVICES		= SKILL_ADEPT,
-	                    SKILL_EVA           = SKILL_ADEPT,
-	                    SKILL_ANATOMY       = SKILL_ADEPT,
+	                    SKILL_ANATOMY       = SKILL_EXPERT,
+	                    SKILL_SCIENCE     	= SKILL_ADEPT,
+	                    SKILL_MEDICAL     	= SKILL_ADEPT,
 	                    SKILL_MECH          = HAS_PERK)
 
 	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,

--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -9,7 +9,6 @@
 	minimal_player_age = 4
 	economic_power = 7
 	minimum_character_age = list(SPECIES_HUMAN = 25)
-	ideal_character_age = 35
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/exploration/pathfinder
 	allowed_branches = list(/datum/mil_branch/expeditionary_corps)
 	allowed_ranks = list(
@@ -29,9 +28,7 @@
 	access = list(
 		access_pathfinder, access_explorer, access_eva, access_maint_tunnels, access_bridge, access_emergency_storage,
 		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_expedition_shuttle_helm,
-		access_guppy, access_hangar, access_petrov, access_petrov_helm, access_petrov_analysis, access_petrov_phoron,
-		access_petrov_toxins, access_petrov_chemistry, access_petrov_maint, access_tox, access_tox_storage, access_research,
-		access_xenobiology, access_xenoarch
+		access_guppy, access_hangar
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/deck_management,
@@ -51,7 +48,6 @@
 	economic_power = 10
 	minimal_player_age = 0
 	minimum_character_age = list(SPECIES_HUMAN = 24)
-	ideal_character_age = 25
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/pilot
 	allowed_branches = list(
 		/datum/mil_branch/civilian,
@@ -66,11 +62,8 @@
 	)
 
 	access = list(
-		access_mining_office, access_petrov, access_petrov_helm, access_petrov_analysis, access_petrov_phoron,
-		access_petrov_toxins, access_petrov_chemistry, access_petrov_maint, access_mining_station, access_expedition_shuttle,
-		access_expedition_shuttle_helm, access_guppy, access_hangar, access_guppy_helm, access_mining, access_pilot,
-		access_solgov_crew, access_eva, access_explorer, access_tox, access_tox_storage, access_research, access_xenobiology,
-		access_xenoarch
+	 access_guppy, access_hangar, access_maint_tunnels, access_guppy_helm, access_pilot,
+		access_solgov_crew, access_eva, access_explorer,
 	)
 	min_skill = list(	SKILL_EVA   = SKILL_BASIC,
 						SKILL_PILOT = SKILL_ADEPT)
@@ -87,7 +80,6 @@
 	supervisors = "the Commanding Officer, Executive Officer, and Pathfinder"
 	selection_color = "#68099e"
 	minimum_character_age = list(SPECIES_HUMAN = 18)
-	ideal_character_age = 20
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/exploration/explorer
 	allowed_branches = list(/datum/mil_branch/expeditionary_corps)
 
@@ -104,9 +96,6 @@
 
 	access = list(access_explorer, access_maint_tunnels, access_eva, access_emergency_storage,
 		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
-		access_petrov, access_petrov_analysis, access_petrov_phoron, access_petrov_toxins,
-		access_petrov_chemistry, access_petrov_maint, access_tox, access_tox_storage, access_research,
-		access_xenobiology, access_xenoarch
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/deck_management)

--- a/maps/torch/job/hestia_jobs.dm
+++ b/maps/torch/job/hestia_jobs.dm
@@ -11,7 +11,6 @@
 	economic_power = 1
 	minimal_player_age = 0
 	minimum_character_age = list(SPECIES_HUMAN = 18)
-	ideal_character_age = 19
 	selection_color = "#601c1c"
 	alt_titles = list(
 		"Forensics Trainee"
@@ -65,7 +64,6 @@
 	minimal_player_age = 12
 	economic_power = 7
 	minimum_character_age = list(SPECIES_HUMAN = 25)
-	ideal_character_age = 35
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/infantry/squad_lead
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_EVA         = SKILL_ADEPT,
@@ -91,7 +89,6 @@
 	economic_power = 4
 	minimal_player_age = 6
 	minimum_character_age = list(SPECIES_HUMAN = 24)
-	ideal_character_age = 25
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/infantry/combat_tech
 	min_skill = list(	SKILL_CONSTRUCTION = SKILL_ADEPT,
 						SKILL_ELECTRICAL   = SKILL_ADEPT,
@@ -122,7 +119,6 @@
 	supervisors = "the Combat Technician and Squad Leader"
 	selection_color = "#557e38"
 	minimum_character_age = list(SPECIES_HUMAN = 18)
-	ideal_character_age = 20
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/infantry
 	software_on_spawn = list(/datum/computer_file/program/deck_management)
 	allowed_branches = list(/datum/mil_branch/marine_corps)
@@ -139,7 +135,7 @@
 	alt_titles = list(
 		"Grunt",
 		"Trooper")
-	
+
 /datum/job/grunt/get_description_blurb()
 	return "You are a Marine! Your duty is to listen to the Squad Leader. If they're not present, the Combat Technician may pull rank. Do your best not to die, while also taking orders. Oorah!"
 

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -4,7 +4,6 @@
 	department_flag = MED
 	minimal_player_age = 0
 	minimum_character_age = list(SPECIES_HUMAN = 29)
-	ideal_character_age = 45
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = "the Chief Medical Officer"
@@ -52,7 +51,6 @@
 	supervisors = "Physicians and the Chief Medical Officer"
 	economic_power = 7
 	minimum_character_age = list(SPECIES_HUMAN = 19)
-	ideal_character_age = 40
 	minimal_player_age = 0
 	alt_titles = list(
 		"Paramedic",
@@ -96,7 +94,6 @@
 	supervisors = "Medical personnel, and the Chief Medical Officer"
 	selection_color = "#013d3b"
 	minimum_character_age = list(SPECIES_HUMAN = 18)
-	ideal_character_age = 20
 	alt_titles = list(
 		"Corpsman Trainee")
 
@@ -141,7 +138,6 @@
 	selection_color = "#013d3b"
 	economic_power = 4
 	minimum_character_age = list(SPECIES_HUMAN = 25)
-	ideal_character_age = 30
 	minimal_player_age = 0
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/chemist
 	allowed_branches = list(/datum/mil_branch/civilian)
@@ -165,7 +161,6 @@
 	title = "Counselor"
 	total_positions = 1
 	spawn_positions = 1
-	ideal_character_age = 40
 	economic_power = 5
 	minimum_character_age = list(SPECIES_HUMAN = 24)
 	minimal_player_age = 0
@@ -190,7 +185,7 @@
 	max_skill = list(
 		SKILL_MEDICAL     = SKILL_MAX
 	)
-	access = list(access_medical, access_psychiatrist, access_solgov_crew, access_medical_equip, access_virology)
+	access = list(access_medical, access_psychiatrist, access_maint_tunnels, access_solgov_crew, access_medical_equip, access_virology)
 	minimal_access = list()
 	software_on_spawn = list(
 		/datum/computer_file/program/suit_sensors,

--- a/maps/torch/job/misc_jobs.dm
+++ b/maps/torch/job/misc_jobs.dm
@@ -56,7 +56,6 @@ Civilian
 	spawn_positions = 2
 	availablity_chance = 30
 	supervisors = "the invisible hand of the market"
-	ideal_character_age = 30
 	minimal_player_age = 0
 	create_record = 0
 	outfit_type = /decl/hierarchy/outfit/job/torch/merchant

--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -10,7 +10,6 @@
 	economic_power = 12
 	minimal_player_age = 3
 	minimum_character_age = list(SPECIES_HUMAN = 30)
-	ideal_character_age = 50
 	alt_titles = list(
 		"Research Supervisor")
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/research/senior_scientist
@@ -46,7 +45,6 @@
 	supervisors = "the Chief Science Officer and the Workplace Liaison"
 	economic_power = 10
 	minimum_character_age = list(SPECIES_HUMAN = 25)
-	ideal_character_age = 45
 	minimal_player_age = 0
 	alt_titles = list(
 		"Xenoarcheologist",
@@ -76,9 +74,9 @@
 		/datum/mil_rank/sol/scientist = /decl/hierarchy/outfit/job/torch/passenger/research/scientist/solgov
 	)
 
-	access = list(access_tox, access_tox_storage, access_research, access_petrov, access_petrov_helm,
+	access = list(access_tox, access_maint_tunnels, access_tox_storage, access_research, access_petrov_maint, access_petrov, access_petrov_helm,
 						access_mining_office, access_mining_station, access_xenobiology, access_guppy_helm,
-						access_xenoarch, access_nanotrasen, access_expedition_shuttle, access_guppy, access_hangar,
+						access_xenoarch, access_nanotrasen, access_expedition_shuttle, access_guppy, access_solgov_crew, access_hangar,
 						access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_robotics, access_robotics_engineering)
 	minimal_access = list()
 	skill_points = 20
@@ -93,7 +91,6 @@
 	selection_color = "#633d63"
 	economic_power = 3
 	minimum_character_age = list(SPECIES_HUMAN = 18)
-	ideal_character_age = 30
 	alt_titles = list(
 		"Custodian" = /decl/hierarchy/outfit/job/torch/passenger/research/assist/janitor,
 		"Testing Assistant" = /decl/hierarchy/outfit/job/torch/passenger/research/assist/testsubject,
@@ -117,7 +114,7 @@
 	                    SKILL_DEVICES     = SKILL_MAX,
 	                    SKILL_SCIENCE     = SKILL_MAX)
 
-	access = list(access_tox, access_tox_storage, access_research, access_petrov,
+	access = list(access_tox, access_maint_tunnels, access_tox_storage, access_research, access_petrov_maint, access_petrov,
 						access_mining_office, access_mining_station, access_xenobiology,
-						access_xenoarch, access_nanotrasen, access_expedition_shuttle, access_guppy, access_hangar,
+						access_xenoarch, access_nanotrasen, access_expedition_shuttle, access_solgov_crew, access_guppy, access_hangar,
 						access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry)

--- a/maps/torch/job/security_jobs.dm
+++ b/maps/torch/job/security_jobs.dm
@@ -5,7 +5,6 @@
 	supervisors = "the Chief of Security"
 	economic_power = 5
 	minimal_player_age = 6
-	ideal_character_age = 35
 	minimum_character_age = list(SPECIES_HUMAN = 27)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/security/brig_chief
 	allowed_branches = list(
@@ -31,7 +30,7 @@
 
 	access = list(access_security, access_brig, access_armory, access_forensics_lockers,
 			            access_maint_tunnels, access_external_airlocks, access_emergency_storage,
-			            access_eva, access_sec_doors, access_solgov_crew, access_gun, access_petrov, access_petrov_security)
+			            access_eva, access_sec_doors, access_solgov_crew, access_gun, access_petrov, access_petrov_security, access_hangar)
 	minimal_access = list()
 
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
@@ -45,7 +44,6 @@
 	economic_power = 5
 	minimal_player_age = 0
 	minimum_character_age = list(SPECIES_HUMAN = 25)
-	ideal_character_age = 35
 	skill_points = 18
 	alt_titles = list(
 		"Criminal Investigator"
@@ -94,7 +92,6 @@
 	economic_power = 4
 	minimal_player_age = 3
 	minimum_character_age = list(SPECIES_HUMAN = 18)
-	ideal_character_age = 29
 	alt_titles = list() // This is a hack. Overriding a list var with null does not actually override it due to the particulars of dm list init. Do not "clean up" without testing.
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/security/maa
 	allowed_branches = list(

--- a/maps/torch/job/service_jobs.dm
+++ b/maps/torch/job/service_jobs.dm
@@ -5,7 +5,6 @@
 	total_positions = 1
 	spawn_positions = 1
 	minimum_character_age = list(SPECIES_HUMAN = 24)
-	ideal_character_age = 40
 	economic_power = 5
 	minimal_player_age = 0
 	supervisors = "the Executive Officer"
@@ -20,7 +19,7 @@
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/ec/o1)
 	min_skill = list(SKILL_BUREAUCRACY = SKILL_BASIC)
-	access = list(access_morgue, access_chapel_office, access_crematorium, access_solgov_crew)
+	access = list(access_morgue, access_chapel_office, access_crematorium, access_solgov_crew, access_medical, access_maint_tunnels)
 	minimal_access = list()
 
 /datum/job/janitor
@@ -31,7 +30,6 @@
 	spawn_positions = 2
 	supervisors = "the Executive Officer"
 	minimum_character_age = list(SPECIES_HUMAN = 18)
-	ideal_character_age = 20
 	alt_titles = list(
 		"Janitor")
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/service/janitor
@@ -49,7 +47,7 @@
 	)
 	min_skill = list(   SKILL_HAULING = SKILL_BASIC)
 
-	access = list(access_maint_tunnels, access_emergency_storage, access_janitor, access_solgov_crew)
+	access = list(access_maint_tunnels, access_emergency_storage, access_janitor, access_solgov_crew, access_hangar)
 	minimal_access = list()
 
 /datum/job/chef
@@ -92,7 +90,6 @@
 	spawn_positions = 2
 	supervisors = "the Executive Officer and the Corporate Liaison"
 	minimum_character_age = list(SPECIES_HUMAN = 18)
-	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/service/bartender
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
@@ -101,7 +98,7 @@
 		"Barista",
 		"Apprentice Bartender"
 		)
-	access = list(access_hydroponics, access_bar, access_solgov_crew, access_kitchen, access_commissary)
+	access = list(access_hydroponics, access_bar, access_solgov_crew, access_kitchen, access_commissary, access_maint_tunnels)
 	minimal_access = list()
 	min_skill = list(   SKILL_COOKING   = SKILL_BASIC,
 	                    SKILL_BOTANY    = SKILL_BASIC,
@@ -115,7 +112,6 @@
 	spawn_positions = 10
 	supervisors = "the Executive Officer and SolGov Personnel"
 	minimum_character_age = list(SPECIES_HUMAN = 18)
-	ideal_character_age = 20
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/service/crewman
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -8,7 +8,6 @@
 	economic_power = 5
 	minimal_player_age = 0
 	minimum_character_age = list(SPECIES_HUMAN = 27)
-	ideal_character_age = 35
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/deckofficer
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
@@ -46,7 +45,6 @@
 	spawn_positions = 3
 	supervisors = "the Deck Chief and Executive Officer"
 	minimum_character_age = list(SPECIES_HUMAN = 18)
-	ideal_character_age = 24
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/tech
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
@@ -83,13 +81,13 @@
 	supervisors = "the Deck Chief, the Corporate Liaison and the Executive Officer"
 	economic_power = 7
 	minimum_character_age = list(SPECIES_HUMAN = 18)
-	ideal_character_age = 25
 	alt_titles = list(
 		"Drill Technician",
 		"Shaft Miner",
 		"Salvage Technician")
 	min_skill = list(   SKILL_HAULING = SKILL_ADEPT,
-	                    SKILL_EVA     = SKILL_BASIC)
+	                    SKILL_EVA     = SKILL_BASIC,
+	                    SKILL_PILOT   = SKILL_BASIC)
 
 	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
 
@@ -98,5 +96,5 @@
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
 
 	access = list(access_mining, access_mining_office, access_mining_station,
-						access_expedition_shuttle, access_guppy, access_hangar, access_guppy_helm, access_solgov_crew, access_eva)
+						access_expedition_shuttle, access_guppy, access_hangar, access_guppy_helm, access_solgov_crew, access_cargo, access_eva)
 	minimal_access = list()


### PR DESCRIPTION
This PR does several things.

First off, removes the "preferred age" line that made specific ages more likely to roll the job. Not even sure how much it effected, but it was stupid, so it's gone now.

Secondly, removes a fair number of the age locks, and lowers a few. I've left most of the higher roles, but things like your average engineer or the medical trainee have had them removed. These things were a joke any way, since half of them were locked at 18 (literally the youngest you can be here, why did they even exist?)

Thirdly, buffs the starting skills on a few roles, particularly prospector and roboticist. These two have enough skills to do their jobs well now, without needing to invest anything. Not sure if there's any other roles who need extra points or minimum skills, so let me know and I'll consider changing it in this PR.

Finally, I've tweaked a bunch of access restrictions. I'll list em all out here.

All roles: Maint access has been given across the board. Maint is a way of life, and also half the safe rooms are in maint soooo. Quite a few were lacking this, including scientists, bartenders, and counselors. This has been fixed.

Roboticist: Given access to the petrov and science

Exploration in general: Lost access to the mining rooms, and lost all their science access. Stay out of my ~~swamp~~ lab b*tches.

Engineering: Lost access to the janitor's closet

BO: Gained access to the teleporter room. 

Prospector: Gained access to cargo.

Janitor: Gained hangar access

Brig Chief: For some odd reason, lacked hangar access, despite the average seccie grunt and the CoS having it. Gained hangar access.

Corporate Liaison: Lost access to security.