### PR TITLE
Lets Riflemen be Corporals (E4s) again

### DIFF
--- a/maps/torch/job/hestia_jobs.dm
+++ b/maps/torch/job/hestia_jobs.dm
@@ -152,7 +152,8 @@
 	allowed_ranks = list(
 		/datum/mil_rank/marine_corps/e1,
 		/datum/mil_rank/marine_corps/e2,
-		/datum/mil_rank/marine_corps/e3
+		/datum/mil_rank/marine_corps/e3,
+		/datum/mil_rank/marine_corps/e4
 	)
 	access = list(access_maint_tunnels, access_solgov_crew, access_petrov, access_petrov_security,
 			            access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy, access_hangar, access_guppy_helm, access_infantry,


### PR DESCRIPTION
I agree with removing E5 from the Rifleman role but E4 is a bit too much. Also, we follow the typical billet > rank so I doubt we will see E4 riflemen trying to go above the combat tech.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->