### PR TITLE
Moves most lethal weapons from SEC-ARM to E-ARM/Replaces default smartgun with compact/Adds spare equipment to SEC/Excessive laser carbine purge

### DIFF
--- a/code/modules/boh_misc/boxes.dm
+++ b/code/modules/boh_misc/boxes.dm
@@ -51,7 +51,7 @@
 /obj/item/gunbox/attack_self(mob/living/user)
 	var/list/options = list()
 	options["Ballistic"] = list(/obj/item/weapon/gun/projectile/pistol/military/alt/solar,/obj/item/ammo_magazine/pistol/double/rubber)
-	options["Energy"] = list(/obj/item/weapon/gun/energy/gun/secure)
+	options["Energy"] = list(/obj/item/weapon/gun/energy/gun/small/secure)
 	options["Energy - Stun"] = list(/obj/item/weapon/gun/energy/stunrevolver/secure)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -78,7 +78,7 @@
 	firemodes = list(
 		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun),
 		list(mode_name="shock", projectile_type=/obj/item/projectile/beam/stun/shock),
-		list(mode_name="kill", projectile_type=/obj/item/projectile/beam),
+		list(mode_name="kill", projectile_type=/obj/item/projectile/beam/smalllaser),
 		)
 
 	var/fail_counter = 0

--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -6,10 +6,15 @@
 		slot_l_hand_str = 'icons/mob/onmob/items/lefthand_guns_secure.dmi',
 		slot_r_hand_str = 'icons/mob/onmob/items/righthand_guns_secure.dmi',
 		)
+	firemodes = list(
+		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun, modifystate="smallgunstun"),
+		list(mode_name="shock", projectile_type=/obj/item/projectile/beam/stun/shock, modifystate="smallgunshock"),
+		list(mode_name="kill", projectile_type=/obj/item/projectile/beam/tinylaser, modifystate="smallgunkill"),
+		)
 	req_access = list(list(access_brig, access_bridge))
 	authorized_modes = list(ALWAYS_AUTHORIZED, AUTHORIZED)
-	max_shots = 3
-	recharge_time = 8
+	max_shots = 5
+	recharge_time = 14
 	self_recharge = 1
 
 /obj/item/weapon/gun/energy/stunrevolver/secure

--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -14,7 +14,7 @@
 	req_access = list(list(access_brig, access_bridge))
 	authorized_modes = list(ALWAYS_AUTHORIZED, AUTHORIZED)
 	max_shots = 5
-	recharge_time = 14
+	recharge_time = 12
 	self_recharge = 1
 
 /obj/item/weapon/gun/energy/stunrevolver/secure

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -12,7 +12,7 @@
 	caliber = CALIBER_SHOTGUN
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2)
 	load_method = SINGLE_CASING
-	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
+	ammo_type = /obj/item/ammo_casing/shotgun
 	handle_casings = HOLD_CASINGS
 	one_hand_penalty = 8
 	bulk = 6
@@ -67,7 +67,6 @@
 	wielded_item_state = "cshotgun-wielded"
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	max_shells = 7 //match the ammo box capacity, also it can hold a round in the chamber anyways, for a total of 8.
-	ammo_type = /obj/item/ammo_casing/shotgun
 	one_hand_penalty = 8
 
 /obj/item/weapon/gun/projectile/shotgun/pump/combat/on_update_icon()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -25,8 +25,12 @@
 	damage = 2
 	eyeblur = 2
 
+/obj/item/projectile/beam/tinylaser
+	damage = 15
+
 /obj/item/projectile/beam/smalllaser
 	damage = 25
+	armor_penetration = 10
 
 /obj/item/projectile/beam/midlaser
 	damage = 45

--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -149,12 +149,11 @@
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/PPE
-	name = "Bridge primary cabinet"
+	name = "Bridge armor cabinet"
 	req_access = list(list(access_armory,access_emergency_armory,access_hos,access_hop,access_ce,access_cmo,access_rd,access_senadv,access_bridge))
 
 /obj/structure/closet/secure_closet/guncabinet/PPE/WillContain()
 	return list(
-		/obj/item/weapon/gun/energy/laser/secure = 4,
 		/obj/item/clothing/suit/armor/pcarrier/medium/command = 4,
 		/obj/item/clothing/head/helmet/solgov/command = 4
 	)

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -3603,11 +3603,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
-/obj/structure/closet/secure_closet/guncabinet,
-/obj/item/weapon/gun/energy/laser/secure,
-/obj/item/weapon/gun/energy/laser/secure,
-/obj/item/weapon/gun/energy/laser/secure,
-/obj/item/weapon/gun/energy/laser/secure,
+/obj/structure/closet/secure_closet/guncabinet/sidearm/small,
 /turf/simulated/floor/tiled/steel_grid,
 /area/defturrets)
 "gR" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -488,8 +488,7 @@
 	dir = 4
 	},
 /obj/structure/table/rack,
-/obj/item/weapon/gun/projectile/shotgun/pump/combat,
-/obj/item/weapon/gun/projectile/shotgun/pump/combat,
+/obj/item/weapon/gun/energy/plasmastun,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "aaP" = (
@@ -555,7 +554,8 @@
 	dir = 1
 	},
 /obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/gun/projectile/shotgun/pump/beanbag,
+/obj/item/weapon/storage/box/ammo/solar/rubber,
+/obj/item/weapon/storage/box/ammo/solar/rubber,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "aaU" = (
@@ -578,9 +578,16 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/gun/energy/taser/carbine,
-/obj/item/weapon/gun/energy/taser/carbine,
-/obj/item/weapon/gun/energy/stunrevolver/rifle,
+/obj/item/weapon/storage/belt/security,
+/obj/item/weapon/storage/belt/security,
+/obj/item/weapon/storage/belt/holster/forensic,
+/obj/item/weapon/storage/belt/holster/security,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/drop_pouches/black,
+/obj/item/clothing/accessory/storage/drop_pouches/black,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/item/clothing/accessory/storage/holster/thigh,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "aaW" = (
@@ -1029,8 +1036,11 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/table/rack,
-/obj/item/weapon/gun/projectile/shotgun/sabotgun,
+/obj/machinery/door/window/brigdoor/eastright{
+	req_access = list("ACCESS_ARMORY")
+	},
 /obj/item/weapon/storage/box/ammo/sabotbox,
+/obj/item/weapon/gun/projectile/shotgun/sabotgun,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "abI" = (
@@ -1080,9 +1090,8 @@
 	dir = 1;
 	health = 1e+006
 	},
-/obj/item/weapon/storage/box/ammo/beanbags/full,
-/obj/item/weapon/storage/box/ammo/beanbags/full,
-/obj/item/clothing/accessory/storage/bandolier,
+/obj/item/weapon/melee/baton/loaded,
+/obj/item/weapon/melee/baton/loaded,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "abL" = (
@@ -1780,9 +1789,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/weapon/storage/box/ammo/solar/rubber,
-/obj/item/weapon/storage/box/ammo/solar/rubber,
-/obj/item/weapon/storage/box/ammo/solar/rubber,
+/obj/item/weapon/storage/box/ammo/solar/full,
+/obj/item/weapon/storage/box/ammo/solar/full,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "adi" = (
@@ -1813,10 +1821,8 @@
 	dir = 8;
 	health = 1e+006
 	},
-/obj/item/ammo_magazine/smg_top/rubber,
-/obj/item/ammo_magazine/smg_top/rubber,
-/obj/item/ammo_magazine/smg_top/rubber,
-/obj/item/ammo_magazine/smg_top/rubber,
+/obj/item/gunbox,
+/obj/item/gunbox,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "adk" = (
@@ -1836,8 +1842,20 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head/aux)
 "adl" = (
-/obj/machinery/weapons_fabricator,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/clothing/suit/armor/pcarrier/medium/security,
+/obj/item/clothing/suit/armor/pcarrier/medium/security,
+/obj/item/clothing/head/helmet/solgov/security,
+/obj/item/clothing/head/helmet/solgov/security,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "adm" = (
@@ -2314,8 +2332,8 @@
 	health = 1e+006
 	},
 /obj/structure/table/rack,
-/obj/item/weapon/gun/energy/laser/secure,
-/obj/item/weapon/gun/energy/laser/secure,
+/obj/item/weapon/gun/projectile/shotgun/pump/beanbag,
+/obj/item/weapon/gun/projectile/shotgun/pump/beanbag,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "aee" = (
@@ -2401,7 +2419,11 @@
 	dir = 4
 	},
 /obj/structure/table/rack,
-/obj/item/weapon/gun/energy/plasmastun,
+/obj/item/weapon/storage/box/ammo/beanbags/full,
+/obj/item/weapon/storage/box/ammo/beanbags/full,
+/obj/item/weapon/storage/box/ammo/beanbags/full,
+/obj/item/clothing/accessory/storage/bandolier,
+/obj/item/clothing/accessory/storage/bandolier,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "aen" = (
@@ -2977,10 +2999,13 @@
 	c_tag = "Security Wing - Armory";
 	dir = 8
 	},
-/obj/machinery/computer/rdconsole/robotics{
-	dir = 8;
-	name = "security fabrication console";
-	req_access = list("ACCESS_BRIG")
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
@@ -3530,7 +3555,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/robotics)
 "agj" = (
-/obj/item/weapon/storage/box/ammo/shotgunammo/full,
 /obj/structure/table/rack/shelf/steel,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3541,7 +3565,6 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/weapon/storage/box/ammo/shotgunammo/full,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "agk" = (
@@ -4054,9 +4077,9 @@
 	dir = 8;
 	health = 1e+006
 	},
-/obj/item/weapon/gun/energy/stunrevolver/rifle,
-/obj/item/weapon/gun/energy/taser/carbine,
-/obj/item/weapon/gun/energy/taser/carbine,
+/obj/item/weapon/gun/energy/laser/secure,
+/obj/item/weapon/gun/energy/laser/secure,
+/obj/item/weapon/gun/energy/laser/secure,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
 "ahb" = (
@@ -7798,8 +7821,10 @@
 	health = 1e+006
 	},
 /obj/structure/table/rack,
-/obj/item/weapon/gun/projectile/automatic/sec_smg,
-/obj/item/weapon/gun/projectile/automatic/sec_smg,
+/obj/item/weapon/gun/energy/taser/carbine,
+/obj/item/weapon/gun/energy/taser/carbine,
+/obj/item/weapon/gun/energy/taser/carbine,
+/obj/item/weapon/gun/energy/taser/carbine,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "any" = (
@@ -7961,9 +7986,8 @@
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
-/obj/item/weapon/storage/box/fragshells,
-/obj/item/weapon/storage/box/fragshells,
-/obj/item/weapon/gun/launcher/grenade,
+/obj/item/weapon/gun/energy/stunrevolver/rifle,
+/obj/item/weapon/gun/energy/stunrevolver/rifle,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "anL" = (
@@ -21039,9 +21063,8 @@
 	dir = 8;
 	health = 1e+006
 	},
-/obj/item/weapon/gun/energy/laser/secure,
-/obj/item/weapon/gun/energy/laser/secure,
-/obj/item/weapon/gun/energy/laser/secure,
+/obj/item/weapon/gun/projectile/shotgun/pump,
+/obj/item/weapon/gun/projectile/shotgun/pump,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
 "hGb" = (
@@ -30353,9 +30376,10 @@
 	dir = 8;
 	health = 1e+006
 	},
-/obj/item/weapon/gun/energy/gun/secure,
-/obj/item/weapon/gun/energy/gun/secure,
-/obj/item/weapon/gun/energy/gun/secure,
+/obj/item/weapon/storage/box/ammo/shotgunammo/full,
+/obj/item/weapon/storage/box/ammo/shotgunammo/full,
+/obj/item/clothing/accessory/storage/bandolier,
+/obj/item/clothing/accessory/storage/bandolier,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
 "vkW" = (

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -3961,8 +3961,6 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/guncabinet/sidearm/small,
-/obj/item/weapon/gun/energy/laser/secure,
-/obj/item/weapon/gun/energy/laser/secure,
 /turf/simulated/floor/tiled/dark,
 /area/aquila/cockpit)
 "gt" = (


### PR DESCRIPTION
:cl: 
balance: Removes laser carbines, combat shotguns, gun printer/console from SEC-ARM. Replaces with 4 electrolasers, 4 smartguns, 2 stun rifles, 2 beanbag shotguns, 2 bandoliers, 3 heavy beanbag boxes, and 2 lethal 10mm boxes. Tectonic remains but has a windoor that requires armory access added to it. https://i.imgur.com/IRe5nr3.png

balance: For quality of life, 2 spare gun kits, stunbatons, plate carriers, helmets, holsters, black webbing/drop pouches, security belts and 1 of forensic and sec holster belt were added to SEC-ARM and Equipment storage respectively. https://i.imgur.com/T2ZASAN.png

balance: Rubber 10mm was moved to Equipment Storage.

balance: E-ARM now contains 2 pump shotguns, 3 laser carbines, 2 slug boxes, 2 bandoliers instead of its previous arsenal. https://i.imgur.com/NvOTdKM.png

balance: Removes laser carbines from Bridge equipment storage and Byakhee. Replaces laser carbine gun locker in anti-boarding control with compact smartguns.

maptweaks: Implements changes from above.

balance: Replaces normal smartgun from MAA equipment kit with a compact smartgun. It has 5 shots, a 15 damage laser with no AP, and recharges 1 shot every 12 seconds. 1 minute for full charge. It can't be charged in a charger.

balance: Readds AP to small laser. This has the side effect of buffing the antag holdout e-gun which didn't get changed to APless laser.

balance: Swaps advanced energy gun laser to small laser which has AP.

balance: Changes starting ammo for pump shotgun to be slugs instead of beanbag.

/:cl: