### PR TITLE
Galilei ID

### DIFF
--- a/code/datums/mil_ranks.dm
+++ b/code/datums/mil_ranks.dm
@@ -178,6 +178,7 @@ var/datum/mil_branches/mil_branches = new()
 					// rank doesn't usually serve as a prefix to the individual's name.
 	var/list/accessory		//type of accesory that will be equipped by job code with this rank
 	var/sort_order = 0 // A numerical equivalent of the rank used to indicate its order when compared to other datums: eg e-1 = 1, o-1 = 11
+	var/pow_cat = 0 //A numerical equivelent of the Geneva Convention Category of the rank, 0 for non-sol forces unless they have signed for some reason.
 
 //Returns short designation (yes shorter than name_short), like E1, O3 etc.
 /datum/mil_rank/proc/grade()

--- a/code/datums/mil_ranks.dm
+++ b/code/datums/mil_ranks.dm
@@ -178,7 +178,7 @@ var/datum/mil_branches/mil_branches = new()
 					// rank doesn't usually serve as a prefix to the individual's name.
 	var/list/accessory		//type of accesory that will be equipped by job code with this rank
 	var/sort_order = 0 // A numerical equivalent of the rank used to indicate its order when compared to other datums: eg e-1 = 1, o-1 = 11
-	var/pow_cat = 0 //A numerical equivelent of the Geneva Convention Category of the rank, 0 for non-sol forces unless they have signed for some reason.
+	var/pow_cat = 0 //A numerical equivelent of the Geneva/Galilei Convention Category of the rank, 0 for non-sol forces unless they have signed for some reason.
 
 //Returns short designation (yes shorter than name_short), like E1, O3 etc.
 /datum/mil_rank/proc/grade()

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -55,6 +55,7 @@
 
 	var/required_language
 	var/is_whitelisted = FALSE
+	var/max_pow_cat = 0 //If the rank pow_cat is great then this, set to this.  This is used for Galilei Convention IDs
 
 /datum/job/New()
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -325,7 +325,7 @@ var/const/NO_EMAG_ACT = -50
 				pow_roman = "IV"
 			if(5)
 				pow_roman = "V"
-		dat += text("Gaia Convention: Cat []<BR>\n", pow_roman)
+		dat += text("Galilei Convention: Cat []<BR>\n", pow_roman)
 	dat += text("<BR>\n")
 	if(front && side)
 		dat +="<td align = center valign = top>Photo:<br><img src=front.png height=80 width=80 border=4><img src=side.png height=80 width=80 border=4></td>"

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -185,6 +185,8 @@ var/const/NO_EMAG_ACT = -50
 
 	var/datum/mil_branch/military_branch = null //Vars for tracking branches and ranks on multi-crewtype maps
 	var/datum/mil_rank/military_rank = null
+	var/pow_cat = 0
+	var/max_pow_cat = 0
 
 	var/formal_name_prefix
 	var/formal_name_suffix
@@ -198,6 +200,7 @@ var/const/NO_EMAG_ACT = -50
 		var/datum/job/j = SSjobs.get_by_path(job_access_type)
 		if(j)
 			rank = j.title
+			max_pow_cat = j.max_pow_cat
 			assignment = rank
 			access |= j.get_access()
 			if(!detail_color)
@@ -290,6 +293,9 @@ var/const/NO_EMAG_ACT = -50
 		id_card.military_branch = char_branch
 	if(GLOB.using_map.flags & MAP_HAS_RANK)
 		id_card.military_rank = char_rank
+		id_card.pow_cat = char_rank.pow_cat
+		if(id_card.pow_cat > id_card.max_pow_cat)
+			id_card.pow_cat = id_card.max_pow_cat
 
 /obj/item/weapon/card/id/proc/dat()
 	var/list/dat = list("<table><tr><td>")
@@ -305,7 +311,22 @@ var/const/NO_EMAG_ACT = -50
 	dat += text("Assignment: []</A><BR>\n", assignment)
 	dat += text("Fingerprint: []</A><BR>\n", fingerprint_hash)
 	dat += text("Blood Type: []<BR>\n", blood_type)
-	dat += text("DNA Hash: []<BR><BR>\n", dna_hash)
+	dat += text("DNA Hash: []<BR>\n", dna_hash)
+	if(pow_cat && GLOB.using_map.flags & MAP_HAS_RANK)
+		var/pow_roman = ""
+		switch(pow_cat)
+			if(1)
+				pow_roman = "I"
+			if(2)
+				pow_roman = "II"
+			if(3)
+				pow_roman = "III"
+			if(4)
+				pow_roman = "IV"
+			if(5)
+				pow_roman = "V"
+		dat += text("Gaia Convention: Cat []<BR>\n", pow_roman)
+	dat += text("<BR>\n")
 	if(front && side)
 		dat +="<td align = center valign = top>Photo:<br><img src=front.png height=80 width=80 border=4><img src=side.png height=80 width=80 border=4></td>"
 	dat += "</tr></table>"

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -220,6 +220,7 @@
 				var/new_rank = sanitize(input(user,"What rank would you like to put on this card?","Agent Card Rank") as null|anything in mil_branches.spawn_ranks(military_branch.name))
 				if(!isnull(new_rank) && CanUseTopic(user, state))
 					src.military_rank = mil_branches.spawn_ranks(military_branch.name)[new_rank]
+					src.pow_cat = src.military_rank.pow_cat
 					to_chat(user, "<span class='notice'>Rank changed to '[military_rank.name]'.</span>")
 					. = 1
 

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -17,7 +17,7 @@
 		)
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/workplace_liaison
 	allowed_branches = list(/datum/mil_branch/civilian)
-	allowed_ranks = list(/datum/mil_rank/civ/contractor)
+	allowed_ranks = list(/datum/mil_rank/civ/ntr)
 	min_skill = list(   SKILL_BUREAUCRACY	= SKILL_EXPERT,
 	                    SKILL_FINANCE		= SKILL_BASIC)
 	skill_points = 20

--- a/maps/torch/job/misc_jobs.dm
+++ b/maps/torch/job/misc_jobs.dm
@@ -47,6 +47,7 @@ Civilian
 		/datum/mil_rank/civ/civ,
 		/datum/mil_rank/civ/contractor
 	)
+	max_pow_cat = 0
 
 /datum/job/merchant
 	title = "Merchant"

--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -110,6 +110,7 @@
 		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/passenger/research/assist,
 		/datum/mil_rank/sol/scientist = /decl/hierarchy/outfit/job/torch/passenger/research/assist/solgov
 	)
+	max_pow_cat = 2
 	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_DEVICES     = SKILL_MAX,
 	                    SKILL_SCIENCE     = SKILL_MAX)

--- a/maps/torch/job/service_jobs.dm
+++ b/maps/torch/job/service_jobs.dm
@@ -45,6 +45,7 @@
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4
 	)
+	max_pow_cat = 1
 	min_skill = list(   SKILL_HAULING = SKILL_BASIC)
 
 	access = list(access_maint_tunnels, access_emergency_storage, access_janitor, access_solgov_crew, access_hangar)

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -58,6 +58,7 @@
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/civ/contractor
 	)
+	max_pow_cat = 1
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_FINANCE     = SKILL_BASIC,
 	                    SKILL_HAULING     = SKILL_BASIC)

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -93,11 +93,10 @@
 	)
 	required_language = LANGUAGE_HUMAN_EURO
 
-	var/max_pow_cat = 5 //If the rank pow_cat is great then this, set to this.
 	/* pow_cat is rank equivalent based, max_pow_cat is for non-professional (manual labor) contractor jobs.
 	   A contractor having a higher Galilei/Geneva Convention Article 3 equivelent rank then then an enlisted person for similar work is expected behavior.
-	   Source material is DOD Instruction 1000.01
-	*/
+	   Source material is DOD Instruction 1000.01 */
+	max_pow_cat = 5
 
 
 

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -95,7 +95,7 @@
 
 	var/max_pow_cat = 5 //If the rank pow_cat is great then this, set to this.
 	/* pow_cat is rank equivalent based, max_pow_cat is for non-professional (manual labor) contractor jobs.
-	   A contractor having a higher Gaia/Geneva Convention Article 3 equivelent rank then then an enlisted person for similar work is expected behavior.
+	   A contractor having a higher Galilei/Geneva Convention Article 3 equivelent rank then then an enlisted person for similar work is expected behavior.
 	   Source material is DOD Instruction 1000.01
 	*/
 

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -93,5 +93,14 @@
 	)
 	required_language = LANGUAGE_HUMAN_EURO
 
+	var/max_pow_cat = 5 //If the rank pow_cat is great then this, set to this.
+	/* pow_cat is rank equivalent based, max_pow_cat is for non-professional (manual labor) contractor jobs.
+	   A contractor having a higher Gaia/Geneva Convention Article 3 equivelent rank then then an enlisted person for similar work is expected behavior.
+	   Source material is DOD Instruction 1000.01
+	*/
+
+
+
+
 /datum/map/torch
 	default_assistant_title = "Passenger"

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -236,12 +236,14 @@
 	rank_types = list(
 		/datum/mil_rank/civ/civ,
 		/datum/mil_rank/civ/contractor,
+		/datum/mil_rank/civ/ntr,
 		/datum/mil_rank/civ/synthetic
 	)
 
 	spawn_rank_types = list(
 		/datum/mil_rank/civ/civ,
 		/datum/mil_rank/civ/contractor,
+		/datum/mil_rank/civ/ntr,
 		/datum/mil_rank/civ/synthetic
 	)
 
@@ -307,144 +309,168 @@
 	name_short = "CR"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 1
+	pow_cat = 1
 
 /datum/mil_rank/fleet/e2
 	name = "Crewman Apprentice"
 	name_short = "CA"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e2, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 2
+	pow_cat = 1
 
 /datum/mil_rank/fleet/e3
 	name = "Crewman"
 	name_short = "CN"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e3, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 3
+	pow_cat = 1
 
 /datum/mil_rank/fleet/e4
 	name = "Petty Officer Third Class"
 	name_short = "PO3"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e4, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 4
+	pow_cat = 1
 
 /datum/mil_rank/fleet/e5
 	name = "Petty Officer Second Class"
 	name_short = "PO2"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e5, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 5
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e6
 	name = "Petty Officer First Class"
 	name_short = "PO1"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e6, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 6
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e7
 	name = "Chief Petty Officer"
 	name_short = "CPO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e7, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 7
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e8
 	name = "Senior Chief Petty Officer"
 	name_short = "SCPO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e8, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 8
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e9
 	name = "Master Chief Petty Officer"
 	name_short = "MCPO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e9_alt1
 	name = "Command Master Chief Petty Officer"
 	name_short = "CMCPO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt1, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e9_alt2
 	name = "Fleet Master Chief Petty Officer"
 	name_short = "FLTCM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt2, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e9_alt3
 	name = "Force Master Chief Petty Officer"
 	name_short = "FORCM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt3, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e9_alt4
 	name = "Master Chief Petty Officer of the Fleet"
 	name_short = "MCPOF"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt4, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/fleet/o1
 	name = "Ensign"
 	name_short = "ENS"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 11
+	pow_cat = 3
 
 /datum/mil_rank/fleet/o2
 	name = "Sub-lieutenant"
 	name_short = "SLT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o2, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 12
+	pow_cat = 3
 
 /datum/mil_rank/fleet/o3
 	name = "Lieutenant"
 	name_short = "LT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o3, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 13
+	pow_cat = 3
 
 /datum/mil_rank/fleet/o4
 	name = "Lieutenant Commander"
 	name_short = "LCDR"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o4, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 14
+	pow_cat = 4
 
 /datum/mil_rank/fleet/o5
 	name = "Commander"
 	name_short = "CDR"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o5, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 15
+	pow_cat = 4
 
 /datum/mil_rank/fleet/o6
 	name = "Captain"
 	name_short = "CAPT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o6, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 16
+	pow_cat = 4
 
 /datum/mil_rank/fleet/o7
 	name = "Commodore"
 	name_short = "CDRE"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 17
+	pow_cat = 5
 
 /datum/mil_rank/fleet/o8
 	name = "Rear Admiral"
 	name_short = "RADM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o8, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 18
+	pow_cat = 5
 
 /datum/mil_rank/fleet/o9
 	name = "Vice Admiral"
 	name_short = "VADM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o9, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 19
+	pow_cat = 5
 
 /datum/mil_rank/fleet/o10
 	name = "Admiral"
 	name_short = "ADM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o10, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 20
+	pow_cat = 5
 
 /datum/mil_rank/fleet/o10_alt
 	name = "Fleet Admiral"
 	name_short = "FADM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o10_alt, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 20
+	pow_cat = 5
 
 
 /*
@@ -456,54 +482,63 @@
 	name_short = "AXPL"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted)
 	sort_order = 1
+	pow_cat = 1
 
 /datum/mil_rank/ec/e3
 	name = "Explorer"
 	name_short = "XPL"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e3)
 	sort_order = 3
+	pow_cat = 1
 
 /datum/mil_rank/ec/e5
 	name = "Senior Explorer"
 	name_short = "SXPL"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e5)
 	sort_order = 5
+	pow_cat = 2
 
 /datum/mil_rank/ec/e7
 	name = "Chief Explorer"
 	name_short = "CXPL"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e7)
 	sort_order = 7
+	pow_cat = 2
 
 /datum/mil_rank/ec/o1
 	name = "Ensign"
 	name_short = "ENS"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/officer)
 	sort_order = 11
+	pow_cat = 3
 
 /datum/mil_rank/ec/o3
 	name = "Lieutenant"
 	name_short = "LT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/officer/o3)
 	sort_order = 13
+	pow_cat = 3
 
 /datum/mil_rank/ec/o5
 	name = "Commander"
 	name_short = "CDR"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/officer/o5)
 	sort_order = 15
+	pow_cat = 4
 
 /datum/mil_rank/ec/o6
 	name = "Captain"
 	name_short = "CAPT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/officer/o6)
 	sort_order = 16
+	pow_cat = 4
 
 /datum/mil_rank/ec/o8
 	name = "Admiral"
 	name_short = "ADM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/officer/o8)
 	sort_order = 18
+	pow_cat = 5
 
 /*
  *  Army
@@ -514,138 +549,161 @@
 	name_short = "PVT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/enlisted)
 	sort_order = 1
+	pow_cat = 1
 
 /datum/mil_rank/army/e2
 	name = "Private Second Class"
 	name_short = "PV2"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/enlisted/e2)
 	sort_order = 2
+	pow_cat = 1
 
 /datum/mil_rank/army/e3
 	name = "Private First Class"
 	name_short = "PV1"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/enlisted/e3)
 	sort_order = 3
+	pow_cat = 1
 
 /datum/mil_rank/army/e4
 	name = "Corporal"
 	name_short = "CPL"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/enlisted/e4)
 	sort_order = 4
+	pow_cat = 1
 
 /datum/mil_rank/army/e5
 	name = "Sergeant"
 	name_short = "SGT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/enlisted/e5)
 	sort_order = 5
+	pow_cat = 2
 
 /datum/mil_rank/army/e6
 	name = "Staff Sergeant"
 	name_short = "SSG"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/enlisted/e6)
 	sort_order = 6
+	pow_cat = 2
 
 /datum/mil_rank/army/e7
 	name = "Sergeant First Class"
 	name_short = "SFC"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/enlisted/e7)
 	sort_order = 7
+	pow_cat = 2
 
 /datum/mil_rank/army/e8
 	name = "Master Sergeant"
 	name_short = "MSG"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/enlisted/e8)
 	sort_order = 8
+	pow_cat = 2
 
 /datum/mil_rank/army/e8_alt
 	name = "First Sergeant"
 	name_short = "1SG"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/enlisted/e8_alt)
 	sort_order = 8
+	pow_cat = 2
 
 /datum/mil_rank/army/e9
 	name = "Sergeant Major"
 	name_short = "SGM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/enlisted/e9)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/army/e9_alt1
 	name = "Command Sergeant Major"
 	name_short = "CSM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/enlisted/e9_alt1)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/army/e9_alt2
 	name = "Sergeant Major of the Army"
 	name_short = "SMA"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/enlisted/e9_alt2)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/army/o1
 	name = "Second Lieutenant"
 	name_short = "2LT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/officer)
 	sort_order = 11
+	pow_cat = 3
 
 /datum/mil_rank/army/o2
 	name = "First Lieutenant"
 	name_short = "1LT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/officer/o2)
 	sort_order = 12
+	pow_cat = 3
 
 /datum/mil_rank/army/o3
 	name = "Captain"
 	name_short = "CPT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/officer/o3)
 	sort_order = 13
+	pow_cat = 3
 
 /datum/mil_rank/army/o4
 	name = "Major"
 	name_short = "MAJ"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/officer/o4)
 	sort_order = 14
+	pow_cat = 4
 
 /datum/mil_rank/army/o5
 	name = "Lieutenant Colonel"
 	name_short = "LTC"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/officer/o5)
 	sort_order = 15
+	pow_cat = 4
 
 /datum/mil_rank/army/o6
 	name = "Colonel"
 	name_short = "COL"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/officer/o6)
 	sort_order = 16
+	pow_cat = 4
 
 /datum/mil_rank/army/o7
 	name = "Brigadier General"
 	name_short = "BG"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/flag)
 	sort_order = 17
+	pow_cat = 5
 
 /datum/mil_rank/army/o8
 	name = "Major General"
 	name_short = "MG"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/flag/o8)
 	sort_order = 18
+	pow_cat = 5
 
 /datum/mil_rank/army/o9
 	name = "Lieutenant General"
 	name_short = "LTG"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/flag/o9)
 	sort_order = 19
+	pow_cat = 5
 
 /datum/mil_rank/army/o10
 	name = "General"
 	name_short = "GEN"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/flag/o10)
 	sort_order = 20
+	pow_cat = 5
 
 /datum/mil_rank/army/o10_alt
 	name = "General of the Army"
 	name_short = "GA"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/flag/o10_alt)
 	sort_order = 20
+	pow_cat = 5
 
 /*
  *  Civilians
@@ -654,12 +712,20 @@
 
 /datum/mil_rank/civ/civ
 	name = "Civilian"
+	pow_cat = 3
 
 /datum/mil_rank/civ/contractor
 	name = "Contractor"
+	pow_cat = 3
+
+/datum/mil_rank/civ/ntr
+	name = "NanoTrasen Representative"
+	name_short = "NTR"
+	pow_cat = 5
 
 /datum/mil_rank/civ/synthetic
 	name = "Synthetic"
+	pow_cat = 0
 
 /*
  *  SolGov Employees
@@ -670,15 +736,18 @@
 	name = "SolGov Representative"
 	name_short = "SGR"
 	accessory = list(/obj/item/clothing/accessory/badge/solgov/representative)
+	pow_cat = 5
 
 /datum/mil_rank/sol/agent
 	name = "SFP Agent"
 	name_short = "AGT"
 	accessory = list(/obj/item/clothing/accessory/badge/agent)
+	pow_cat = 3
 
 /datum/mil_rank/sol/scientist
 	name = "Government Scientist"
 	name_short = "GOVT"
+	pow_cat = 3
 
 /*
  *  Terrans

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -243,108 +243,126 @@
 	name_short = "CR"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 1
+	pow_cat = 1
 
 /datum/mil_rank/fleet/e1_exp
 	name = "Recruit Explorer"
 	name_short = "RXPL"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted)
 	sort_order = 1
+	pow_cat = 1
 
 /datum/mil_rank/fleet/e2
 	name = "Crewman Apprentice"
 	name_short = "CA"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e2, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 2
+	pow_cat = 1
 
 /datum/mil_rank/fleet/e2_exp
 	name = "Junior Explorer"
 	name_short = "JXPL"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e2, /obj/item/clothing/accessory/solgov/specialty/enlisted/explorer)
 	sort_order = 2
+	pow_cat = 1
 
 /datum/mil_rank/fleet/e3
 	name = "Crewman"
 	name_short = "CN"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e3, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 3
+	pow_cat = 1
 
 /datum/mil_rank/fleet/e3_exp
 	name = "Explorer"
 	name_short = "XPL"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e3, /obj/item/clothing/accessory/solgov/specialty/enlisted/explorer)
 	sort_order = 3
+	pow_cat = 1
 
 /datum/mil_rank/fleet/e4
 	name = "Petty Officer Third Class"
 	name_short = "PO3"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e4, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 4
+	pow_cat = 1
 
 /datum/mil_rank/fleet/e5
 	name = "Petty Officer Second Class"
 	name_short = "PO2"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e5, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 5
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e5_exp
 	name = "Senior Explorer"
 	name_short = "SXPL"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e5, /obj/item/clothing/accessory/solgov/specialty/enlisted/explorer)
 	sort_order = 5
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e6
 	name = "Petty Officer First Class"
 	name_short = "PO1"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e6, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 6
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e7
 	name = "Chief Petty Officer"
 	name_short = "CPO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e7, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 7
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e7_exp
 	name = "Chief Explorer"
 	name_short = "CXPL"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e7, /obj/item/clothing/accessory/solgov/specialty/enlisted/explorer)
 	sort_order = 7
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e8
 	name = "Senior Chief Petty Officer"
 	name_short = "SCPO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e8, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 8
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e9
 	name = "Master Chief Petty Officer"
 	name_short = "MCPO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e9_alt1
 	name = "Command Master Chief Petty Officer"
 	name_short = "CMCPO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt1, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e9_alt2
 	name = "Fleet Master Chief Petty Officer"
 	name_short = "FLTCM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt2, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e9_alt3
 	name = "Force Master Chief Petty Officer"
 	name_short = "FORCM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt3, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/fleet/e9_alt4
 	name = "Master Chief Petty Officer of the Fleet"
 	name_short = "MCPOF"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt4, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/fleet/w1
 	name = "Junior Warrant Officer"
@@ -381,66 +399,77 @@
 	name_short = "ENS"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 16
+	pow_cat = 3
 
 /datum/mil_rank/fleet/o2
 	name = "Lieutenant Junior-Grade"
 	name_short = "LTJG"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o2, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 17
+	pow_cat = 3
 
 /datum/mil_rank/fleet/o3
 	name = "Lieutenant"
 	name_short = "LT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o3, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 18
+	pow_cat = 3
 
 /datum/mil_rank/fleet/o4
 	name = "Lieutenant Commander"
 	name_short = "LCDR"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o4, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 19
+	pow_cat = 4
 
 /datum/mil_rank/fleet/o5
 	name = "Commander"
 	name_short = "CDR"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o5, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 20
+	pow_cat = 4
 
 /datum/mil_rank/fleet/o6
 	name = "Captain"
 	name_short = "CAPT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o6, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 21
+	pow_cat = 4
 
 /datum/mil_rank/fleet/o7
 	name = "Commodore"
 	name_short = "CDRE"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 22
+	pow_cat = 5
 
 /datum/mil_rank/fleet/o8
 	name = "Rear Admiral"
 	name_short = "RADM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o8, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 23
+	pow_cat = 5
 
 /datum/mil_rank/fleet/o9
 	name = "Vice Admiral"
 	name_short = "VADM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o9, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 24
+	pow_cat = 5
 
 /datum/mil_rank/fleet/o10
 	name = "Admiral"
 	name_short = "ADM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o10, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 25
+	pow_cat = 5
 
 /datum/mil_rank/fleet/o10_alt
 	name = "Fleet Admiral"
 	name_short = "FADM"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o10_alt, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 25
+	pow_cat = 5
 /*****/
 
 /*
@@ -452,72 +481,84 @@
 	name_short = "Pvt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted)
 	sort_order = 1
+	pow_cat = 1
 
 /datum/mil_rank/marine_corps/e2
 	name = "Private First Class"
 	name_short = "PFC"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e2)
 	sort_order = 2
+	pow_cat = 1
 
 /datum/mil_rank/marine_corps/e3
 	name = "Lance Corporal"
 	name_short = "LCpl"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e3)
 	sort_order = 3
+	pow_cat = 1
 
 /datum/mil_rank/marine_corps/e4
 	name = "Corporal"
 	name_short = "Cpl"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e4)
 	sort_order = 4
+	pow_cat = 1
 
 /datum/mil_rank/marine_corps/e5
 	name = "Sergeant"
 	name_short = "Sgt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e5)
 	sort_order = 5
+	pow_cat = 2
 
 /datum/mil_rank/marine_corps/e6
 	name = "Staff Sergeant"
 	name_short = "SSgt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e6)
 	sort_order = 6
+	pow_cat = 2
 
 /datum/mil_rank/marine_corps/e7
 	name = "Gunnery Sergeant"
 	name_short = "GySgt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e7)
 	sort_order = 7
+	pow_cat = 2
 
 /datum/mil_rank/marine_corps/e8
 	name = "Master Sergeant"
 	name_short = "MSgt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e8)
 	sort_order = 8
+	pow_cat = 2
 
 /datum/mil_rank/marine_corps/e8_alt
 	name = "First Sergeant"
 	name_short = "1stSg"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e8_alt)
 	sort_order = 8
+	pow_cat = 2
 
 /datum/mil_rank/marine_corps/e9
 	name = "Master Gunnery Sergeant"
 	name_short = "MGySgt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e9)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/marine_corps/e9_alt
 	name = "Sergeant Major"
 	name_short = "SgtMaj"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e9_alt)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/marine_corps/e9_alt2
 	name = "Sergeant Major of the Marine Corps"
 	name_short = "SMMC"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e9_alt2)
 	sort_order = 9
+	pow_cat = 2
 
 /datum/mil_rank/marine_corps/w1
 	name = "Warrant Officer"
@@ -554,18 +595,21 @@
 	name_short = "2ndLt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer)
 	sort_order = 16
+	pow_cat = 3
 
 /datum/mil_rank/marine_corps/o2
 	name = "First Lieutenant"
 	name_short = "1stLt"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o2)
 	sort_order = 17
+	pow_cat = 3
 
 /datum/mil_rank/marine_corps/o3
 	name = "Captain "
 	name_short = "CPT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o3)
 	sort_order = 18
+	pow_cat = 3
 
 // Specially, to avoid two "Capt" on-board.
 /datum/mil_rank/marine_corps/o3_alt
@@ -573,54 +617,63 @@
 	name_short = "M-CPT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o3_alt)
 	sort_order = 19
+	pow_cat = 3
 
 /datum/mil_rank/marine_corps/o3_alt2
 	name = "Specialist Captain"
 	name_short = "SP-CPT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o3_alt2)
 	sort_order = 20
+	pow_cat = 3
 
 /datum/mil_rank/marine_corps/o4
 	name = "Major"
 	name_short = "Maj"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o4)
 	sort_order = 21
+	pow_cat = 4
 
 /datum/mil_rank/marine_corps/o5
 	name = "Lieutenant Colonel"
 	name_short = "LtCol"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o5)
 	sort_order = 22
+	pow_cat = 4
 
 /datum/mil_rank/marine_corps/o6
 	name = "Colonel"
 	name_short = "Col"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o6)
 	sort_order = 23
+	pow_cat = 4
 
 /datum/mil_rank/marine_corps/o7
 	name = "Brigadier General"
 	name_short = "BGen"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/flag)
 	sort_order = 24
+	pow_cat = 5
 
 /datum/mil_rank/marine_corps/o8
 	name = "Major General"
 	name_short = "MGen"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/flag/o8)
 	sort_order = 25
+	pow_cat = 5
 
 /datum/mil_rank/marine_corps/o9
 	name = "Lieutenant General"
 	name_short = "LtGen"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/flag/o9)
 	sort_order = 26
+	pow_cat = 5
 
 /datum/mil_rank/marine_corps/o10
 	name = "General"
 	name_short = "Gen"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/flag/o10)
 	sort_order = 27
+	pow_cat = 5
 /*****/
 
 // Addon: Sec Contractors
@@ -644,15 +697,18 @@
 /datum/mil_rank/private_security/pcrc
 	name = "PCRC Contractor"
 	name_short = "PCRC"
+	pow_cat = 3
 
 // Kind of hacky, to allow usage of PCRC suit via outfit.
 /datum/mil_rank/private_security/pcrc_agt
 	name = "PCRC Agent"
 	name_short = "PCRC-AGT"
+	pow_cat = 3
 
 /datum/mil_rank/private_security/saare
 	name = "SAARE Operative"
 	name_short = "SAARE"
+	pow_cat = 3
 /*****/
 
 // Ends of defines


### PR DESCRIPTION
After discussions with BoH staff this PR implements part of the Geneva Convention Article 3 identification requirements as part of the Galilei Convention and adds them to NTSS Dagon ID Cards.  

This adds everyone favorite feature of international law.  POW Rank equivalency and a Geneva Convention ID status to military IDs.

A Galilei Convention: Cat # on all Dagon ID cards identifying what category they would fall under if captured.   

This is a human fluff thing, yelling “You can’t dissect me, I am a POW!" at an Ascent Xenobiologist is unlikely to be helpful but would be fun to watch.


![image](https://user-images.githubusercontent.com/8165455/78463860-0a754280-76b0-11ea-9e99-2b5e72f14809.png)


The following categories and assignments are from DOD Instruction 1000.1.

Cat 5:  Admin spawned Generals/Admirals, SolGov Rep, NT Rep
Cat 4: NTEF and Marine O4 - O6
Cat 3: NTEF and Marine O1 - O3, default level for civilian and contractor staff
Cat 2: NTEF and Marine E5 - E9, contractor Research Assistants
Cat 1: NTEF and Marine E1 - E4, contractor Janitor, Deckhand

<details>
  <summary>Rank equivalency is not a rank or a billet</summary>

Rank equivalency in the military does not in any way override rank or billet.  It is a way to establish relative rank between organizations that have different rank systems, and to establish where civilian employees fit for the purpose of amenities and precedence in military ceremony.  Outside of POW stuff, it is so nobody accidentally places the Deputy Director of Corvette Acquisitions at the wrong table during a promotion ceremony.

The Deputy Director cannot ruin your military career because they have the equivalency of an admiral.

The Deputy Director has the equivalency of an admiral because of the position they hold within society and the military which allows them to ruin your career.

</details>


In the background, a new rank is created under /datum/mil_rank/civ as NT Representative (NTR) to match SolGov Representative (SGR) so that the `pow_cat` variable can be assigned to the rank given to /datum/job/liaison.


🆑 Alffd
add: Galilei convention POW categories appear on ID cards.
tweak: NT Rep now has its own rank, /datum/mil_rank/civ/ntr 
/🆑

