### PR TITLE
[PORT] Forensics Borgs can now do forensics stuff

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -128,11 +128,26 @@
 	desc = "A simple grasping tool for holding and manipulating organic and mechanical organs, both internal and external."
 
 	can_hold = list(
-	/obj/item/organ,
-	/obj/item/robot_parts,
-	/obj/item/weapon/reagent_containers/ivbag
+		/obj/item/organ,
+		/obj/item/robot_parts,
+		/obj/item/weapon/reagent_containers/ivbag
 	)
-
+	
+/obj/item/weapon/gripper/forensics
+	name = "forensics gripper"
+	icon_state = "gripper"
+	desc = "A simple grasping tool for holding forensics evidence and paper."
+	
+	can_hold = list(
+		/obj/item/weapon/sample,
+		/obj/item/weapon/evidencebag,
+		/obj/item/weapon/forensics,
+		/obj/item/weapon/photo,
+		/obj/item/weapon/paper,
+		/obj/item/weapon/paper_bundle
+	)
+	
+	
 /obj/item/weapon/gripper/no_use //Used when you want to hold and put items in other things, but not able to 'use' the item
 
 /obj/item/weapon/gripper/no_use/attack_self(mob/user as mob)

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
@@ -16,6 +16,7 @@
 		/obj/item/weapon/storage/evidence,
 		/obj/item/weapon/forensics/sample_kit,
 		/obj/item/weapon/forensics/sample_kit/powder,
+		/obj/item/weapon/gripper/forensics,
 		/obj/item/device/flash,
 		/obj/item/borg/sight/hud/sec,
 		/obj/item/taperoll/police,


### PR DESCRIPTION
Gives Forensic (flying) borgs access to a Forensics Gripper™, which holds everything their forensics kit can hold.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->