### PR TITLE
Makes the totally not swiss-knife only have one version with all tools.

### DIFF
--- a/code/game/objects/items/weapons/material/swiss.dm
+++ b/code/game/objects/items/weapons/material/swiss.dm
@@ -18,9 +18,9 @@
 	takes_colour = FALSE
 	valid_colors = null
 	max_force = 10
-
+	color = COLOR_NT_RED
 	var/active_tool = SWISSKNF_CLOSED
-	var/tools = list(SWISSKNF_LBLADE, SWISSKNF_CLIFTER, SWISSKNF_COPENER)
+	var/tools = list(SWISSKNF_LBLADE, SWISSKNF_SBLADE, SWISSKNF_CLIFTER, SWISSKNF_COPENER, SWISSKNF_CSCREW, SWISSKNF_GBLADE, SWISSKNF_WCUTTER, SWISSKNF_WBLADE, SWISSKNF_CROWBAR)
 	var/can_use_tools = FALSE
 	var/sharp_tools = list(SWISSKNF_LBLADE, SWISSKNF_SBLADE, SWISSKNF_GBLADE, SWISSKNF_WBLADE)
 
@@ -115,48 +115,6 @@
 			can_use_tools = FALSE
 			return
 	return ..()
-
-/obj/item/weapon/material/knife/folding/swiss/officer
-	name = "officer's combi-knife"
-	desc = "A small, blue, multi-purpose folding knife. This one adds a corkscrew."
-	color = COLOR_COMMAND_BLUE
-
-	tools = list(SWISSKNF_LBLADE, SWISSKNF_CLIFTER, SWISSKNF_COPENER, SWISSKNF_CSCREW)
-
-/obj/item/weapon/material/knife/folding/swiss/sec
-	name = "Master-At-Arms' combi-knife"
-	desc = "A small, red, multi-purpose folding knife. This one adds no special tools."
-	color = COLOR_NT_RED
-
-	tools = list(SWISSKNF_LBLADE, SWISSKNF_CLIFTER, SWISSKNF_COPENER)
-
-/obj/item/weapon/material/knife/folding/swiss/medic
-	name = "medic's combi-knife"
-	desc = "A small, green, multi-purpose folding knife. This one adds a smaller blade in place of the large blade and a glass cutter."
-	color = COLOR_OFF_WHITE
-
-	tools = list(SWISSKNF_SBLADE, SWISSKNF_CLIFTER, SWISSKNF_COPENER, SWISSKNF_GBLADE)
-
-/obj/item/weapon/material/knife/folding/swiss/engineer
-	name = "engineer's combi-knife"
-	desc = "A small, yellow, multi-purpose folding knife. This one adds a wood saw and wire cutters."
-	color = COLOR_AMBER
-
-	tools = list(SWISSKNF_LBLADE, SWISSKNF_SBLADE, SWISSKNF_CLIFTER, SWISSKNF_COPENER, SWISSKNF_WBLADE, SWISSKNF_WCUTTER)
-
-/obj/item/weapon/material/knife/folding/swiss/explorer
-	name = "explorer's combi-knife"
-	desc = "A small, purple, multi-purpose folding knife. This one adds a wood saw and pry bar."
-	color = COLOR_PURPLE
-
-	tools = list(SWISSKNF_LBLADE, SWISSKNF_SBLADE, SWISSKNF_CLIFTER, SWISSKNF_COPENER, SWISSKNF_WBLADE, SWISSKNF_CROWBAR)
-
-/obj/item/weapon/material/knife/folding/swiss/loot
-	name = "black combi-knife"
-	desc = "A small, silver, multi-purpose folding knife. This one adds a small blade and corkscrew."
-	color = COLOR_TITANIUM
-
-	tools = list(SWISSKNF_LBLADE, SWISSKNF_SBLADE, SWISSKNF_CLIFTER, SWISSKNF_COPENER, SWISSKNF_CSCREW)
 
 #undef SWISSKNF_CLOSED
 #undef SWISSKNF_LBLADE

--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -226,7 +226,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(books)
 
 /datum/gear/swiss
-	display_name = "multi-tool"
+	display_name = "combi-knife"
 	path = /obj/item/weapon/material/knife/folding/swiss
 	cost = 4
 	flags = GEAR_HAS_COLOR_SELECTION

--- a/maps/torch/structures/closets.dm
+++ b/maps/torch/structures/closets.dm
@@ -197,7 +197,7 @@
 		/obj/item/clothing/gloves/thick/duty/solgov/sec,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/weapon/storage/belt/security,
-		/obj/item/weapon/material/knife/folding/swiss/sec,
+		/obj/item/weapon/material/knife/folding/swiss,
 		/obj/item/weapon/storage/belt/medical/emt,
 		/obj/item/clothing/mask/gas/half,
 		/obj/item/weapon/storage/box/autoinjectors,

--- a/maps/torch/structures/closets/command.dm
+++ b/maps/torch/structures/closets/command.dm
@@ -46,7 +46,7 @@
 		/obj/item/weapon/material/clipboard,
 		/obj/item/device/holowarrant,
 		/obj/item/weapon/folder/blue,
-		/obj/item/weapon/material/knife/folding/swiss/officer,
+		/obj/item/weapon/material/knife/folding/swiss,
 		/obj/item/gunbox/captain,
 		/obj/item/weapon/sd_key,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/captain, /obj/item/weapon/storage/backpack/satchel/cap)),
@@ -75,7 +75,7 @@
 		/obj/item/weapon/material/clipboard,
 		/obj/item/device/holowarrant,
 		/obj/item/weapon/folder/blue,
-		/obj/item/weapon/material/knife/folding/swiss/officer,
+		/obj/item/weapon/material/knife/folding/swiss,
 		/obj/item/weapon/sd_key,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/captain, /obj/item/weapon/storage/backpack/satchel/cap)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/captain, /obj/item/weapon/storage/backpack/messenger/com))
@@ -99,7 +99,7 @@
 		/obj/item/weapon/material/clipboard,
 		/obj/item/device/holowarrant,
 		/obj/item/weapon/folder/blue,
-		/obj/item/weapon/material/knife/folding/swiss/officer,
+		/obj/item/weapon/material/knife/folding/swiss,
 		/obj/item/gunbox,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel/grey)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag, /obj/item/weapon/storage/backpack/messenger))
@@ -124,7 +124,7 @@
 		/obj/item/device/radio/headset/bridgeofficer,
 		/obj/item/device/radio/headset/bridgeofficer/alt,
 		/obj/item/weapon/storage/belt/general,
-		/obj/item/weapon/material/knife/folding/swiss/officer,
+		/obj/item/weapon/material/knife/folding/swiss,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel/grey)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag, /obj/item/weapon/storage/backpack/messenger)),
 		new /datum/atom_creator/weighted(list(/obj/item/device/flashlight, /obj/item/device/flashlight/flare, /obj/item/device/flashlight/flare/glowstick/random))

--- a/maps/torch/structures/closets/engineering.dm
+++ b/maps/torch/structures/closets/engineering.dm
@@ -64,7 +64,7 @@
 		/obj/item/device/holowarrant,
 		/obj/item/weapon/storage/box/armband/engine,
 		/obj/item/weapon/storage/box/secret_project_disks,
-		/obj/item/weapon/material/knife/folding/swiss/officer,
+		/obj/item/weapon/material/knife/folding/swiss,
 		/obj/item/clothing/head/hardhat/damage_control/White,
 		/obj/item/weapon/sd_key,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/industrial, /obj/item/weapon/storage/backpack/satchel/eng)),
@@ -91,7 +91,7 @@
 		/obj/item/taperoll/atmos,
 		/obj/item/clothing/gloves/insulated,
 		/obj/item/clothing/gloves/thick/duty/solgov/eng,
-		/obj/item/weapon/material/knife/folding/swiss/engineer,
+		/obj/item/weapon/material/knife/folding/swiss,
 		/obj/item/clothing/head/hardhat/damage_control,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/industrial, /obj/item/weapon/storage/backpack/satchel/eng)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/eng, /obj/item/weapon/storage/backpack/messenger/engi))
@@ -120,7 +120,7 @@
 		/obj/item/device/megaphone,
 		/obj/item/clothing/gloves/insulated,
 		/obj/item/clothing/gloves/thick/duty/solgov/eng,
-		/obj/item/weapon/material/knife/folding/swiss/engineer,
+		/obj/item/weapon/material/knife/folding/swiss,
 		/obj/item/clothing/head/hardhat/damage_control/Yellow,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/industrial, /obj/item/weapon/storage/backpack/satchel/eng)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/eng, /obj/item/weapon/storage/backpack/messenger/engi))

--- a/maps/torch/structures/closets/exploration.dm
+++ b/maps/torch/structures/closets/exploration.dm
@@ -49,7 +49,7 @@
 		/obj/item/device/radio/headset/pathfinder/alt,
 		/obj/item/weapon/storage/box/encryptionkey/exploration,
 		/obj/item/device/binoculars,
-		/obj/item/weapon/material/knife/folding/swiss/explorer,
+		/obj/item/weapon/material/knife/folding/swiss,
 		/obj/item/clothing/accessory/buddytag,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel/grey)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag, /obj/item/weapon/storage/backpack/messenger)),
@@ -74,7 +74,7 @@
 		/obj/item/device/radio/headset/exploration/alt,
 		/obj/item/device/binoculars,
 		/obj/item/clothing/accessory/buddytag,
-		/obj/item/weapon/material/knife/folding/swiss/explorer,
+		/obj/item/weapon/material/knife/folding/swiss,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel/grey)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag, /obj/item/weapon/storage/backpack/messenger)),
 		new /datum/atom_creator/weighted(list(/obj/item/device/flashlight, /obj/item/device/flashlight/flare, /obj/item/device/flashlight/flare/glowstick/random))
@@ -101,7 +101,7 @@
 		/obj/item/clothing/head/helmet/solgov/pilot,
 		/obj/item/clothing/head/helmet/solgov/pilot/fleet,
 		/obj/item/clothing/head/helmet/nt/pilot,
-		/obj/item/weapon/material/knife/folding/swiss/explorer,
+		/obj/item/weapon/material/knife/folding/swiss,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel/grey)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag, /obj/item/weapon/storage/backpack/messenger)),
 		new /datum/atom_creator/weighted(list(/obj/item/device/flashlight, /obj/item/device/flashlight/flare, /obj/item/device/flashlight/flare/glowstick/random))

--- a/maps/torch/structures/closets/medical.dm
+++ b/maps/torch/structures/closets/medical.dm
@@ -54,7 +54,7 @@
 		/obj/item/weapon/storage/firstaid/adv,
 		/obj/item/weapon/storage/box/armband/med,
 		/obj/item/weapon/storage/belt/general,
-		/obj/item/weapon/material/knife/folding/swiss/officer,
+		/obj/item/weapon/material/knife/folding/swiss,
 		/obj/item/weapon/sd_key,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/medic, /obj/item/weapon/storage/backpack/satchel/med)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/med, /obj/item/weapon/storage/backpack/messenger/med)),
@@ -84,7 +84,7 @@
 		/obj/item/device/flash,
 		/obj/item/device/megaphone,
 		/obj/item/weapon/storage/firstaid/adv,
-		/obj/item/weapon/material/knife/folding/swiss/medic,
+		/obj/item/weapon/material/knife/folding/swiss,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/medic, /obj/item/weapon/storage/backpack/satchel/med)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/med, /obj/item/weapon/storage/backpack/messenger/med)),
 		RANDOM_SCRUBS = 2
@@ -113,7 +113,7 @@
 		/obj/item/weapon/storage/firstaid/adv,
 		/obj/item/clothing/suit/storage/medical_chest_rig,
 		/obj/item/clothing/head/hardhat/EMS,
-		/obj/item/weapon/material/knife/folding/swiss/medic,
+		/obj/item/weapon/material/knife/folding/swiss,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/medic, /obj/item/weapon/storage/backpack/satchel/med)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/med, /obj/item/weapon/storage/backpack/messenger/med))
 	)

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -56,7 +56,7 @@
 		/obj/item/device/holowarrant,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/weapon/storage/belt/security,
-		/obj/item/weapon/material/knife/folding/swiss/sec,
+		/obj/item/weapon/material/knife/folding/swiss,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel/sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
 	)
@@ -95,7 +95,7 @@
 		/obj/item/device/flashlight/maglight,
 		/obj/item/device/taperecorder,
 		/obj/item/weapon/hand_labeler,
-		/obj/item/weapon/material/knife/folding/swiss/officer,
+		/obj/item/weapon/material/knife/folding/swiss,
 		/obj/item/weapon/sd_key,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel/sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
@@ -128,7 +128,7 @@
 		/obj/item/clothing/gloves/thick,
 		/obj/item/clothing/gloves/thick/duty/solgov/sec,
 		/obj/item/device/flashlight/maglight,
-		/obj/item/weapon/material/knife/folding/swiss/sec,
+		/obj/item/weapon/material/knife/folding/swiss,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel/sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
 	)
@@ -158,7 +158,7 @@
 		/obj/item/weapon/storage/belt/holster/security,
 		/obj/item/clothing/gloves/thick,
 		/obj/item/clothing/gloves/thick/duty/solgov/sec,
-		/obj/item/weapon/material/knife/folding/swiss/sec,
+		/obj/item/weapon/material/knife/folding/swiss,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel/sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
 	)


### PR DESCRIPTION
🆑Roland410
tweak:The default combi-knife (also known as multi-tool) now has all tools.
rscdel:"Specialized" versions have been removed, all of them use the default now.
/🆑