### PR TITLE
Potential Armalis Character generation bugfix

### DIFF
--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -138,7 +138,7 @@
 
 	slowdown = 1.5
 	hidden_from_codex = TRUE
-	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_FLAG_NO_MINOR_CUT
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_FLAG_NO_MINOR_CUT // | SPECIES_IS_WHITELISTED
 	brute_mod = 0.5
 	burn_mod = 0.5
 	strength = STR_HIGH

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -138,7 +138,7 @@
 
 	slowdown = 1.5
 	hidden_from_codex = TRUE
-	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION | NO_MINOR_CUT
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_FLAG_NO_MINOR_CUT
 	brute_mod = 0.5
 	burn_mod = 0.5
 	strength = STR_HIGH

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -138,7 +138,7 @@
 
 	slowdown = 1.5
 	hidden_from_codex = TRUE
-	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION // | SPECIES_IS_WHITELISTED
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION | NO_MINOR_CUT
 	brute_mod = 0.5
 	burn_mod = 0.5
 	strength = STR_HIGH

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -138,7 +138,7 @@
 
 	slowdown = 1.5
 	hidden_from_codex = TRUE
-	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_FLAG_NO_MINOR_CUT // | SPECIES_IS_WHITELISTED
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION // | SPECIES_IS_WHITELISTED
 	brute_mod = 0.5
 	burn_mod = 0.5
 	strength = STR_HIGH

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -3,6 +3,7 @@
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
 									 /datum/job/roboticist, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender),
 		/datum/species/vox/ = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
+		/datum/species/vox/armalis = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
 		/datum/species/human/mule = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
 	)
 


### PR DESCRIPTION
Adding a de-active white list spawn flag for the Vox armalis. Also specifically added in an active dagon merchant job whitelist to the Dagon to hopefully fix the bug where the armalis are de listed from character generation despite having the SPECIES_CAN_JOIN spawn flag.