### PR TITLE
Removes vox pariah

### DIFF
--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -51,8 +51,8 @@
 	poison_types = list(GAS_OXYGEN = TRUE)
 	siemens_coefficient = 0.2
 
-	species_flags = SPECIES_FLAG_NO_SCAN
-	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION// | SPECIES_IS_WHITELISTED
+	species_flags = SPECIES_FLAG_NO_SCAN | SPECIES_FLAG_NO_MINOR_CUT
+	spawn_flags = SPECIES_CAN_JOIN // | SPECIES_IS_WHITELISTED
 	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
 
 	blood_color = "#2299fc"
@@ -125,66 +125,6 @@
 /datum/species/vox/skills_from_age(age)
 	. = 8
 
-/datum/species/vox/pariah
-	name = SPECIES_VOXPARIAH
-	description = "Sickly biproducts of Vox society, these creatures are vilified by their own kind \
-	and taken advantage of by enterprising companies for cheap, disposable labor. \
-	They aren't very smart, smell worse than a vox, and vomit constantly, \
-	earning them the true title of 'shitbird'."
-	rarity_value = 0.1
-	speech_chance = 60        // No volume control.
-	siemens_coefficient = 0.5 // Ragged scaleless patches.
-	unarmed_types = list(
-		/datum/unarmed_attack/stomp,
-		/datum/unarmed_attack/kick,
-		/datum/unarmed_attack/claws/,
-		/datum/unarmed_attack/punch,
-		/datum/unarmed_attack/bite/
-	)
-
-	oxy_mod = 1.4
-	brute_mod = 1.3
-	burn_mod = 1.4
-	toxins_mod = 1.3
-
-	cold_level_1 = 130
-	cold_level_2 = 100
-	cold_level_3 = 60
-
-	warning_low_pressure = WARNING_LOW_PRESSURE
-	hazard_low_pressure = HAZARD_LOW_PRESSURE
-
-	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick,  /datum/unarmed_attack/claws, /datum/unarmed_attack/bite)
-
-	// Pariahs have no stack.
-	has_organ = list(
-		BP_STOMACH =    /obj/item/organ/internal/stomach/vox,
-		BP_HEART =      /obj/item/organ/internal/heart/vox,
-		BP_LUNGS =      /obj/item/organ/internal/lungs/vox,
-		BP_LIVER =      /obj/item/organ/internal/liver/vox,
-		BP_KIDNEYS =    /obj/item/organ/internal/kidneys/vox,
-		BP_BRAIN =      /obj/item/organ/internal/pariah_brain,
-		BP_EYES =       /obj/item/organ/internal/eyes/vox,
-		BP_HINDTONGUE = /obj/item/organ/internal/hindtongue
-		)
-
-	descriptors = list(
-		/datum/mob_descriptor/height = -1,
-		/datum/mob_descriptor/build = 1,
-		/datum/mob_descriptor/pariah_stink = 0
-	)
-
-	species_flags = SPECIES_FLAG_NO_SCAN//shouldn't be needed, but in game happenings have shown otherwise. For some reason.
-	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_NO_LACE
-	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
-
-/datum/species/vox/pariah/get_bodytype(var/mob/living/carbon/human/H)
-	return SPECIES_VOX
-
-// No combat skills for you.
-/datum/species/vox/pariah/can_shred(var/mob/living/carbon/human/H, var/ignore_intent)
-	return 0
-
 /datum/species/vox/armalis
 	name = SPECIES_VOX_ARMALIS
 	name_plural = SPECIES_VOX_ARMALIS
@@ -198,7 +138,7 @@
 
 	slowdown = 1.5
 	hidden_from_codex = TRUE
-	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_FLAG_NO_MINOR_CUT
 	brute_mod = 0.5
 	burn_mod = 0.5
 	strength = STR_HIGH

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -51,7 +51,7 @@
 	poison_types = list(GAS_OXYGEN = TRUE)
 	siemens_coefficient = 0.2
 
-	species_flags = SPECIES_FLAG_NO_SCAN | SPECIES_FLAG_NO_MINOR_CUT
+	species_flags = SPECIES_FLAG_NO_SCAN
 	spawn_flags = SPECIES_CAN_JOIN // | SPECIES_IS_WHITELISTED
 	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
 

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -6,7 +6,6 @@
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
 									 /datum/job/roboticist, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender),
 		/datum/species/vox/ = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
-		/datum/species/vox/pariah = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/cargo_tech),
 		/datum/species/human/mule = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
 	)
 

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -78,7 +78,7 @@
 		/datum/species/vasilissan	= list(UNRESTRICTED, /datum/mil_branch/private_security),
 		/datum/species/vulpkanin	= list(UNRESTRICTED, SEMIRESTRICTED),
 		/datum/species/customhuman	= list(UNRESTRICTED, SEMIRESTRICTED),
-		/datum/species/shapeshifter/promethean	= list(/datum/mil_branch/civilian),
+		/datum/species/shapeshifter/promethean	= list(UNRESTRICTED, SEMIRESTRICTED),
 		//datum/species/tesh/		= list(UNRESTRICTED),
 		/datum/species/vox			= list(/datum/mil_branch/alien),
 		/datum/species/vox/armalis	= list(/datum/mil_branch/alien)
@@ -89,6 +89,7 @@
 		/datum/species/unathi/yeosa	= list(SMC_TROOPERS_ONLY),
 		/datum/species/humanathi	= list(SMC_TROOPERS_ONLY),
 		/datum/species/tajaran		= list(SMC_TROOPERS_ONLY),
+		/datum/species/shapeshifter/promethean	= list(SMC_TROOPERS_ONLY)
 	)
 
 /datum/mil_branch/fleet

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -78,10 +78,9 @@
 		/datum/species/vasilissan	= list(UNRESTRICTED, /datum/mil_branch/private_security),
 		/datum/species/vulpkanin	= list(UNRESTRICTED, SEMIRESTRICTED),
 		/datum/species/customhuman	= list(UNRESTRICTED, SEMIRESTRICTED),
-		/datum/species/shapeshifter/promethean	= list(UNRESTRICTED, SEMIRESTRICTED),
+		/datum/species/shapeshifter/promethean	= list(/datum/mil_branch/civilian),
 		//datum/species/tesh/		= list(UNRESTRICTED),
 		/datum/species/vox			= list(/datum/mil_branch/alien),
-		/datum/species/vox/pariah	= list(/datum/mil_branch/civilian),
 		/datum/species/vox/armalis	= list(/datum/mil_branch/alien)
 	)
 
@@ -90,7 +89,6 @@
 		/datum/species/unathi/yeosa	= list(SMC_TROOPERS_ONLY),
 		/datum/species/humanathi	= list(SMC_TROOPERS_ONLY),
 		/datum/species/tajaran		= list(SMC_TROOPERS_ONLY),
-		/datum/species/shapeshifter/promethean	= list(SMC_TROOPERS_ONLY)
 	)
 
 /datum/mil_branch/fleet


### PR DESCRIPTION
Removes the Vox Pariahs from the game. No one plays as them and the massive job restrictions given to them promotes shithead behavior . Everyone i spoke to about it seems to be in agreement that they do not belong here.