### PR TITLE
Gives the APA access to command comms & a maglight

### DIFF
--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -76,9 +76,10 @@
 		/obj/item/clothing/accessory/legguards,
 		/obj/item/clothing/glasses/sunglasses/big,
 		/obj/item/clothing/accessory/badge/nanotrasen,
-		/obj/item/device/radio/headset/heads/torchcorp,
-		/obj/item/device/radio/headset/heads/torchcorp/alt
-	)
+		/obj/item/device/flashlight/maglight,
+		/obj/item/device/radio/headset/heads/torchntcommand,
+		/obj/item/device/radio/headset/heads/torchntcommand/alt,
+		)
 
 /obj/structure/closet/secure_closet/representative
 	name = "\improper Sol Central Government representative's locker"

--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -78,7 +78,7 @@
 		/obj/item/clothing/accessory/badge/nanotrasen,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/device/radio/headset/heads/torchntcommand,
-		/obj/item/device/radio/headset/heads/torchntcommand/alt,
+		/obj/item/device/radio/headset/heads/torchntcommand/alt
 		)
 
 /obj/structure/closet/secure_closet/representative


### PR DESCRIPTION
Literally all the APA used to do was to grab the spare headset from the CLs locker, so this fixes this. I also added a maglight.

