### PR TITLE
Fixes syndicate beacons needing power

### DIFF
--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -14,6 +14,7 @@
 
 	anchored = 1
 	density = 1
+	interact_offline = 1
 
 	var/temptext = ""
 	var/selfdestructing = 0


### PR DESCRIPTION
🆑Roland410
bugfix:Fixes syndicate beacons from xenoarch findings needing power.
/🆑
Currently if you do manage to get this, it can't be used because it's anchored in a powerless place, usually on an asteroid etc.