### PR TITLE
Blacklists IPCs from the Foundation Advisor role

### DIFF
--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -15,7 +15,7 @@
 		/datum/species/unathi  = list(HUMAN_ONLY_JOBS, /datum/job/representative), //Other jobs unavailable via branch restrictions,
 		/datum/species/unathi/yeosa = list(HUMAN_ONLY_JOBS, /datum/job/representative),
 		/datum/species/skrell  = list(HUMAN_ONLY_JOBS, /datum/job/representative),
-		/datum/species/machine = list(HUMAN_ONLY_JOBS, /datum/job/representative),
+		/datum/species/machine = list(HUMAN_ONLY_JOBS, /datum/job/representative, /datum/job/psiadvisor),
 		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/officer, /datum/job/warden),
 		/datum/species/sergal = list(HUMAN_ONLY_JOBS, /datum/job/representative),
 		/datum/species/akula = list(HUMAN_ONLY_JOBS, /datum/job/representative),
@@ -24,8 +24,7 @@
 		/datum/species/vasilissan= list(HUMAN_ONLY_JOBS, /datum/job/representative),
 		/datum/species/vulpkanin= list(HUMAN_ONLY_JOBS, /datum/job/representative),
 		/datum/species/customhuman= list(HUMAN_ONLY_JOBS, /datum/job/representative),
-		/datum/species/custom= list(HUMAN_ONLY_JOBS, /datum/job/representative),
-		//datum/species/tesh= list(HUMAN_ONLY_JOBS),
+		/datum/species/custom= list(HUMAN_ONLY_JOBS, /datum/job/representative)
 	)
 #undef HUMAN_ONLY_JOBS
 


### PR DESCRIPTION
🆑Roland410
tweak:Blacklists IPCs from the Foundation Advisor role, as per Loredev request.
/🆑
@ProbablyCarl Good for speedmerging if you want to.