### PR TITLE
Force ERT Spawn

### DIFF
--- a/maps/antag_spawn/ert/ert.dm
+++ b/maps/antag_spawn/ert/ert.dm
@@ -1,6 +1,7 @@
 /datum/map_template/ruin/antag_spawn/ert
 	name = "ERT Base"
 	suffixes = list("ert/ert_base.dmm")
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 	shuttles_to_initialise = list(/datum/shuttle/autodock/multi/antag/rescue)
 	apc_test_exempt_areas = list(
 		/area/map_template/rescue_base = NO_SCRUBBER|NO_VENT|NO_APC


### PR DESCRIPTION
This is a very simple flag addition. Forces ERT base to spawn roundstart, so admins don't have to abuse the traitor panel to force a template load.
