### PR TITLE
SRV Verne Rework: functional overmap science shuttle.

### DIFF
--- a/maps/away/unishi/unishi-1.dmm
+++ b/maps/away/unishi/unishi-1.dmm
@@ -813,6 +813,7 @@
 /obj/item/weapon/rcd_ammo/large,
 /obj/item/weapon/rcd_ammo/large,
 /obj/item/weapon/rpd,
+/obj/item/weapon/rpd,
 /turf/simulated/floor,
 /area/unishi/engineroom)
 "bZ" = (
@@ -1882,14 +1883,21 @@
 /obj/structure/window/phoronreinforced,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
-"gv" = (
+"nv" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1380;
+	id_tag = "right_shuttle_pump_internal"
+	},
+/turf/simulated/floor,
+/area/ship/New_Horizons)
+"qc" = (
 /obj/machinery/alarm{
 	icon_state = "alarm0";
 	dir = 1
 	},
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
-"rp" = (
+"yy" = (
 /obj/machinery/power/port_gen/pacman/super/potato,
 /obj/structure/cable{
 	icon_state = "0-8";
@@ -1898,33 +1906,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
-"vA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/wallframe_spawn/phoron,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/New_Horizons)
-"vH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 6
-	},
+"yD" = (
+/obj/structure/fuel_port,
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
-"xm" = (
+"Bq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 8
-	},
-/turf/simulated/wall/titanium,
-/area/ship/New_Horizons)
-"zs" = (
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor,
-/area/unishi/engineroom)
-"ED" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 10
 	},
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
@@ -1934,46 +1923,58 @@
 	},
 /turf/simulated/floor,
 /area/unishi/engineroom)
-"GX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 9
-	},
-/turf/simulated/wall/titanium,
-/area/ship/New_Horizons)
+"FV" = (
+/obj/machinery/atmospherics/omni/filter,
+/turf/simulated/floor,
+/area/unishi/engineroom)
 "Ic" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/wall,
 /area/unishi/engineering)
-"NE" = (
+"Kg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"Nq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 4
 	},
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
-"QD" = (
+"Rg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/wallframe_spawn/phoron,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"Va" = (
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor,
+/area/unishi/engineroom)
+"VE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 5
 	},
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
-"UE" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1380;
-	id_tag = "right_shuttle_pump_internal"
+"Xl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
-"Vm" = (
-/obj/machinery/atmospherics/omni/filter,
-/turf/simulated/floor,
-/area/unishi/engineroom)
-"WZ" = (
-/obj/structure/fuel_port,
+"Zz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 6
+	},
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
 
@@ -7108,8 +7109,8 @@ dS
 bc
 bc
 bB
-zs
-Vm
+Va
+FV
 bV
 cc
 ce
@@ -8021,7 +8022,7 @@ da
 dh
 dk
 da
-QD
+VE
 aa
 aa
 aY
@@ -8118,12 +8119,12 @@ cz
 aZ
 aa
 aa
-xm
+Bq
 db
 di
 do
 du
-NE
+Nq
 aa
 aa
 aY
@@ -8220,16 +8221,16 @@ cA
 aZ
 aa
 cO
-GX
+Xl
 dc
 di
 dq
 du
-ED
+Kg
 dz
-UE
+nv
 dH
-rp
+yy
 ep
 cu
 cu
@@ -8319,7 +8320,7 @@ aY
 aI
 cu
 cx
-WZ
+yD
 cL
 cL
 cU
@@ -8429,7 +8430,7 @@ dd
 di
 dM
 dl
-vA
+Rg
 dD
 dV
 dK
@@ -8727,7 +8728,7 @@ aY
 aJ
 cx
 cu
-gv
+qc
 cL
 cL
 cY
@@ -8832,14 +8833,14 @@ cr
 aZ
 cK
 cS
-QD
+VE
 df
 di
 dd
 dx
-vH
+Zz
 dA
-UE
+nv
 aY
 eb
 er
@@ -8934,12 +8935,12 @@ cG
 aZ
 aa
 aa
-NE
+Nq
 dg
 di
 dp
 dx
-NE
+Nq
 aa
 aa
 aY
@@ -9041,7 +9042,7 @@ da
 dn
 ds
 da
-GX
+Xl
 aa
 aa
 aY

--- a/maps/away/unishi/unishi-1.dmm
+++ b/maps/away/unishi/unishi-1.dmm
@@ -1119,7 +1119,7 @@
 /obj/machinery/access_button/airlock_exterior{
 	master_tag = "left_shuttle"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 6
 	},
@@ -1178,15 +1178,15 @@
 	frequency = 1380;
 	master_tag = "right_shuttle"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 10
 	},
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
 "da" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/wallframe_spawn/phoron,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "db" = (
@@ -1272,7 +1272,8 @@
 	frequency = 1379;
 	id_tag = "left_shuttle_outer"
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	icon_state = "map";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1297,12 +1298,12 @@
 	frequency = 1379;
 	id_tag = "left_shuttle_outer"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "dl" = (
@@ -1328,7 +1329,8 @@
 	frequency = 1380;
 	id_tag = "right_shuttle_outer"
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	icon_state = "map";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1376,7 +1378,7 @@
 	frequency = 1380;
 	id_tag = "right_shuttle_outer"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "dt" = (
@@ -1633,12 +1635,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
-"dX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/turf/simulated/wall/titanium,
-/area/ship/New_Horizons)
 "dY" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	controlled = 1;
@@ -1729,13 +1725,6 @@
 /area/ship/New_Horizons)
 "ek" = (
 /obj/machinery/atmospherics/binary/pump,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/New_Horizons)
-"el" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "em" = (
@@ -1893,40 +1882,14 @@
 /obj/structure/window/phoronreinforced,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
-"gb" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/simulated/wall/titanium,
-/area/ship/New_Horizons)
-"gO" = (
-/obj/machinery/atmospherics/omni/filter,
-/turf/simulated/floor,
-/area/unishi/engineroom)
-"oi" = (
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor,
-/area/unishi/engineroom)
-"qn" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 10
-	},
-/turf/simulated/wall/titanium,
-/area/ship/New_Horizons)
-"se" = (
-/obj/structure/fuel_port,
-/turf/simulated/wall/titanium,
-/area/ship/New_Horizons)
-"vu" = (
+"gv" = (
 /obj/machinery/alarm{
 	icon_state = "alarm0";
 	dir = 1
 	},
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
-"ww" = (
+"rp" = (
 /obj/machinery/power/port_gen/pacman/super/potato,
 /obj/structure/cable{
 	icon_state = "0-8";
@@ -1935,10 +1898,33 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
-"Fv" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
+"vA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/wallframe_spawn/phoron,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"vH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
-	dir = 9
+	dir = 6
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"xm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 8
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"zs" = (
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor,
+/area/unishi/engineroom)
+"ED" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 10
 	},
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
@@ -1948,43 +1934,46 @@
 	},
 /turf/simulated/floor,
 /area/unishi/engineroom)
+"GX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
 "Ic" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/wall,
 /area/unishi/engineering)
-"LM" = (
+"NE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"QD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"UE" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1380;
 	id_tag = "right_shuttle_pump_internal"
 	},
 /turf/simulated/floor,
 /area/ship/New_Horizons)
-"Pw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/wallframe_spawn/phoron,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/New_Horizons)
-"PQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 6
-	},
-/turf/simulated/wall/titanium,
-/area/ship/New_Horizons)
-"Qs" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 8
-	},
-/turf/simulated/wall/titanium,
-/area/ship/New_Horizons)
-"Uq" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 5
-	},
+"Vm" = (
+/obj/machinery/atmospherics/omni/filter,
+/turf/simulated/floor,
+/area/unishi/engineroom)
+"WZ" = (
+/obj/structure/fuel_port,
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
 
@@ -7119,8 +7108,8 @@ dS
 bc
 bc
 bB
-oi
-gO
+zs
+Vm
 bV
 cc
 ce
@@ -8032,10 +8021,10 @@ da
 dh
 dk
 da
-Uq
+QD
 aa
 aa
-dX
+aY
 aY
 aY
 cL
@@ -8129,12 +8118,12 @@ cz
 aZ
 aa
 aa
-Qs
+xm
 db
 di
 do
 du
-gb
+NE
 aa
 aa
 aY
@@ -8231,16 +8220,16 @@ cA
 aZ
 aa
 cO
-Fv
+GX
 dc
 di
 dq
 du
-qn
+ED
 dz
-LM
+UE
 dH
-ww
+rp
 ep
 cu
 cu
@@ -8330,7 +8319,7 @@ aY
 aI
 cu
 cx
-se
+WZ
 cL
 cL
 cU
@@ -8440,7 +8429,7 @@ dd
 di
 dM
 dl
-Pw
+vA
 dD
 dV
 dK
@@ -8738,7 +8727,7 @@ aY
 aJ
 cx
 cu
-vu
+gv
 cL
 cL
 cY
@@ -8753,7 +8742,7 @@ aY
 eb
 eq
 cu
-el
+cu
 ex
 dC
 aa
@@ -8843,14 +8832,14 @@ cr
 aZ
 cK
 cS
-Uq
+QD
 df
 di
 dd
 dx
-PQ
+vH
 dA
-LM
+UE
 aY
 eb
 er
@@ -8945,12 +8934,12 @@ cG
 aZ
 aa
 aa
-Qs
+NE
 dg
 di
 dp
 dx
-Qs
+NE
 aa
 aa
 aY
@@ -9052,7 +9041,7 @@ da
 dn
 ds
 da
-Fv
+GX
 aa
 aa
 aY

--- a/maps/away/unishi/unishi-1.dmm
+++ b/maps/away/unishi/unishi-1.dmm
@@ -232,46 +232,77 @@
 /turf/simulated/floor,
 /area/unishi/engineering)
 "aI" = (
+/obj/machinery/computer/ship/navigation,
+/obj/machinery/button/blast_door{
+	id_tag = "auxbar";
+	pixel_x = 0;
+	pixel_y = 25
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	cycle_to_external_air = 1;
+	id_tag = "left_shuttle";
+	pixel_y = 25;
+	tag_airpump = "left_shuttle_pump_internal";
+	tag_chamber_sensor = "left_shuttle_sensor";
+	tag_exterior_door = "left_shuttle_outer";
+	tag_interior_door = "left_shuttle_inner"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"aJ" = (
+/obj/machinery/computer/ship/engines,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1380;
+	id_tag = "right_shuttle";
+	pixel_y = 25;
+	tag_airpump = "right_shuttle_pump_internal";
+	tag_chamber_sensor = "right_shuttle_sensor";
+	tag_exterior_door = "right_shuttle_outer";
+	tag_interior_door = "right_shuttle_inner"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"aK" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/unishi/engineering)
+"aL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor,
-/area/unishi/engineering)
-"aJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor,
-/area/unishi/engineering)
-"aK" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 4;
-	target_pressure = 200
-	},
-/turf/simulated/floor,
-/area/unishi/engineering)
-"aL" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
-	dir = 4;
-	id_tag = "unishi_inner"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor,
 /area/unishi/engineering)
 "aM" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	frequency = 1379;
-	id_tag = "unishi_vent"
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/unishi/engineering)
 "aN" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/atmospherics/binary/pump/on{
 	dir = 4;
-	id_tag = "unishi_outer"
+	target_pressure = 200
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/unishi/engineering)
@@ -365,16 +396,17 @@
 /turf/simulated/floor,
 /area/unishi/engineering)
 "aY" = (
-/obj/structure/sign/warning/airlock,
 /turf/simulated/wall/titanium,
-/area/unishi/engineering)
+/area/ship/New_Horizons)
 "aZ" = (
-/obj/machinery/access_button/airlock_exterior{
-	master_tag = "unishi";
-	pixel_x = -28
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	dir = 1;
+	id_tag = "auxbar";
+	name = "Blast Shutters"
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
 "ba" = (
 /obj/machinery/atmospherics/binary/pump,
 /obj/machinery/light/small{
@@ -721,11 +753,12 @@
 /turf/simulated/floor,
 /area/unishi/engineroom)
 "bQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 10
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/unishi/engineroom)
+/obj/machinery/atmospherics/unary/vent_scrubber,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
 "bR" = (
 /turf/simulated/wall,
 /area/unishi/engineroom)
@@ -836,6 +869,1091 @@
 /obj/effect/shuttle_landmark/nav_unishi/nav3,
 /turf/space,
 /area/space)
+"ck" = (
+/obj/machinery/computer/modular{
+	icon_state = "computer";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cl" = (
+/obj/structure/bed/chair/shuttle/black{
+	icon_state = "shuttle_chair_preview";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cm" = (
+/obj/machinery/door/airlock/external/bolted/cycling{
+	dir = 4;
+	id_tag = "unishi_inner"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/unishi/engineering)
+"cn" = (
+/obj/machinery/computer/shuttle_control/explore/New_Horizons,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"co" = (
+/obj/machinery/computer/ship/helm,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cp" = (
+/obj/machinery/computer/ship/sensors,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cq" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1379;
+	id_tag = "unishi_vent"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/unishi/engineering)
+"cr" = (
+/obj/structure/bed/chair/shuttle/black{
+	icon_state = "shuttle_chair_preview";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cs" = (
+/obj/machinery/computer/atmos_alert{
+	icon_state = "computer";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"ct" = (
+/obj/machinery/computer/modular/preset/dock{
+	icon_state = "console";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cu" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cw" = (
+/obj/structure/bed/chair/shuttle/black{
+	icon_state = "shuttle_chair_preview";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/effect/overmap/visitable/ship/landable/New_Horizons,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cy" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/machinery/computer/modular/preset/dock{
+	icon_state = "";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cz" = (
+/obj/machinery/computer/power_monitor{
+	icon_state = "computer";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cA" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 0;
+	dir = 4;
+	frequency = 1331;
+	id_tag = "calypso_cargo_pump"
+	},
+/obj/structure/bed/chair/shuttle/black{
+	icon_state = "shuttle_chair_preview";
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/fuel_port,
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"cC" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0;
+	req_access = newlist()
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cD" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cE" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	icon_state = "intact";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cF" = (
+/obj/structure/bed/chair/shuttle/black{
+	icon_state = "shuttle_chair_preview";
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cG" = (
+/obj/machinery/computer/air_control{
+	dir = 8;
+	name = "Atmospheric Sensors";
+	sensor_tag = "calypso_out"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cH" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cI" = (
+/obj/machinery/door/airlock/engineering,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cJ" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cK" = (
+/obj/machinery/shipsensors,
+/turf/simulated/floor,
+/area/ship/New_Horizons)
+"cL" = (
+/obj/effect/wallframe_spawn/phoron,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	icon_state = "intact";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cO" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1379;
+	id_tag = "left_shuttle_pump_external"
+	},
+/turf/simulated/floor,
+/area/ship/New_Horizons)
+"cP" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24;
+	req_access = newlist()
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/red{
+	icon_state = "map";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	icon_state = "intact";
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cS" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1380;
+	id_tag = "right_shuttle_pump_external"
+	},
+/turf/simulated/floor,
+/area/ship/New_Horizons)
+"cT" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/access_button/airlock_exterior{
+	master_tag = "left_shuttle"
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"cU" = (
+/obj/machinery/access_button/airlock_interior{
+	master_tag = "left_shuttle"
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"cV" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0;
+	req_access = newlist()
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cW" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	icon_state = "map_scrubber_off";
+	dir = 4
+	},
+/obj/effect/shuttle_landmark/nav_unishi/New_Horizons,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	icon_state = "intact";
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"cY" = (
+/obj/machinery/access_button/airlock_interior{
+	frequency = 1380;
+	master_tag = "right_shuttle"
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"cZ" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/access_button/airlock_exterior{
+	frequency = 1380;
+	master_tag = "right_shuttle"
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"da" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"db" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1379;
+	id_tag = "left_shuttle_pump_internal"
+	},
+/obj/machinery/airlock_sensor{
+	id_tag = "left_shuttle_sensor";
+	pixel_y = 25
+	},
+/obj/structure/handrai,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dc" = (
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	cycle_to_external_air = 1;
+	id_tag = "left_shuttle";
+	pixel_y = 25;
+	tag_airpump = "left_shuttle_pump_internal";
+	tag_chamber_sensor = "left_shuttle_sensor";
+	tag_exterior_door = "left_shuttle_outer";
+	tag_interior_door = "left_shuttle_inner"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1379;
+	id_tag = "left_shuttle_pump_internal"
+	},
+/obj/structure/handrai,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dd" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	icon_state = "map";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"de" = (
+/obj/machinery/door/airlock/external/bolted/cycling{
+	dir = 4;
+	id_tag = "unishi_outer"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/unishi/engineering)
+"df" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1380;
+	id_tag = "right_shuttle_pump_internal"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "right_shuttle_sensor";
+	pixel_y = 25
+	},
+/obj/structure/handrai,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dg" = (
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1380;
+	id_tag = "right_shuttle";
+	pixel_y = 25;
+	tag_airpump = "right_shuttle_pump_internal";
+	tag_chamber_sensor = "right_shuttle_sensor";
+	tag_exterior_door = "right_shuttle_outer";
+	tag_interior_door = "right_shuttle_inner"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1380;
+	id_tag = "right_shuttle_pump_internal"
+	},
+/obj/structure/handrai,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dh" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "left_shuttle_outer"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"di" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dj" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "left_shuttle_inner"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dk" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "left_shuttle_outer"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dl" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dm" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "right_shuttle_inner"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dn" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "right_shuttle_outer"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"do" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	icon_state = "map";
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dp" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	icon_state = "map";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dq" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	icon_state = "map";
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dr" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "right_shuttle_inner"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"ds" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "right_shuttle_outer"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dt" = (
+/obj/machinery/access_button/airlock_exterior{
+	master_tag = "unishi";
+	pixel_x = 0
+	},
+/turf/simulated/wall/titanium,
+/area/unishi/engineering)
+"du" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 1;
+	dir = 1;
+	frequency = 1379;
+	id_tag = "left_shuttle_pump_internal"
+	},
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dv" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	icon_state = "intact";
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dw" = (
+/obj/machinery/door/airlock/engineering,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dx" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 1;
+	dir = 1;
+	frequency = 1380;
+	id_tag = "right_shuttle_pump_internal"
+	},
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dy" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"dz" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 1;
+	dir = 1;
+	frequency = 1379;
+	id_tag = "left_shuttle_pump_external"
+	},
+/turf/simulated/floor,
+/area/ship/New_Horizons)
+"dA" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 1;
+	dir = 1;
+	frequency = 1380;
+	id_tag = "right_shuttle_pump_external"
+	},
+/turf/simulated/floor,
+/area/ship/New_Horizons)
+"dB" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	icon_state = "intact";
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dC" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/closet/radiation,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dF" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/radiation,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dG" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "left_shuttle_inner"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dI" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 0;
+	dir = 4;
+	frequency = 1331;
+	id_tag = "calypso_cargo_pump"
+	},
+/turf/simulated/floor,
+/area/ship/New_Horizons)
+"dJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	icon_state = "intact";
+	dir = 8
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"dK" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/red{
+	icon_state = "map";
+	dir = 1
+	},
+/obj/machinery/alarm,
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"dL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"dM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	icon_state = "intact";
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "raddoor"
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"dO" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1379;
+	id_tag = "unishi_vent"
+	},
+/turf/simulated/floor,
+/area/ship/New_Horizons)
+"dP" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	icon_state = "map_scrubber_off";
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dQ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/red{
+	icon_state = "map";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dR" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	icon_state = "map";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dS" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/unishi/engineroom)
+"dT" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/unishi/engineroom)
+"dU" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/red,
+/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/blast/regular{
+	dir = 1;
+	id_tag = "raddoor";
+	name = "Blast Shutters"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dY" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 1;
+	dir = 1;
+	frequency = 1379;
+	id_tag = "left_shuttle_pump_internal"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dZ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"ea" = (
+/obj/machinery/power/port_gen/pacman/super/potato,
+/obj/structure/cable{
+	icon_state = "0-8";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"eb" = (
+/obj/machinery/power/smes/buildable/preset/torch/shuttle,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"ec" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 10
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor,
+/area/unishi/engineroom)
+"ed" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor,
+/area/unishi/engineroom)
+"ee" = (
+/obj/structure/closet/crate/uranium,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"ef" = (
+/obj/effect/shuttle_landmark/transit/nav_unishi/New_Horizons,
+/turf/space,
+/area/space)
+"eg" = (
+/obj/effect/shuttle_landmark/ship,
+/turf/space,
+/area/space)
+"eh" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	icon_state = "map_scrubber_off";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"ei" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"ej" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"ek" = (
+/obj/machinery/atmospherics/binary/pump,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"el" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	icon_state = "intact";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"em" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"en" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"eo" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"ep" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"eq" = (
+/obj/machinery/power/terminal{
+	icon_state = "term";
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"er" = (
+/obj/machinery/power/terminal{
+	icon_state = "term";
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"es" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"et" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"eu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/toolcloset,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"ev" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"ew" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 6
+	},
+/obj/structure/closet/crate/uranium,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/obj/structure/window/phoronreinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"ex" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	icon_state = "map";
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"ey" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/obj/structure/window/phoronreinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"ez" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	icon_state = "map";
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/window/phoronreinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"eA" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	icon_state = "intact";
+	dir = 10
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
 "FR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -3128,7 +4246,7 @@ aa
 aa
 aa
 aa
-aa
+ef
 aa
 aa
 aa
@@ -5976,7 +7094,7 @@ Ic
 aH
 aT
 bc
-bc
+dS
 bc
 bc
 bB
@@ -6075,15 +7193,15 @@ ah
 ao
 aw
 aA
-aw
-aU
-aU
-aU
+aK
+bc
+bc
+dT
 aU
 FR
 bC
 bH
-bQ
+ec
 bW
 cc
 ce
@@ -6177,7 +7295,7 @@ am
 ap
 ax
 aB
-aI
+aL
 aV
 bf
 bn
@@ -6279,7 +7397,7 @@ ai
 aq
 ai
 ai
-aJ
+aM
 aW
 bg
 bg
@@ -6381,7 +7499,7 @@ ab
 ar
 ay
 aC
-aK
+aN
 aX
 bh
 aw
@@ -6389,8 +7507,8 @@ aw
 by
 bF
 bK
-aU
-aU
+ed
+ed
 cd
 ce
 cg
@@ -6483,8 +7601,8 @@ aa
 as
 ay
 aD
-aL
-aY
+cm
+ay
 ab
 ab
 ab
@@ -6585,7 +7703,7 @@ aa
 aa
 ay
 aE
-aM
+cq
 ay
 ab
 ab
@@ -6687,7 +7805,7 @@ aa
 aa
 ay
 aF
-aw
+ak
 ay
 aa
 aa
@@ -6789,12 +7907,12 @@ aa
 aa
 ay
 ai
-aN
-ay
+de
+dt
 aa
 aa
 aa
-aa
+dI
 aa
 aa
 aa
@@ -6881,28 +7999,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+aY
 aZ
+aZ
+aZ
+aY
 aa
+cO
+cT
+da
+dh
+dk
+da
+dy
+dz
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+dJ
+aY
+aY
+cL
+cL
+aY
+aY
 aa
 aa
 aa
@@ -6983,28 +8101,28 @@ aa
 aa
 aa
 aa
+aZ
+ck
+ct
+cz
+aZ
 aa
 aa
+aY
+db
+di
+do
+du
+aY
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+dJ
+ea
+eo
+ee
+ee
+ew
+dC
 aa
 aa
 aa
@@ -7085,28 +8203,28 @@ aa
 aa
 aa
 aa
+aZ
+cl
+cu
+cA
+aZ
 aa
 aa
+aY
+dc
+di
+dq
+du
+aY
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+dJ
+ea
+ep
+cu
+cu
+ex
+dC
 aa
 aa
 aa
@@ -7187,28 +8305,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+aY
+aI
+cu
+cB
+aY
+cL
+cL
+cU
+cJ
+dj
+dG
+cJ
+aY
+cL
+cL
+dK
+et
+dX
+eh
+cu
+ex
+dC
 aa
 aa
 aa
@@ -7289,28 +8407,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+aZ
+co
+cv
+cC
+cH
+cM
+cM
+cV
+dd
+di
+dM
+dl
+cH
+dD
+dV
+dL
+eu
+cQ
+cu
+cu
+ex
+dC
 aa
 aa
 aa
@@ -7391,28 +8509,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+aZ
+cn
+cw
+cD
+cI
+cu
+cu
+cW
+cD
+cx
+dP
+cu
+dw
+dE
+dE
+dW
+dR
+dY
+ei
+ek
+ey
+dC
 aa
 aa
 aa
@@ -7493,28 +8611,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+aZ
+cp
+cx
+bQ
+cE
+cN
+cN
+cP
+cR
+cX
+dQ
+dv
+dB
+dF
+dH
+dN
+ev
+dZ
+cu
+cu
+ex
+dC
 aa
 aa
 aa
@@ -7595,28 +8713,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+aY
+aJ
+cx
+aY
+aY
+cL
+cL
+cY
+cJ
+dm
+dr
+cJ
+aY
+cL
+cL
+dJ
+eb
+eq
+cu
+el
+ex
+dC
 aa
 aa
 aa
@@ -7697,28 +8815,28 @@ aa
 aa
 aa
 aa
+aZ
+cr
+cx
+cF
+aZ
 aa
 aa
+aY
+df
+di
+dd
+dx
+aY
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+dJ
+eb
+er
+cu
+ej
+ez
+dC
 aa
 aa
 aa
@@ -7799,28 +8917,28 @@ aa
 aa
 aa
 aa
+aZ
+cs
+cy
+cG
+aZ
 aa
 aa
+aY
+dg
+di
+dp
+dx
+aY
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+dJ
+dU
+en
+es
+em
+eA
+dC
 aa
 aa
 aa
@@ -7901,28 +9019,28 @@ aa
 aa
 aa
 aa
+aY
+aZ
+aZ
+aZ
+aY
 aa
+cS
+cZ
+da
+dn
+ds
+da
+dy
+dA
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+dJ
+aY
+aY
+cL
+cL
+aY
+aY
 aa
 aa
 aa
@@ -8007,6 +9125,7 @@ aa
 aa
 aa
 aa
+cK
 aa
 aa
 aa
@@ -8017,8 +9136,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+dO
 aa
 aa
 aa
@@ -9395,7 +10513,7 @@ aa
 aa
 aa
 aa
-aa
+eg
 aa
 aa
 aa

--- a/maps/away/unishi/unishi-1.dmm
+++ b/maps/away/unishi/unishi-1.dmm
@@ -247,6 +247,9 @@
 	tag_exterior_door = "left_shuttle_outer";
 	tag_interior_door = "left_shuttle_inner"
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "aJ" = (
@@ -259,6 +262,9 @@
 	tag_chamber_sensor = "right_shuttle_sensor";
 	tag_exterior_door = "right_shuttle_outer";
 	tag_interior_door = "right_shuttle_inner"
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
@@ -399,7 +405,7 @@
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
 "aZ" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/wallframe_spawn/phoron,
 /obj/machinery/door/blast/regular{
 	dir = 1;
 	id_tag = "auxbar";
@@ -753,9 +759,6 @@
 /turf/simulated/floor,
 /area/unishi/engineroom)
 "bQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
@@ -809,6 +812,7 @@
 /obj/item/weapon/rcd_ammo/large,
 /obj/item/weapon/rcd_ammo/large,
 /obj/item/weapon/rcd_ammo/large,
+/obj/item/weapon/rpd,
 /turf/simulated/floor,
 /area/unishi/engineroom)
 "bZ" = (
@@ -999,31 +1003,6 @@
 	icon_state = "shuttle_chair_preview";
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/New_Horizons)
-"cB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/structure/fuel_port,
-/turf/simulated/wall/titanium,
-/area/ship/New_Horizons)
-"cC" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0;
-	req_access = newlist()
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "cD" = (
@@ -1033,22 +1012,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "cE" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/New_Horizons)
-"cF" = (
-/obj/structure/bed/chair/shuttle/black{
-	icon_state = "shuttle_chair_preview";
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/wallframe_spawn/phoron,
+/obj/machinery/door/blast/regular{
+	dir = 1;
+	id_tag = "auxbar";
+	name = "Blast Shutters"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
@@ -1061,8 +1030,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "cH" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/wallframe_spawn/phoron,
+/obj/machinery/door/blast/regular{
+	dir = 1;
+	id_tag = "auxbar";
+	name = "Blast Shutters"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "cI" = (
@@ -1070,7 +1044,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "cJ" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/wallframe_spawn/phoron,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "cK" = (
@@ -1087,10 +1061,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "cN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "cO" = (
@@ -1110,13 +1081,12 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	icon_state = "map";
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "0-2";
 	d2 = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
@@ -1130,15 +1100,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "cR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 1
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "cS" = (
@@ -1149,9 +1116,12 @@
 /turf/simulated/floor,
 /area/ship/New_Horizons)
 "cT" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/access_button/airlock_exterior{
 	master_tag = "left_shuttle"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 6
 	},
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
@@ -1188,15 +1158,12 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 1
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "cY" = (
@@ -1207,16 +1174,19 @@
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
 "cZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/access_button/airlock_exterior{
 	frequency = 1380;
 	master_tag = "right_shuttle"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 10
+	},
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
 "da" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/wallframe_spawn/phoron,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "db" = (
@@ -1430,26 +1400,31 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "dv" = (
-/obj/machinery/light{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 1
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dw" = (
+/obj/machinery/light{
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/New_Horizons)
-"dw" = (
-/obj/machinery/door/airlock/engineering,
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "dx" = (
@@ -1464,10 +1439,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/New_Horizons)
-"dy" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
 "dz" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -1488,16 +1459,13 @@
 /turf/simulated/floor,
 /area/ship/New_Horizons)
 "dB" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 9
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/wallframe_spawn/phoron,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "dC" = (
@@ -1512,7 +1480,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "dE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/radiation,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "dF" = (
@@ -1521,7 +1495,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/closet/radiation,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "dG" = (
@@ -1537,45 +1512,34 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "dH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/New_Horizons)
-"dI" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	controlled = 0;
-	dir = 4;
-	frequency = 1331;
-	id_tag = "calypso_cargo_pump"
-	},
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
 "dJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 8
+/obj/machinery/alarm,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
 "dK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	icon_state = "map";
-	dir = 1
-	},
-/obj/machinery/alarm,
-/turf/simulated/wall/titanium,
-/area/ship/New_Horizons)
-"dL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"dL" = (
+/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/blast/regular{
+	dir = 1;
+	id_tag = "raddoor";
+	name = "Blast Shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "dM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -1587,10 +1551,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "dN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -1599,15 +1559,10 @@
 /obj/machinery/button/blast_door{
 	id_tag = "raddoor"
 	},
-/turf/simulated/wall/titanium,
-/area/ship/New_Horizons)
-"dO" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	frequency = 1379;
-	id_tag = "unishi_vent"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
 "dP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -1622,20 +1577,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "dQ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	icon_state = "map";
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "dR" = (
@@ -1679,24 +1622,22 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "dW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/red,
-/obj/machinery/door/airlock/engineering,
-/obj/machinery/door/blast/regular{
-	dir = 1;
-	id_tag = "raddoor";
-	name = "Blast Shutters"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/New_Horizons)
-"dX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"dX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/wall/titanium,
 /area/ship/New_Horizons)
 "dY" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -1832,6 +1773,9 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "eq" = (
@@ -1874,11 +1818,6 @@
 /area/ship/New_Horizons)
 "es" = (
 /obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/New_Horizons)
-"et" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red,
-/obj/structure/closet/secure_closet/engineering_welding,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
 "eu" = (
@@ -1954,6 +1893,55 @@
 /obj/structure/window/phoronreinforced,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/New_Horizons)
+"gb" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"gO" = (
+/obj/machinery/atmospherics/omni/filter,
+/turf/simulated/floor,
+/area/unishi/engineroom)
+"oi" = (
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor,
+/area/unishi/engineroom)
+"qn" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"se" = (
+/obj/structure/fuel_port,
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"vu" = (
+/obj/machinery/alarm{
+	icon_state = "alarm0";
+	dir = 1
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"ww" = (
+/obj/machinery/power/port_gen/pacman/super/potato,
+/obj/structure/cable{
+	icon_state = "0-8";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"Fv" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
 "FR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -1966,6 +1954,39 @@
 	},
 /turf/simulated/wall,
 /area/unishi/engineering)
+"LM" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1380;
+	id_tag = "right_shuttle_pump_internal"
+	},
+/turf/simulated/floor,
+/area/ship/New_Horizons)
+"Pw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/wallframe_spawn/phoron,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/New_Horizons)
+"PQ" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"Qs" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 8
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
+"Uq" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/simulated/wall/titanium,
+/area/ship/New_Horizons)
 
 (1,1,1) = {"
 aa
@@ -7098,8 +7119,8 @@ dS
 bc
 bc
 bB
-aU
-bP
+oi
+gO
 bV
 cc
 ce
@@ -7912,7 +7933,7 @@ dt
 aa
 aa
 aa
-dI
+aa
 aa
 aa
 aa
@@ -8005,16 +8026,16 @@ aZ
 aZ
 aY
 aa
-cO
+aa
 cT
 da
 dh
 dk
 da
-dy
-dz
+Uq
 aa
-dJ
+aa
+dX
 aY
 aY
 cL
@@ -8108,15 +8129,15 @@ cz
 aZ
 aa
 aa
-aY
+Qs
 db
 di
 do
 du
+gb
+aa
+aa
 aY
-aa
-aa
-dJ
 ea
 eo
 ee
@@ -8209,17 +8230,17 @@ cu
 cA
 aZ
 aa
-aa
-aY
+cO
+Fv
 dc
 di
 dq
 du
-aY
-aa
-aa
-dJ
-ea
+qn
+dz
+LM
+dH
+ww
 ep
 cu
 cu
@@ -8308,8 +8329,8 @@ aa
 aY
 aI
 cu
-cB
-aY
+cx
+se
 cL
 cL
 cU
@@ -8320,9 +8341,9 @@ cJ
 aY
 cL
 cL
-dK
-et
-dX
+dJ
+dQ
+dW
 eh
 cu
 ex
@@ -8410,7 +8431,7 @@ aa
 aZ
 co
 cv
-cC
+di
 cH
 cM
 cM
@@ -8419,10 +8440,10 @@ dd
 di
 dM
 dl
-cH
+Pw
 dD
 dV
-dL
+dK
 eu
 cQ
 cu
@@ -8521,10 +8542,10 @@ cD
 cx
 dP
 cu
-dw
-dE
-dE
-dW
+cI
+cu
+cu
+dL
 dR
 dY
 ei
@@ -8621,11 +8642,11 @@ cN
 cP
 cR
 cX
-dQ
 dv
+dw
 dB
+dE
 dF
-dH
 dN
 ev
 dZ
@@ -8716,8 +8737,8 @@ aa
 aY
 aJ
 cx
-aY
-aY
+cu
+vu
 cL
 cL
 cY
@@ -8728,7 +8749,7 @@ cJ
 aY
 cL
 cL
-dJ
+aY
 eb
 eq
 cu
@@ -8818,19 +8839,19 @@ aa
 aZ
 cr
 cx
-cF
+cr
 aZ
-aa
-aa
-aY
+cK
+cS
+Uq
 df
 di
 dd
 dx
+PQ
+dA
+LM
 aY
-aa
-aa
-dJ
 eb
 er
 cu
@@ -8924,15 +8945,15 @@ cG
 aZ
 aa
 aa
-aY
+Qs
 dg
 di
 dp
 dx
+Qs
+aa
+aa
 aY
-aa
-aa
-dJ
 dU
 en
 es
@@ -9025,16 +9046,16 @@ aZ
 aZ
 aY
 aa
-cS
+aa
 cZ
 da
 dn
 ds
 da
-dy
-dA
+Fv
 aa
-dJ
+aa
+aY
 aY
 aY
 cL
@@ -9125,7 +9146,6 @@ aa
 aa
 aa
 aa
-cK
 aa
 aa
 aa
@@ -9136,7 +9156,8 @@ aa
 aa
 aa
 aa
-dO
+aa
+aa
 aa
 aa
 aa

--- a/maps/away/unishi/unishi.dm
+++ b/maps/away/unishi/unishi.dm
@@ -1,5 +1,6 @@
 #include "unishi_areas.dm"
 #include "unishi_jobs.dm"
+#include "unishi_shuttles.dm"
 
 /obj/effect/submap_landmark/joinable_submap/unishi
 	name = "SRV Verne"
@@ -13,39 +14,14 @@
 		/datum/job/submap/unishi_researcher
 	)
 
-/obj/effect/overmap/visitable/ship/unishi
-	name = "SRV Verne"
-	desc = "Sensor array detects unknown class medium size vessel. The vessel appears unarmed.\
-	A small amount of radiation has been detected at the aft of the ship"
-	vessel_mass = 5000
-	max_speed = 1/(3 SECONDS)
-	initial_generic_waypoints = list(
-		"nav_unishi_1",
-		"nav_unishi_2",
-		"nav_unishi_3",
-	)
-
 /datum/map_template/ruin/away_site/unishi
 	name = "University Ship"
 	id = "awaysite_unishi"
 	description = "CTI research ship.."
 	suffixes = list("unishi/unishi-1.dmm", "unishi/unishi-2.dmm", "unishi/unishi-3.dmm")
+	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/New_Horizons)
 	cost = 2
-	area_usage_test_exempted_root_areas = list(/area/unishi)
-
-
-/obj/effect/shuttle_landmark/nav_unishi/nav1
-	name = "CTI Research Vessel Deck 1 Port"
-	landmark_tag = "nav_unishi_1"
-
-/obj/effect/shuttle_landmark/nav_unishi/nav2
-	name = "CTI Research Vessel Deck 2 Starboard"
-	landmark_tag = "nav_unishi_2"
-
-/obj/effect/shuttle_landmark/nav_unishi/nav3
-	name = "CTI Research Vessel Deck 3 Aft"
-	landmark_tag = "nav_unishi_3"
-
+	area_usage_test_exempted_root_areas = list(/area/unishi, /area/ship)
 
 /obj/machinery/power/supermatter/randomsample
 	name = "experimental supermatter sample"
@@ -170,4 +146,4 @@ obj/item/weapon/paper/prof2
 
 /datum/chemical_reaction/clonexadone/nophoron
 	required_reagents = list(/datum/reagent/cryoxadone = 1, /datum/reagent/sodium = 1, /datum/reagent/toxin/phoron/safe = 0.1)
-
+	

--- a/maps/away/unishi/unishi_areas.dm
+++ b/maps/away/unishi/unishi_areas.dm
@@ -68,3 +68,7 @@
 /area/unishi/smresearch
 	name = "\improper Supermatter Research Area"
 	icon_state = "smresearch"
+
+/area/ship/New_Horizons
+	name = "New Horizons"
+	icon_state = "shuttle3"

--- a/maps/away/unishi/unishi_shuttles.dm
+++ b/maps/away/unishi/unishi_shuttles.dm
@@ -1,0 +1,64 @@
+/obj/machinery/computer/shuttle_control/explore/New_Horizons
+	name = "New Horizons control console"
+	shuttle_tag = "New Horizons"
+
+/obj/effect/overmap/visitable/ship/unishi
+	name = "SRV Verne"
+	desc = "Sensor array detects unknown class medium size vessel. The vessel appears unarmed.\
+	A small amount of radiation has been detected at the aft of the ship"
+	vessel_mass = 5000
+	max_speed = 1/(3 SECONDS)
+	initial_generic_waypoints = list(
+		"nav_unishi_1",
+		"nav_unishi_2",
+		"nav_unishi_3",
+	)
+	initial_restricted_waypoints = list(
+		"New Horizons" = list("nav_unishi_dock")
+	)
+
+/datum/shuttle/autodock/overmap/New_Horizons
+	name = "New Horizons"
+	move_time = 10
+	shuttle_area = list(/area/ship/New_Horizons)
+	dock_target = "New_Horizons"
+	current_location = "nav_unishi_dock"
+	landmark_transition = "nav_unishi_transit"
+	range = 3
+	fuel_consumption = 4
+	ceiling_type = /turf/simulated/floor/shuttle_ceiling/
+	skill_needed = SKILL_NONE
+	defer_initialisation = TRUE
+
+/obj/effect/overmap/visitable/ship/landable/New_Horizons
+	name = "New Horizons"
+	shuttle = "New Horizons"
+	initial_generic_waypoints = list(
+		"nav_unishi_1",
+		"nav_unishi_2",
+		"nav_unishi_3",
+	)
+	fore_dir = WEST
+	vessel_size = SHIP_SIZE_SMALL
+
+/obj/effect/shuttle_landmark/nav_unishi/New_Horizons
+	name = "unishi shuttle Dock"
+	landmark_tag = "nav_unishi_dock"
+	base_area = /area/space
+	base_turf = /turf/simulated/floor/tiled/techfloor
+
+/obj/effect/shuttle_landmark/transit/nav_unishi/New_Horizons
+	name = "In transit"
+	landmark_tag = "nav_unishi_transit"
+
+/obj/effect/shuttle_landmark/nav_unishi/nav1
+	name = "CTI Research Vessel Deck 1 Port"
+	landmark_tag = "nav_unishi_1"
+
+/obj/effect/shuttle_landmark/nav_unishi/nav2
+	name = "CTI Research Vessel Deck 2 Starboard"
+	landmark_tag = "nav_unishi_2"
+
+/obj/effect/shuttle_landmark/nav_unishi/nav3
+	name = "CTI Research Vessel Deck 3 Aft"
+	landmark_tag = "nav_unishi_3"


### PR DESCRIPTION

![unishi 1](https://user-images.githubusercontent.com/62187092/79173515-caa40e80-7dc5-11ea-8af4-d8b4942b6c04.png)

![unishi 2](https://user-images.githubusercontent.com/62187092/79173581-ff17ca80-7dc5-11ea-9973-ab4de9c170c7.png)

![unishi 3](https://user-images.githubusercontent.com/62187092/79173592-08a13280-7dc6-11ea-9243-bcfc233bc403.png)

Adds in a functioning Overmap shuttle for the SRV Verne. This shuttle should serve as a potential escape ship or a scouting science vessel for research and exploration. Given the context of the Verne in game, Science is off the table for most of the survivors and just want a way to escape and find safety.

