### PR TITLE
Adds Adrenalin Implant to traitor uplink

### DIFF
--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -40,3 +40,11 @@
 	set of law-like instructions to follow. This kit contains an autoinjector with a dose of Mindbreaker Toxin."
 	item_cost = 10
 	path = /obj/item/weapon/storage/box/syndie_kit/imp_imprinting
+	
+/datum/uplink_item/item/implants/adrenalin
+	name = "Adrenalin Implant"
+	desc "An implant with precisely 3 charges. On use it removes any and all none pain related means of crowd control. \
+	namely knockdowns, stuns and weakening. Does nothing against pain related crowd control. Usefull in case you get shot \
+	in the leg."
+	item_cost = 25
+	path = /obj/item/weapon/implanter/adrenalin

--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -43,7 +43,7 @@
 	
 /datum/uplink_item/item/implants/adrenalin
 	name = "Adrenalin Implant"
-	desc "An implant with precisely 3 charges. On use it removes any and all none pain related means of crowd control. \
+	desc = "An implant with precisely 3 charges. On use it removes any and all none pain related means of crowd control. \
 	namely knockdowns, stuns and weakening. Does nothing against pain related crowd control. Usefull in case you get shot \
 	in the leg."
 	item_cost = 25


### PR DESCRIPTION
Adds an adrenalin implant to the traitor uplink for 25 TC. 

Why only 25 TC? 

It does jackall to pain. Pain is the major source of being stunned. This implant is a counter against usual one shot cheese methods people tend to employ like going for the head or going for the legs.
Being in pain is still an easy way to get stunned rather fast.
