### PR TITLE
Removes infantry SL's thermals

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -11087,7 +11087,6 @@
 	},
 /obj/item/clothing/mask/gas/skrell,
 /obj/item/weapon/rig/military/infantry,
-/obj/item/rig_module/vision/multi,
 /turf/simulated/floor/tiled/monotile,
 /area/security/infantry/com)
 "sR" = (


### PR DESCRIPTION
- Infantry SL's thermals module has been removed. Considering that infantry are meant to avoid validhunting or generally interfering with sec affairs at all if they can avoid it, giving their SL a thermal vision module, of all things, seems excessive. You don't need thermals to hunt simplemobs on away sites.