### PR TITLE
Halves dionaea slowdown

### DIFF
--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -222,7 +222,7 @@
 	move_intents = list(/decl/move_intent/walk, /decl/move_intent/creep)
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/diona)
 	//primitive_form = "Nymph"
-	slowdown = 5
+	slowdown = 2.5
 	rarity_value = 3
 	hud_type = /datum/hud_data/diona
 	siemens_coefficient = 0.3


### PR DESCRIPTION
🆑Roland410
tweak:Halves dionaea slowdown.
/🆑
Dionaea machine go whoom, basically makes dionaea somewhat faster considering they can't run, and the huge slowdown they have makes it a pretty awful species to play when it takes five minutes to go from point A to point B.
Hopefully this will make them a bit more popular.