### PR TITLE
esword damage buff

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -121,7 +121,7 @@
 	name = "energy sword"
 	desc = "May the force be within you."
 	icon_state = "sword0"
-	active_force = 30
+	active_force = 50
 	active_throwforce = 20
 	force = 3
 	throwforce = 5


### PR DESCRIPTION
After a bit of discussion with Sparrow on the discord, we realized that the e-sword was massively underpowered. melee weapons for the most part are really bad on baycode due to the high amount of damage all ranged weapons do 

for reference, esword is 32 TC. It does 30 damage without this PR. the holdout kit, that comes with two magazines, a holdout pistol, and a silencer, is also 32 tc. The holdout does 40 damage, 10 more than the esword, is ranged, and is wayyy quieter than an esword (with the included silencer)

This PR buffs e-sword to do 50 damage instead of the previous 30. Now it does more damage than a holdout pistol which can fire faster and is ofc ranged
