### PR TITLE
Makes the MAA brassard available in loadout

### DIFF
--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -70,8 +70,13 @@
 	allowed_branches = list(/datum/mil_branch/fleet)
 
 /datum/gear/accessory/armband_ma
-	display_name = "master at arms brassard"
+	display_name = "master-at-arms brassard"
 	path = /obj/item/clothing/accessory/armband/solgov/ma
+	allowed_roles = SECURITY_ROLES
+
+/datum/gear/accessory/armband_mp
+	display_name = "military police brassard"
+	path = /obj/item/clothing/accessory/armband/solgov/mp
 	allowed_roles = SECURITY_ROLES
 
 /datum/gear/accessory/armband_security

--- a/maps/torch/loadout/loadout_accessories_boh.dm
+++ b/maps/torch/loadout/loadout_accessories_boh.dm
@@ -10,6 +10,11 @@
 	flags = GEAR_HAS_COLOR_SELECTION
 
 /datum/gear/accessory/armband_ma
+	display_name = "master-at-arms brassard"
+	path = /obj/item/clothing/accessory/armband/solgov/ma
+	allowed_roles = SECURITY_ROLES
+
+/datum/gear/accessory/armband_mp
 	display_name = "military police brassard"
 	path = /obj/item/clothing/accessory/armband/solgov/mp
 	allowed_roles = SECURITY_ROLES


### PR DESCRIPTION
- Adds the master-at-arms brassard into the accessories loadout section.

Looks like this just got flat-out replaced by the MP brassard during the port off Bay or something. Thanks, Hestia, very cool. Now masters-at-arms can have their shoulder thingy too.