### PR TITLE
Makes musical instruments usable as weapons.

### DIFF
--- a/code/modules/synthesized_instruments/real_instruments/Guitar/guitar.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Guitar/guitar.dm
@@ -3,6 +3,7 @@
 	desc = "A wooden musical instrument with six strings. This one looks like it may actually work."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "guitar"
+	force = 10
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar/clean_crisis
 
@@ -12,5 +13,6 @@
 	desc = "An instrument for a more ass-kicking era."
 	icon = 'icons/obj/musician.dmi'
 	icon_state = "eguitar"
+	force = 10
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar

--- a/code/modules/synthesized_instruments/real_instruments/Synthesizer/synthesizer.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Synthesizer/synthesizer.dm
@@ -46,6 +46,7 @@
 	name = "Synthesizer Mini"
 	desc = "The power of an entire orchestra in a handy midi keyboard format."
 	icon_state = "h_synthesizer"
+	force = 10
 	path = /datum/instrument
 	sound_player = /datum/sound_player/synthesizer
 

--- a/code/modules/synthesized_instruments/real_instruments/Trumpet/trumpet.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Trumpet/trumpet.dm
@@ -2,5 +2,6 @@
 	name = "Omnitrumpet"
 	desc = "The Omnitrumptet series 400 with more than 30 sound samples and fully customizable high fidelity output provides the ultimate means to toot your own horn"
 	icon_state = "trumpet"
+	force = 10
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/brass

--- a/code/modules/synthesized_instruments/real_instruments/Violin/violin.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Violin/violin.dm
@@ -6,6 +6,7 @@
 	name = "violin"
 	desc = "A wooden musical instrument with four strings and a bow. \"The devil went down to space, he was looking for an assistant to grief.\"."
 	icon_state = "violin"
+	force = 10
 	sound_player = /datum/sound_player/violin
 	path = /datum/instrument/obsolete/violin
 


### PR DESCRIPTION
🆑Roland410
tweak:Makes musical instruments usable as weapons (only 10 force though).
/🆑
Shale commissioned this from me. As per title and CL, this allows instruments to be used as low-strength weapons. Go you rockstars!