### PR TITLE
Autolathe/Matter Tweaks

### DIFF
--- a/code/game/objects/items/devices/paint_gun.dm
+++ b/code/game/objects/items/devices/paint_gun.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "flpainter"
 	item_state = "fl_painter"
+	matter = list(MATERIAL_STEEL = 2500, MATERIAL_PLASTIC = 1000, MATERIAL_ALUMINIUM = 500)
 	desc = "A slender and none-too-sophisticated device capable of painting, erasing, and applying decals to most types of exosuits, floors and walls."
 
 	var/decal =        "remove all decals"

--- a/code/game/objects/items/plunger.dm
+++ b/code/game/objects/items/plunger.dm
@@ -9,7 +9,7 @@
 	w_class = 3
 	slot_flags = SLOT_HEAD | SLOT_MASK
 	hitsound = 'sound/effects/plunger.ogg'
-	matter = list("steel" = 5000)
+	matter = list(MATERIAL_STEEL = 300, MATERIAL_PLASTIC = 1500)
 
 /obj/item/device/plunger/robot
 	name = "plunger"

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/trash.dmi'
 	w_class = ITEM_SIZE_SMALL
 	desc = "This is rubbish."
-	matter = list(MATERIAL_PLASTIC = 50)
+	matter = list(MATERIAL_PLASTIC = 100)
 	var/age = 0
 
 /obj/item/trash/New(var/newloc, var/_age)
@@ -57,17 +57,17 @@
 /obj/item/trash/waffles
 	name = "waffles"
 	icon_state = "waffles"
-	matter = list(MATERIAL_ALUMINIUM = 50)
+	matter = list(MATERIAL_ALUMINIUM = 150)
 
 /obj/item/trash/plate
 	name = "plate"
 	icon_state = "plate"
-	matter = list(MATERIAL_GLASS = 80)
+	matter = list(MATERIAL_GLASS = 100)
 
 /obj/item/trash/snack_bowl
 	name = "snack bowl"
 	icon_state	= "snack_bowl"
-	matter = list(MATERIAL_PLASTIC = 150)
+	matter = list(MATERIAL_PLASTIC = 300)
 
 /obj/item/trash/pistachios
 	name = "pistachios pack"
@@ -80,12 +80,12 @@
 /obj/item/trash/fishegg
 	name = "caviar can"
 	icon_state = "fisheggs"
-	matter = list(MATERIAL_ALUMINIUM = 30)
+	matter = list(MATERIAL_ALUMINIUM = 100)
 
 /obj/item/trash/carpegg
 	name = "caviar can"
 	icon_state = "carpeggs"
-	matter = list(MATERIAL_ALUMINIUM = 30)
+	matter = list(MATERIAL_ALUMINIUM = 100)
 
 /obj/item/trash/salo
 	name = "salo pack"
@@ -127,22 +127,22 @@
 /obj/item/trash/beef
 	name = "empty can"
 	icon_state = "beef"
-	matter = list(MATERIAL_ALUMINIUM = 50)
+	matter = list(MATERIAL_ALUMINIUM = 100)
 
 /obj/item/trash/beans
 	name = "empty can"
 	icon_state = "beans"
-	matter = list(MATERIAL_ALUMINIUM = 50)
+	matter = list(MATERIAL_ALUMINIUM = 100)
 
 /obj/item/trash/tomato
 	name = "empty can"
 	icon_state = "tomato"
-	matter = list(MATERIAL_ALUMINIUM = 50)
+	matter = list(MATERIAL_ALUMINIUM = 100)
 
 /obj/item/trash/spinach
 	name = "empty can"
 	icon_state = "spinach"
-	matter = list(MATERIAL_ALUMINIUM = 50)
+	matter = list(MATERIAL_ALUMINIUM = 100)
 
 /obj/item/trash/cakewrap
 	name = "wrapper"

--- a/code/game/objects/items/weapons/storage/mre.dm
+++ b/code/game/objects/items/weapons/storage/mre.dm
@@ -7,7 +7,7 @@ MRE Stuff
 	desc = "A vacuum-sealed bag containing a day's worth of nutrients for an adult in strenuous situations. There is no visible expiration date on the package."
 	icon = 'icons/obj/food.dmi'
 	icon_state = "mre"
-	matter = list(MATERIAL_PLASTIC = 200, ALUMINIUM = 100)
+	matter = list(MATERIAL_PLASTIC = 300, MATERIAL_ALUMINIUM = 200)
 	storage_slots = 7
 	max_w_class = ITEM_SIZE_SMALL
 	opened = FALSE
@@ -123,7 +123,7 @@ MRE Stuff
 	desc = "A vacuum-sealed bag containing the MRE's main course. Self-heats when opened."
 	icon = 'icons/obj/food.dmi'
 	icon_state = "pouch_medium"
-	matter = list(MATERIAL_PLASTIC = 100, ALUMINIUM = 50)
+	matter = list(MATERIAL_PLASTIC = 200, MATERIAL_ALUMINIUM = 100)
 	storage_slots = 1
 	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_SMALL

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -3,7 +3,7 @@
 	desc = "A roll of sticky tape. Possibly for taping ducks... or was that ducts?"
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "taperoll"
-	matter = list(MATERIAL_PLASTIC = 1000, MATERIAL_ALUMINIUM = 100)
+	matter = list(MATERIAL_PLASTIC = 500, MATERIAL_ALUMINIUM = 100)
 	w_class = ITEM_SIZE_SMALL
 
 /obj/item/weapon/tape_roll/attack(var/mob/living/carbon/human/H, var/mob/user)

--- a/code/modules/fabrication/designs/general/designs_devices_components.dm
+++ b/code/modules/fabrication/designs/general/designs_devices_components.dm
@@ -5,6 +5,18 @@
 /datum/fabricator_recipe/device_component/keyboard
 	path = /obj/item/weapon/stock_parts/keyboard
 
+/datum/fabricator_recipe/device_component/matter_bin
+	path = /obj/item/weapon/stock_parts/matter_bin
+
+/datum/fabricator_recipe/device_component/manipulator
+	path = /obj/item/weapon/stock_parts/manipulator
+
+/datum/fabricator_recipe/device_component/micro_laser
+	path = /obj/item/weapon/stock_parts/micro_laser
+
+/datum/fabricator_recipe/device_component/capacitor
+	path = /obj/item/weapon/stock_parts/capacitor
+
 /datum/fabricator_recipe/device_component/tesla_component
 	path = /obj/item/weapon/stock_parts/power/apc/buildable
 
@@ -52,7 +64,7 @@
 	path = /obj/item/device/assembly/prox_sensor
 
 /datum/fabricator_recipe/device_component/cable_coil
-	path = /obj/item/stack/cable_coil/single
+	path = /obj/item/stack/cable_coil
 
 /datum/fabricator_recipe/device_component/electropack
 	path = /obj/item/device/radio/electropack
@@ -64,6 +76,9 @@
 
 /datum/fabricator_recipe/device_component/cell_device
 	path = /obj/item/weapon/cell/device/standard
+
+/datum/fabricator_recipe/device_component/cell
+	path = /obj/item/weapon/cell/standard
 
 /datum/fabricator_recipe/device_component/ecigcartridge
 	path = /obj/item/weapon/reagent_containers/ecig_cartridge/blank

--- a/code/modules/fabrication/designs/general/designs_tools.dm
+++ b/code/modules/fabrication/designs/general/designs_tools.dm
@@ -38,6 +38,9 @@
 /datum/fabricator_recipe/tool/minihoe
 	path = /obj/item/weapon/material/minihoe
 
+/datum/fabricator_recipe/tool/floor_painter
+	path = /obj/item/device/floor_painter
+
 /datum/fabricator_recipe/tool/welder_industrial
 	path = /obj/item/weapon/weldingtool/largetank
 	hidden = TRUE

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -119,6 +119,7 @@
 	desc = "A rapid and safe way to administer small amounts of drugs by untrained or trained personnel."
 	icon_state = "injector"
 	item_state = "autoinjector"
+	matter = list(MATERIAL_PLASTIC = 100, MATERIAL_GLASS = 50, MATERIAL_STEEL = 30)
 	amount_per_transfer_from_this = 5
 	volume = 5
 	origin_tech = list(TECH_MATERIAL = 2, TECH_BIO = 2)


### PR DESCRIPTION
A few additions to the autolathe alongside changes to the matter amount of some materials, including trash. In a nutshell:

- Raises the plastic value of trash (100 a piece), with 20 making one sheet of plastic
- Makes autoinjectors recyclable (100 plastic, 50 glass, 30 steel)
- Adds stock parts to the autolathe, including the basic matter bin, manipulator, capacitor and micro laser
- Adds the paint gun to the autolathe, a niche tool that's usually incredibly rare for some reason (2500 steel, 1000 plastic, 500 aluminium)
- Fixes typo in MRE matter values (ALUMINIUM instead of MATTER_ALUMINIUM)
- Cable coils now printed in stacks of 30 instead of a single piece (WHO DESIGNED THAT)
- Adds standard power cell (the big battery) to the autolathe
- Tweaks the plunger cost to be made of plastic (1500 plastic + 300 steel, from 6500 steel)

![image](https://user-images.githubusercontent.com/43841046/81621751-14235180-93a4-11ea-9774-130a1f169221.png)
