### PR TITLE
Readds AP to slugs and mid-lasers.

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -30,6 +30,7 @@
 
 /obj/item/projectile/beam/midlaser
 	damage = 45
+	armor_penetration = 20
 	distance_falloff = 1
 
 /obj/item/projectile/beam/heavylaser

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -165,6 +165,7 @@
 	name = "slug"
 	fire_sound = 'sound/weapons/gunshot/shotgun.ogg'
 	damage = 60
+	armor_penetration = 10
 	distance_falloff = 2.5
 
 /obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets


### PR DESCRIPTION
Partial revert to address criticisms of #583 and pre-empt #651 
Slugs and lasers once again have AP. Minor damage nerfs were left in place but still allow for usefulness against armored targets with up to ARMOR_LASER_MAJOR.