### PR TITLE
More Adherent Job Stuff.

### DIFF
--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -13,7 +13,7 @@
 		/datum/species/skrell  = list(HUMAN_ONLY_JOBS, /datum/job/representative),
 		/datum/species/machine = list(HUMAN_ONLY_JOBS, /datum/job/representative),
 		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/officer, /datum/job/warden),
-		/datum/species/adherent = list(HUMAN_ONLY_JOBS, /datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/officer, /datum/job/warden),
+		/datum/species/adherent = list(HUMAN_ONLY_JOBS, /datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/seccadet),
 		/datum/species/sergal = list(HUMAN_ONLY_JOBS, /datum/job/representative),
 		/datum/species/akula = list(HUMAN_ONLY_JOBS, /datum/job/representative),
 		/datum/species/humanathi= list(HUMAN_ONLY_JOBS, /datum/job/representative),

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -42,7 +42,7 @@
 		/datum/species/nabber     = list(/datum/mil_branch/civilian),
 		/datum/species/skrell     = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps, /datum/mil_branch/skrell_fleet),
 		/datum/species/unathi     = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
-		/datum/species/adherent   = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
+		/datum/species/adherent   = list(/datum/mil_branch/civilian),
 		/datum/species/sergal     = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
 		/datum/species/akula     = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
 		/datum/species/custom      = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),


### PR DESCRIPTION
Removes Adherent from the NTEF. If some one wants to put them back, they can. I believe it was intended that Adherent were only originally supposed to be contractors, so this fixes that.

Additionally, blacklists security cadet and forensic technician, as I had forgotten to add those on. Because I can't really see an alien servitor in a job that's whole purpose is to screw people over.