### PR TITLE
Min. age tweaks for various jobs

### DIFF
--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -55,7 +55,7 @@
 	supervisors = "the Chief Engineer"
 	economic_power = 5
 	minimal_player_age = 0
-	minimum_character_age = list(SPECIES_HUMAN = 19)
+	minimum_character_age = list(SPECIES_HUMAN = 24)
 	alt_titles = list(
 		"Engine Technician",
 		"Damage Control Technician",

--- a/maps/torch/job/hestia_jobs.dm
+++ b/maps/torch/job/hestia_jobs.dm
@@ -93,7 +93,7 @@
 	economic_power = 4
 	minimal_player_age = 6
 	skill_points = 24
-	minimum_character_age = list(SPECIES_HUMAN = 24)
+	minimum_character_age = list(SPECIES_HUMAN = 22)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/infantry/combat_tech
 	min_skill = list(	SKILL_CONSTRUCTION = SKILL_ADEPT,
 						SKILL_ELECTRICAL   = SKILL_ADEPT,

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -7,7 +7,7 @@
 	supervisors = "the Executive Officer"
 	economic_power = 5
 	minimal_player_age = 0
-	minimum_character_age = list(SPECIES_HUMAN = 27)
+	minimum_character_age = list(SPECIES_HUMAN = 25)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/deckofficer
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,


### PR DESCRIPTION
- Combat technician min age from 24 to 22. It could potentially be pushed a tiny bit lower too, probably, but whatever.
- Engineer min age from 19 to 24. Ideally, the job would be split between full ship engineers and those who are more like just mechanics, but whatever.
- Deck officer from 27 to 25. The previous age reflects the fact that they were previously locked to high-ranking senior enlisted only; now, they can be relatively junior officers ever since the renaming of the job.