### PR TITLE
removes meta box

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -1,7 +1,7 @@
 /obj/item/weapon/storage/box/syndie_kit
 	name = "box"
 	desc = "A sleek, sturdy box."
-	icon_state = "box_of_doom"
+	icon_state = "box"
 
 //For uplink kits that provide bulkier items
 /obj/item/weapon/storage/backpack/satchel/syndie_kit


### PR DESCRIPTION
🆑 chaoko99
tweak: Traitor kits use regular box sprites now. This should help traitors get away with things for longer.
/ 🆑 
Why meta protect something when you can just make it inconspicuous. 