### PR TITLE
Fixes Voxship runtime because doors

### DIFF
--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -757,6 +757,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/hatch{
+	autoset_access = 0;
 	name = "Quill Quarters";
 	req_access = list("ACCESS_VOXSHIP_CAPTAIN")
 	},


### PR DESCRIPTION
Fixes the Voxship runtime because of a door was set to autoset access while having access requirement set on it.