### PR TITLE
Revert "Removes Black Tar from Uplink"

### DIFF
--- a/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
+++ b/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
@@ -44,3 +44,10 @@
 	desc = "One of the most dangerous chemicals you could think of, easily vialed up. Be extra careful not to drink it!"
 	item_cost = 64
 	path = /obj/item/weapon/reagent_containers/glass/beaker/vial/hfc
+
+/datum/uplink_item/item/stealthy_weapons/zombie
+	name = "Vial of Black Tar"
+	desc = "Supposedly, ingesting this would cause someone to become a little less alive, though still alive. How does it make sense? \
+	Well, it doesn't. That's the fun of it!"
+	item_cost = 190 //Needs two traitors collaborating, and even then, it burns a lot of your TCs. Zombies are overdone, mmkay?
+	path = /obj/item/weapon/reagent_containers/glass/beaker/vial/zombie


### PR DESCRIPTION
Reverts BoHBranch/BoH-Bay#586
Vote was against removal, and this is highly underused as it needs two traitors to cooperate, and even then you only get one use of it.
![Screenshot_20200403-064628](https://user-images.githubusercontent.com/6581435/78325191-3e991800-7577-11ea-87ef-cd1e986c72e0.png)
