### PR TITLE
Changes parts of laptops and tablets, and loadout price.

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -72,31 +72,22 @@ modular computers
 /datum/gear/utility/cheaptablet
 	display_name = "tablet computer, cheap"
 	path = /obj/item/modular_computer/tablet/preset/custom_loadout/cheap
-	cost = 3
+	cost = 2
 
 /datum/gear/utility/normaltablet
 	display_name = "tablet computer, advanced"
 	path = /obj/item/modular_computer/tablet/preset/custom_loadout/advanced
-	cost = 4
-
-/datum/gear/utility/customtablet
-	display_name = "tablet computer, custom"
-	path = /obj/item/modular_computer/tablet
-	cost = 4
-
-/datum/gear/utility/customtablet/New()
-	..()
-	gear_tweaks += new /datum/gear_tweak/tablet()
+	cost = 3
 
 /datum/gear/utility/cheaplaptop
 	display_name = "laptop computer, cheap"
 	path = /obj/item/modular_computer/laptop/preset/custom_loadout/cheap
-	cost = 5
+	cost = 3
 
 /datum/gear/utility/normallaptop
 	display_name = "laptop computer, advanced"
 	path = /obj/item/modular_computer/laptop/preset/custom_loadout/advanced
-	cost = 6
+	cost = 4
 
 /datum/gear/utility/instrument
 	display_name = "Instrument Selection"

--- a/code/modules/modular_computers/computers/subtypes/preset_laptop.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_laptop.dm
@@ -2,7 +2,7 @@
 
 /obj/item/modular_computer/laptop/preset/custom_loadout/cheap/install_default_hardware()
 	..()
-	processor_unit = new/obj/item/weapon/stock_parts/computer/processor_unit/small(src)
+	processor_unit = new/obj/item/weapon/stock_parts/computer/processor_unit(src)
 	tesla_link = new/obj/item/weapon/stock_parts/computer/tesla_link(src)
 	hard_drive = new/obj/item/weapon/stock_parts/computer/hard_drive/(src)
 	network_card = new/obj/item/weapon/stock_parts/computer/network_card/(src)
@@ -13,13 +13,15 @@
 
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced/install_default_hardware()
 	..()
-	processor_unit = new/obj/item/weapon/stock_parts/computer/processor_unit(src)
+	processor_unit = new/obj/item/weapon/stock_parts/computer/processor_unit/photonic(src)
 	tesla_link = new/obj/item/weapon/stock_parts/computer/tesla_link(src)
-	hard_drive = new/obj/item/weapon/stock_parts/computer/hard_drive/advanced(src)
+	hard_drive = new/obj/item/weapon/stock_parts/computer/hard_drive/super(src)
 	network_card = new/obj/item/weapon/stock_parts/computer/network_card/advanced(src)
 	nano_printer = new/obj/item/weapon/stock_parts/computer/nano_printer(src)
 	card_slot = new/obj/item/weapon/stock_parts/computer/card_slot(src)
-	battery_module = new/obj/item/weapon/stock_parts/computer/battery_module/advanced(src)
+	scanner = new/obj/item/weapon/stock_parts/computer/scanner/paper(src)
+	ai_slot = new/obj/item/weapon/stock_parts/computer/ai_slot(src)
+	battery_module = new/obj/item/weapon/stock_parts/computer/battery_module/super(src)
 	battery_module.charge_to_full()
 
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard/install_default_hardware()

--- a/code/modules/modular_computers/computers/subtypes/preset_tablet.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_tablet.dm
@@ -10,30 +10,15 @@
 
 /obj/item/modular_computer/tablet/preset/custom_loadout/advanced/install_default_hardware()
 	..()
-	processor_unit = new/obj/item/weapon/stock_parts/computer/processor_unit/small(src)
+	processor_unit = new/obj/item/weapon/stock_parts/computer/processor_unit/photonic/small(src)
 	tesla_link = new/obj/item/weapon/stock_parts/computer/tesla_link(src)
-	hard_drive = new/obj/item/weapon/stock_parts/computer/hard_drive/small(src)
+	hard_drive = new/obj/item/weapon/stock_parts/computer/hard_drive(src)
 	network_card = new/obj/item/weapon/stock_parts/computer/network_card/advanced(src)
 	nano_printer = new/obj/item/weapon/stock_parts/computer/nano_printer(src)
 	card_slot = new/obj/item/weapon/stock_parts/computer/card_slot(src)
+	ai_slot = new/obj/item/weapon/stock_parts/computer/ai_slot(src)
 	battery_module = new/obj/item/weapon/stock_parts/computer/battery_module(src)
 	battery_module.charge_to_full()
-
-/obj/item/modular_computer/tablet/preset/custom_loadout/standard/install_default_hardware()
-	..()
-	processor_unit = new/obj/item/weapon/stock_parts/computer/processor_unit/small(src)
-	tesla_link = new/obj/item/weapon/stock_parts/computer/tesla_link(src)
-	hard_drive = new/obj/item/weapon/stock_parts/computer/hard_drive/small(src)
-	network_card = new/obj/item/weapon/stock_parts/computer/network_card(src)
-	battery_module = new/obj/item/weapon/stock_parts/computer/battery_module/micro(src)
-	battery_module.charge_to_full()
-
-/obj/item/modular_computer/tablet/preset/custom_loadout/install_default_programs()
-	..()
-	var/mob/living/carbon/human/H = get_holder_of_type(src, /mob)
-	if(!istype(H)) return
-	install_default_programs_by_job(H)
-	hard_drive.store_file(new/datum/computer_file/program/wordprocessor())
 
 //Map presets
 

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -64,11 +64,11 @@
 		total_price = 99
 		switch(dev_cpu)
 			if(1)
-				if(fabricate)
-					fabricated_laptop.processor_unit = new/obj/item/weapon/stock_parts/computer/processor_unit/small(fabricated_laptop)
-			if(2)
-				if(fabricate)
+				if(fabricate) // Standard
 					fabricated_laptop.processor_unit = new/obj/item/weapon/stock_parts/computer/processor_unit(fabricated_laptop)
+			if(2)
+				if(fabricate) // Photonic
+					fabricated_laptop.processor_unit = new/obj/item/weapon/stock_parts/computer/processor_unit/photonic(fabricated_laptop)
 				total_price += 299
 		switch(dev_battery)
 			if(1) // Basic(750C)
@@ -124,8 +124,15 @@
 	else if(devtype == 2) 	// Tablet, more expensive, not everyone could probably afford this.
 		if(fabricate)
 			fabricated_tablet = new(src)
-			fabricated_tablet.processor_unit = new/obj/item/weapon/stock_parts/computer/processor_unit/small(fabricated_tablet)
 		total_price = 199
+		switch(dev_cpu)
+			if(1) // Standard
+				if(fabricate)
+					fabricated_tablet.processor_unit = new/obj/item/weapon/stock_parts/computer/processor_unit/small(fabricated_tablet)
+			if(2) // Photonic
+				if(fabricate)
+					fabricated_tablet.processor_unit = new/obj/item/weapon/stock_parts/computer/processor_unit/photonic/small(fabricated_tablet)
+				total_price += 199
 		switch(dev_battery)
 			if(1) // Basic(300C)
 				if(fabricate)

--- a/nano/templates/computer_fabricator.tmpl
+++ b/nano/templates/computer_fabricator.tmpl
@@ -28,12 +28,10 @@
 			<td>{{:helper.link('None', null, { "hw_netcard" : 0 }, data.hw_netcard == 0 ? 'selected' : null)}}
 			<td>{{:helper.link('Standard', null, { "hw_netcard" : 1 }, data.hw_netcard == 1 ? 'selected' : null)}}
 			<td>{{:helper.link('Advanced', null, { "hw_netcard" : 2 }, data.hw_netcard == 2 ? 'selected' : null)}}
-		{{if data.devtype != 2}} <!-- No tablets -->
 		<tr>
 			<td><b>Processor Unit:</b>
 			<td>{{:helper.link('Standard', null, { "hw_cpu" : 1 }, data.hw_cpu == 1 ? 'selected' : null)}}
 			<td>{{:helper.link('Advanced', null, { "hw_cpu" : 2 }, data.hw_cpu == 2 ? 'selected' : null)}}
-		{{/if}}
 		<tr>
 			<td><b>Tesla Relay:</b>
 			<td>{{:helper.link('None', null, { "hw_tesla" : 0 }, data.hw_tesla == 0 ? 'selected' : null)}}


### PR DESCRIPTION
🆑Roland410
:tweak:Loadout tablets and laptops had their parts upgraded (only for the expensive ones really, you cheap fucks).
:tweak:Laptop vendor can make the better tablets and laptops now.
:tweak:Because of the part changes, access decryptor and DDoS should be a bit better, most noticeable on the decryptor though.
:tweak:Cheap tablets cost 2 loadout points now, advanced is 3. Cheap laptop costs 3 points, advanced is 4 now.
:rscdel:Custom tablet with the part selection was removed as it's kind of pointless.
/🆑
Photonic processors are technically R&D stuff, but it's not a huge deal in my opinion, however these changes (especially for laptops) should hopefully mean more people will start using them. Currently 6 points for a laptop and 4 for a tablet is the highest in the whole loadout system (besides the unobtainable crayon MRE).