### PR TITLE
Revert "Revert "Makes all silicons have zero skills by default.""

### DIFF
--- a/code/modules/mob/skills/skillset_silicon.dm
+++ b/code/modules/mob/skills/skillset_silicon.dm
@@ -1,8 +1,6 @@
 /datum/skillset/silicon
-	skills_transferable = FALSE
-
-/datum/skillset/silicon/robot
 	default_value = SKILL_MIN
+	skills_transferable = FALSE
 
 // better handling for hard resets
 /mob/living/silicon/robot/reset_skillset()


### PR DESCRIPTION
Reverts BoHBranch/BoH-Bay#764
This was reverted for absolutely no fucking reason.