### PR TITLE
Voxship incinerator wall melting fix

### DIFF
--- a/maps/away/voxship/Vox_material.dm
+++ b/maps/away/voxship/Vox_material.dm
@@ -1,0 +1,61 @@
+/////////
+// Material Defines
+/////////
+#define GLASS_COLOR_ALIEN    "#3a5a9a"
+#define MATERIAL_GLASS_ALIEN "alien glass"
+#define MATERIAL_STROT_ALIEN "alien material"
+
+/////////
+// Alien Burnchamber Material - This will never be used by players, aside from off-site spawns.
+/////////
+/material/glass/alien
+	name = MATERIAL_GLASS_ALIEN
+	display_name = "durable glass composite"
+	wall_name = "bulkhead"
+	flags = MATERIAL_UNMELTABLE
+	stack_type = null
+	icon_colour = GLASS_COLOR_PHORON
+	integrity = 6800
+	melting_point = 16000
+	explosion_resistance = 1200
+	hardness = 500
+	weight = 500
+	construction_difficulty = MATERIAL_HARD_DIY
+	hidden_from_codex = TRUE
+	value = 100
+
+/material/alienwall
+	name = MATERIAL_STROT_ALIEN
+	display_name = "durable alloy"
+	wall_name = "bulkhead"
+	flags = MATERIAL_UNMELTABLE
+	stack_type = null
+	icon_colour = "#6c7364"
+	integrity = 6800
+	melting_point = 16000
+	explosion_resistance = 1200
+	hardness = 500
+	weight = 500
+	construction_difficulty = MATERIAL_HARD_DIY
+	hidden_from_codex = TRUE
+	value = 100
+
+/////////
+// Structure Types
+/////////
+/turf/simulated/wall/alienwall/New(var/newloc)
+	..(newloc, MATERIAL_STROT_ALIEN)
+
+/obj/effect/wallframe_spawn/alien
+	name = "alien wall frame window spawner"
+	icon_state = "p-wingrille"
+	win_path = /obj/structure/window/alien/full
+
+/obj/structure/window/alien
+	name = "alien window"
+	color = GLASS_COLOR_ALIEN
+	init_material = MATERIAL_GLASS_ALIEN
+
+/obj/structure/window/alien/full
+	dir = 5
+	icon_state = "window_full"

--- a/maps/away/voxship/Vox_material.dm
+++ b/maps/away/voxship/Vox_material.dm
@@ -1,13 +1,14 @@
 /////////
 // Material Defines
 /////////
+
 #define GLASS_COLOR_ALIEN    "#3a5a9a"
 #define MATERIAL_GLASS_ALIEN "alien glass"
-#define MATERIAL_STROT_ALIEN "alien material"
 
 /////////
 // Alien Burnchamber Material - This will never be used by players, aside from off-site spawns.
 /////////
+
 /material/glass/alien
 	name = MATERIAL_GLASS_ALIEN
 	display_name = "durable glass composite"
@@ -24,32 +25,9 @@
 	hidden_from_codex = TRUE
 	value = 100
 
-/material/alienwall
-	name = MATERIAL_STROT_ALIEN
-	display_name = "durable alloy"
-	wall_name = "bulkhead"
-	flags = MATERIAL_UNMELTABLE
-	stack_type = null
-	icon_colour = "#6c7364"
-	integrity = 6800
-	melting_point = 16000
-	explosion_resistance = 1200
-	hardness = 500
-	weight = 500
-	construction_difficulty = MATERIAL_HARD_DIY
-	hidden_from_codex = TRUE
-	value = 100
-
 /////////
 // Structure Types
 /////////
-/turf/simulated/wall/alienwall/New(var/newloc)
-	..(newloc, MATERIAL_STROT_ALIEN)
-
-/obj/effect/wallframe_spawn/alien
-	name = "alien wall frame window spawner"
-	icon_state = "p-wingrille"
-	win_path = /obj/structure/window/alien/full
 
 /obj/structure/window/alien
 	name = "alien window"

--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -1240,7 +1240,7 @@
 	icon_state = "intact";
 	maximum_pressure = 1e+006
 	},
-/turf/simulated/wall/ocp_wall,
+/turf/simulated/wall/alienwall,
 /area/voxship/engineering)
 "dw" = (
 /obj/machinery/door/blast/regular{
@@ -1825,7 +1825,7 @@
 /obj/machinery/button/ignition{
 	id_tag = "Voxignition"
 	},
-/turf/simulated/wall/ocp_wall,
+/turf/simulated/wall/alienwall,
 /area/voxship/engineering)
 "eX" = (
 /obj/structure/railing/mapped{
@@ -2073,8 +2073,8 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 1
 	},
-/obj/effect/paint/sun,
-/turf/simulated/wall/ocp_wall,
+/obj/structure/window/alien/full,
+/turf/simulated/floor/reinforced/airless,
 /area/voxship/engineering)
 "fB" = (
 /turf/simulated/mineral/random/high_chance,
@@ -4486,7 +4486,7 @@
 	id_tag = "VoxCombVent";
 	name = "Combustion Chamber Vent"
 	},
-/turf/simulated/wall/ocp_wall,
+/turf/simulated/wall/alienwall,
 /area/voxship/engineering)
 "kL" = (
 /obj/machinery/door/firedoor{
@@ -4713,7 +4713,7 @@
 /area/voxship/engineering)
 "lk" = (
 /obj/effect/paint/sun,
-/turf/simulated/wall/ocp_wall,
+/turf/simulated/wall/alienwall,
 /area/voxship/engineering)
 "ll" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
@@ -4767,7 +4767,7 @@
 	dir = 4
 	},
 /obj/effect/paint/sun,
-/turf/simulated/wall/ocp_wall,
+/turf/simulated/wall/alienwall,
 /area/voxship/engineering)
 "lt" = (
 /obj/structure/sign/warning/caution,
@@ -4817,12 +4817,12 @@
 	icon_state = "intact"
 	},
 /obj/effect/paint/sun,
-/turf/simulated/wall/ocp_wall,
+/turf/simulated/wall/alienwall,
 /area/voxship/engineering)
 "lz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/paint/sun,
-/turf/simulated/wall/ocp_wall,
+/turf/simulated/wall/alienwall,
 /area/voxship/engineering)
 "lA" = (
 /obj/structure/inflatable/door,
@@ -7623,6 +7623,11 @@
 /obj/machinery/robotics_fabricator,
 /turf/simulated/floor/plating/vox,
 /area/voxship/med)
+"Yr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/window/alien/full,
+/turf/simulated/floor/reinforced/airless,
+/area/voxship/engineering)
 
 (1,1,1) = {"
 ae
@@ -35375,7 +35380,7 @@ dw
 bj
 bQ
 dm
-lz
+Yr
 dn
 cG
 mC

--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -1011,10 +1011,6 @@
 /obj/item/weapon/card/emag_broken,
 /turf/simulated/floor/plating/vox,
 /area/voxship/ship_fore)
-"cN" = (
-/obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/plating/vox,
-/area/voxship/engineering)
 "cO" = (
 /obj/structure/railing/mapped,
 /obj/structure/closet/crate,
@@ -1210,10 +1206,6 @@
 	},
 /turf/simulated/floor/plating/vox,
 /area/voxship/engineering)
-"dr" = (
-/obj/structure/inflatable/door,
-/turf/simulated/floor/plating/vox,
-/area/voxship/engineering)
 "ds" = (
 /obj/structure/synthesized_instrument/synthesizer/minimoog,
 /turf/simulated/floor/tiled/techmaint/vox,
@@ -1240,7 +1232,7 @@
 	icon_state = "intact";
 	maximum_pressure = 1e+006
 	},
-/turf/simulated/wall/alienwall,
+/turf/simulated/wall/ocp_wall,
 /area/voxship/engineering)
 "dw" = (
 /obj/machinery/door/blast/regular{
@@ -1825,7 +1817,7 @@
 /obj/machinery/button/ignition{
 	id_tag = "Voxignition"
 	},
-/turf/simulated/wall/alienwall,
+/turf/simulated/wall/ocp_wall,
 /area/voxship/engineering)
 "eX" = (
 /obj/structure/railing/mapped{
@@ -4486,7 +4478,7 @@
 	id_tag = "VoxCombVent";
 	name = "Combustion Chamber Vent"
 	},
-/turf/simulated/wall/alienwall,
+/turf/simulated/wall/ocp_wall,
 /area/voxship/engineering)
 "kL" = (
 /obj/machinery/door/firedoor{
@@ -4713,7 +4705,7 @@
 /area/voxship/engineering)
 "lk" = (
 /obj/effect/paint/sun,
-/turf/simulated/wall/alienwall,
+/turf/simulated/wall/ocp_wall,
 /area/voxship/engineering)
 "ll" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
@@ -4767,7 +4759,7 @@
 	dir = 4
 	},
 /obj/effect/paint/sun,
-/turf/simulated/wall/alienwall,
+/turf/simulated/wall/ocp_wall,
 /area/voxship/engineering)
 "lt" = (
 /obj/structure/sign/warning/caution,
@@ -4814,15 +4806,18 @@
 "ly" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
-	icon_state = "intact"
+	icon_state = "intact";
+	maximum_pressure = 100000
 	},
 /obj/effect/paint/sun,
-/turf/simulated/wall/alienwall,
+/turf/simulated/wall/ocp_wall,
 /area/voxship/engineering)
 "lz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	maximum_pressure = 1e+006
+	},
 /obj/effect/paint/sun,
-/turf/simulated/wall/alienwall,
+/turf/simulated/wall/ocp_wall,
 /area/voxship/engineering)
 "lA" = (
 /obj/structure/inflatable/door,
@@ -6520,6 +6515,8 @@
 "pd" = (
 /obj/machinery/light,
 /obj/structure/table/rack,
+/obj/item/device/mmi,
+/obj/item/device/mmi,
 /turf/simulated/floor/tiled/white/usedup{
 	initial_gas = list("nitrogen" = 101.23)
 	},
@@ -7623,11 +7620,16 @@
 /obj/machinery/robotics_fabricator,
 /turf/simulated/floor/plating/vox,
 /area/voxship/med)
-"Yr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
+
+"Vb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	maximum_pressure = 1e+006
+	},
 /obj/structure/window/alien/full,
 /turf/simulated/floor/reinforced/airless,
 /area/voxship/engineering)
+
+
 
 (1,1,1) = {"
 ae
@@ -34568,7 +34570,7 @@ ao
 bb
 an
 cj
-cN
+dl
 bm
 bz
 dl
@@ -34770,7 +34772,7 @@ ae
 bB
 an
 cj
-dr
+lk
 ls
 ls
 lk
@@ -34972,7 +34974,7 @@ ae
 ab
 ab
 aZ
-cN
+lk
 dN
 oI
 cH
@@ -35380,7 +35382,7 @@ dw
 bj
 bQ
 dm
-Yr
+Vb
 dn
 cG
 mC

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -4,6 +4,7 @@
 #include "voxship_jobs.dm"
 #include "voxship_jobs_boh.dm"
 #include "voxship_access.dm"
+#include "Vox_material.dm"
 
 /datum/map_template/ruin/away_site/voxship
 	name = "Vox Ship"


### PR DESCRIPTION
This Makes the walls on the Incinerator wall completely unmeltable. Baystation made the default Osmium-Carbide walls impossible to use for incinerators. So this allows the incinerator to be used again without causing a gas leak