### PR TITLE
Tweaks several items.

### DIFF
--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -218,7 +218,7 @@
 /obj/item/device/radio/uplink/New(var/loc, var/owner, var/amount)
 	..()
 	hidden_uplink = new(src, owner, amount)
-	icon_state = "radio"
+	icon_state = "walkietalkie"
 
 /obj/item/device/radio/uplink/attack_self(mob/user as mob)
 	if(hidden_uplink)

--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -1,7 +1,7 @@
 /obj/item/weapon/rig/unathi
-	name = "\improper NT breacher chassis control module"
-	desc = "A NanoTrasen-made Unathi battle-rig. Looks like a fish, moves like a fish, steers like a cow."
-	suit_type = "\improper NT breacher rig"
+	name = "\improper makeshift breacher chassis control module"
+	desc = "A makeshift Unathi battle-rig. Looks like a fish, moves like a fish, steers like a cow."
+	suit_type = "\improper makeshift breacher rig"
 	icon_state = "breacher_rig_cheap"
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -39,9 +39,9 @@
 /obj/item/clothing/head/helmet/space/rig/light
 	name = "hood"
 
-/obj/item/weapon/rig/light/hacker
+/obj/item/weapon/rig/light/hacker //originally known as the cyber suit
 	name = "null suitcontrol module"
-	suit_type = "cyber"
+	suit_type = "null"
 	desc = "A very lightweight hardsuit. The gloves appear to be insulated."
 	icon_state = "hacker_rig"
 
@@ -160,9 +160,9 @@
 /obj/item/clothing/suit/space/rig/light/ninja
 	breach_threshold = 38 //comparable to regular hardsuits
 
-/obj/item/weapon/rig/light/stealth
+/obj/item/weapon/rig/light/stealth //the stealth suit, also known as the knock off ninja suit.
 	name = "null suit control module"
-	suit_type = "stealth"
+	suit_type = "null"
 	desc = "A very lightweight hardsuit. It's rather inconspicuous."
 	icon_state = "stealth_rig"
 

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -40,9 +40,9 @@
 	name = "hood"
 
 /obj/item/weapon/rig/light/hacker
-	name = "cybersuit control module"
+	name = "null suitcontrol module"
 	suit_type = "cyber"
-	desc = "An advanced powered armour suit with many cyberwarfare enhancements. Comes with built-in insulated gloves for safely tampering with electronics."
+	desc = "A very lightweight hardsuit. The gloves appear to be insulated."
 	icon_state = "hacker_rig"
 
 	req_access = list(access_syndicate)
@@ -161,14 +161,15 @@
 	breach_threshold = 38 //comparable to regular hardsuits
 
 /obj/item/weapon/rig/light/stealth
-	name = "stealth suit control module"
+	name = "null suit control module"
 	suit_type = "stealth"
-	desc = "A highly advanced and expensive suit designed for covert operations."
+	desc = "A very lightweight hardsuit. It's rather inconspicuous."
 	icon_state = "stealth_rig"
 
 	req_access = list(access_syndicate)
 
 	initial_modules = list(
 		/obj/item/rig_module/stealth_field,
-		/obj/item/rig_module/vision
+		/obj/item/rig_module/vision,
+		/obj/item/rig_module/cooling_unit
 		)

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -76,10 +76,10 @@
 	reagents_to_add = list(/datum/reagent/toxin = 60)
 
 /obj/item/weapon/reagent_containers/glass/bottle/cyanide
-	name = "cyanide bottle"
-	desc = "A small bottle of cyanide. Bitter almonds?"
+	name = "bottle"
+	desc = "A small bottle."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle-3"
+	icon_state = "bottle-4"
 	reagents_to_add = list(/datum/reagent/toxin/cyanide = 30)
 
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -88,7 +88,7 @@
 
 /obj/item/weapon/reagent_containers/pill/cyanide
 	name = "strange pill"
-	desc = "It's marked 'KCN'. Smells vaguely of almonds."
+	desc = "A strange, unmarked pill. You probably shouldn't eat this."
 	icon_state = "pillC"
 	volume = 50
 	reagents_to_add = list(/datum/reagent/toxin/cyanide = 50)


### PR DESCRIPTION
Stealth suit/cyber suit: Renamed to null suit, both given descriptions to differentiate them. Cybersuit still has mention of it's insulated gloves. Stealth suit has been given a cooling pack, as that seemed like an oversight, given almost every other hardsuit type has one.

Cyanide pill/bottle: Renamed to make them less noticeable at a glance.

Traitor radio uplink: Given the shortwave sprites. It already acts like a shortwave, not sure why it had a different sprite.

NT Breacher Suit: Renamed to makeshift breacher suit.

Should help these items get meta gamed less, since it's starting to get a little autistic seeing security officers or even random passengers scream "Hey that's an X, security man, slap him!"