### PR TITLE
Removes brain damage from awakening itself

### DIFF
--- a/code/modules/psionics/complexus/complexus_latency.dm
+++ b/code/modules/psionics/complexus/complexus_latency.dm
@@ -1,4 +1,4 @@
-/datum/psi_complexus/proc/check_latency_trigger(var/trigger_strength = 0, var/source, var/redactive = FALSE)
+/datum/psi_complexus/proc/check_latency_trigger(var/trigger_strength = 0, var/source)
 
 	if(!LAZYLEN(latencies))
 		return FALSE
@@ -11,5 +11,4 @@
 	owner.set_psi_rank(faculty, new_rank)
 	var/decl/psionic_faculty/faculty_decl = SSpsi.get_faculty(faculty)
 	to_chat(owner, SPAN_DANGER("You scream internally as your [faculty_decl.name] faculty is forced into operancy by [source]!"))
-	if(!redactive) owner.adjustBrainLoss(rand(trigger_strength * 2, trigger_strength * 4))
 	return TRUE


### PR DESCRIPTION
:cl:Roland410
tweak:Removes brain damage when awakening.
/:cl:
@ProbablyCarl Speeeedmeeerge if passes Travis please.

Internet is RIP rn, so can't test, but if it passes Travis it should be good to go I hope.
Prevents people from dying due to awakening giving brain damage itself lmao. Totally not an oversight when I was fixing shit.
Also totally not made this change on mobile.