### PR TITLE
Adds an new "energy Tectonic" to the SEC-ARM

### DIFF
--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -89,3 +89,6 @@
 	projectile_type = /obj/item/projectile/beam/pulse/xray
 	req_access = list(list(access_brig, access_bridge))
 	authorized_modes = list(UNAUTHORIZED)
+	firemodes = list(
+		list(mode_name="fire", burst=1, fire_delay=null, move_delay=null, one_hand_penalty=8, burst_accuracy=null, dispersion=null),
+		)

--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -90,5 +90,6 @@
     req_access = list(access_brig)
     authorized_modes = list(UNAUTHORIZED)
     firemodes = list(
-        list(mode_name="fire", burst=3, fire_delay=null, move_delay=null, one_hand_penalty=8, burst_accuracy=null, dispersion=null),
+        list(mode_name="high-frequency pulse fire", burst=3, fire_delay=null, move_delay=null, one_hand_penalty=8, burst_accuracy=null, dispersion=list(0, 0, 1), projectile_type=/obj/item/projectile/beam/pulse/xray),
+		list(mode_name="experimental pulse fire", burst=3, fire_delay=null, move_delay=null, one_hand_penalty=8, burst_accuracy=null, dispersion=list(0, 0, 1)projectile_type=/obj/item/projectile/beam/darkmatter/burst),
         )

--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -82,7 +82,7 @@
 
 //Energy Tectonic
 
-/obj/item/weapon/gun/energy/pulse_rifle/shotgun
+/obj/item/weapon/gun/energy/pulse_rifle/sec
     name = "BXJ-5 Culverin"
     desc = "A somewhat experimental product of Ward-Takahashi's energy weapons division, the BXJ-5 combines rapid-fire pulse laser technology \
     with penetrative laser power for the first time. Designed to saw through armour at the cost of raw damage."

--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -91,5 +91,5 @@
     authorized_modes = list(UNAUTHORIZED)
     firemodes = list(
         list(mode_name="high-frequency pulse fire", burst=3, fire_delay=null, move_delay=null, one_hand_penalty=8, burst_accuracy=null, dispersion=list(0, 0, 1), projectile_type=/obj/item/projectile/beam/pulse/xray),
-		list(mode_name="experimental pulse fire", burst=3, fire_delay=null, move_delay=null, one_hand_penalty=8, burst_accuracy=null, dispersion=list(0, 0, 1)projectile_type=/obj/item/projectile/beam/darkmatter/burst),
+		list(mode_name="experimental pulse fire", burst=3, fire_delay=null, move_delay=null, one_hand_penalty=8, burst_accuracy=null, dispersion=list(0, 0, 1), projectile_type=/obj/item/projectile/beam/darkmatter/burst),
         )

--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -79,3 +79,13 @@
 	desc = "A Hephaestus Industries G40E carbine, designed to kill with concentrated energy blasts. Fitted with an NT1019 chip to make sure killcount is tracked appropriately."
 	icon_state = "lasersec"
 	req_access = list(list(access_brig, access_bridge))
+
+//Energy Tectonic
+
+/obj/item/weapon/gun/energy/pulse_rifle/secure
+	name = "BXJ-5 Culverin"
+	desc = "A somewhat experimental product of Ward-Takahashi's energy weapons division, the BXJ-5 combines rapid-fire pulse laser technology with \
+			penetrative laser power for the first time. Designed to saw through armour at the cost of raw damage."
+	projectile_type = /obj/item/projectile/beam/pulse/xray
+	req_access = list(list(access_brig, access_bridge))
+	authorized_modes = list(UNAUTHORIZED)

--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -90,6 +90,6 @@
     req_access = list(access_brig)
     authorized_modes = list(UNAUTHORIZED)
     firemodes = list(
-        list(mode_name="high-frequency pulse fire", burst=3, fire_delay=null, move_delay=null, one_hand_penalty=8, burst_accuracy=null, dispersion=list(0, 0, 1), projectile_type=/obj/item/projectile/beam/pulse/xray),
-		list(mode_name="experimental pulse fire", burst=3, fire_delay=null, move_delay=null, one_hand_penalty=8, burst_accuracy=null, dispersion=list(0, 0, 1), projectile_type=/obj/item/projectile/beam/darkmatter/burst),
+        list(mode_name="high-frequency pulse", burst=3, fire_delay=null, move_delay=null, one_hand_penalty=8, burst_accuracy=null, dispersion=list(0, 0, 1), projectile_type=/obj/item/projectile/beam/pulse/xray),
+		list(mode_name="experimental pulse", burst=3, fire_delay=null, move_delay=null, one_hand_penalty=8, burst_accuracy=null, dispersion=list(0, 0, 1), projectile_type=/obj/item/projectile/beam/darkmatter/burst),
         )

--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -82,13 +82,13 @@
 
 //Energy Tectonic
 
-/obj/item/weapon/gun/energy/pulse_rifle/secure
-	name = "BXJ-5 Culverin"
-	desc = "A somewhat experimental product of Ward-Takahashi's energy weapons division, the BXJ-5 combines rapid-fire pulse laser technology with \
-			penetrative laser power for the first time. Designed to saw through armour at the cost of raw damage."
-	projectile_type = /obj/item/projectile/beam/pulse/xray
-	req_access = list(list(access_brig, access_bridge))
-	authorized_modes = list(UNAUTHORIZED)
-	firemodes = list(
-		list(mode_name="fire", burst=1, fire_delay=null, move_delay=null, one_hand_penalty=8, burst_accuracy=null, dispersion=null),
-		)
+/obj/item/weapon/gun/energy/pulse_rifle/shotgun
+    name = "BXJ-5 Culverin"
+    desc = "A somewhat experimental product of Ward-Takahashi's energy weapons division, the BXJ-5 combines rapid-fire pulse laser technology \
+    with penetrative laser power for the first time. Designed to saw through armour at the cost of raw damage."
+    projectile_type = /obj/item/projectile/beam/pulse/xray
+    req_access = list(access_brig)
+    authorized_modes = list(UNAUTHORIZED)
+    firemodes = list(
+        list(mode_name="fire", burst=3, fire_delay=null, move_delay=null, one_hand_penalty=8, burst_accuracy=null, dispersion=null),
+        )

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -80,9 +80,11 @@
 	damage = 25
 
 /obj/item/projectile/beam/pulse/xray
-	damage = 10
-	armor_penetration = 80
-	distance_falloff = 0.5
+    damage = 25//Fires in bursts, so little damage.
+    armor_penetration = 95//Makes up for it in this -
+    shrapnel_chance_multiplier = 0
+    arterial_bleed_chance_multiplier = 1.5//- and this, ignoring bursts.
+    distance_falloff = 0
 
 /obj/item/projectile/beam/pulse/destroy
 	name = "destroyer pulse"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -64,7 +64,7 @@
 	distance_falloff = 1
 
 /obj/item/projectile/beam/pulse
-	name = "pulse"
+	name = "pulse beam"
 	icon_state = "u_laser"
 	fire_sound='sound/weapons/pulse.ogg'
 	damage = 15 //lower damage, but fires in bursts
@@ -80,9 +80,16 @@
 	damage = 25
 
 /obj/item/projectile/beam/pulse/xray
-    damage = 20 //Fires in bursts, so little damage.
-    armor_penetration = 95 //Makes up for it in this
-    distance_falloff = 1
+	name = "high-frequency pulse beam"
+	damage = 20 //Fires in bursts, so little damage.
+	armor_penetration = 80 //Makes up for it in this
+	distance_falloff = 1
+
+/obj/item/projectile/beam/darkmatter/burst // Tectonic was very anti-Ascent to begin with
+	name = "experimental pulse beam"
+	damage = 15
+	armor_penetration = 85
+	distance_falloff = 1
 
 /obj/item/projectile/beam/pulse/destroy
 	name = "destroyer pulse"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -81,14 +81,14 @@
 
 /obj/item/projectile/beam/pulse/xray
 	name = "high-frequency pulse beam"
-	damage = 20 //Fires in bursts, so little damage.
-	armor_penetration = 80 //Makes up for it in this
+	damage = 18 //fires in bursts, so little damage.
+	armor_penetration = 80 //makes up for it in this
 	distance_falloff = 1
 
-/obj/item/projectile/beam/darkmatter/burst // Tectonic was very anti-Ascent to begin with
+/obj/item/projectile/beam/darkmatter/burst // Brute mode, oh heck
 	name = "experimental pulse beam"
-	damage = 15
-	armor_penetration = 85
+	damage = 12 //sacrificing raw power for alternate damage type
+	armor_penetration = 85 //increased pen to meet a breakpoint
 	distance_falloff = 1
 
 /obj/item/projectile/beam/pulse/destroy

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -80,11 +80,9 @@
 	damage = 25
 
 /obj/item/projectile/beam/pulse/xray
-    damage = 25//Fires in bursts, so little damage.
-    armor_penetration = 95//Makes up for it in this -
-    shrapnel_chance_multiplier = 0
-    arterial_bleed_chance_multiplier = 1.5//- and this, ignoring bursts.
-    distance_falloff = 0
+    damage = 20 //Fires in bursts, so little damage.
+    armor_penetration = 95 //Makes up for it in this
+    distance_falloff = 1
 
 /obj/item/projectile/beam/pulse/destroy
 	name = "destroyer pulse"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -79,6 +79,11 @@
 /obj/item/projectile/beam/pulse/heavy
 	damage = 25
 
+/obj/item/projectile/beam/pulse/xray
+	damage = 10
+	armor_penetration = 80
+	distance_falloff = 0.5
+
 /obj/item/projectile/beam/pulse/destroy
 	name = "destroyer pulse"
 	damage = 100 //badmins be badmins I don't give a fuck

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1029,9 +1029,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/table/rack,
-/obj/item/weapon/storage/box/teargas,
-/obj/item/weapon/storage/box/teargas,
-/obj/item/weapon/storage/box/zipties,
+/obj/item/weapon/gun/energy/pulse_rifle/sec
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "abI" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1029,7 +1029,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/table/rack,
-/obj/item/weapon/gun/energy/pulse_rifle/sec
+/obj/item/weapon/gun/energy/pulse_rifle/sec,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "abI" = (


### PR DESCRIPTION
Oh boy. All values here are very WIP.

- Adds the BXJ-5 Culverin, a 3-round pulse rifle variant, to the SEC-ARM. It can fire 12 bursts before needing recharged.
- The Culverin has two fire modes: high-frequency fire, which inflicts burn; and experimental fire, which inflicts brute damage instead at the cost of raw power.
- The Culverin requires specific authorisation for both fire modes, like the Tectonic. It cannot be fired otherwise unless on red alert or above.
- The final shot of each burst has some dispersion to it and will occasionally go wide. The Tectonic's penetrating power meant it caused some collateral damage when used; this should help replicate this effect.

Security got a flat-out nerf with the addition of infantry. This should help rectify that without just giving them a second Tectonic again. It uses the pulse rifle sprite for now, but considering that pulse rifles are actually just flat-out not used anywhere I don't foresee this being an issue.

High-frequency (burn damage) mode is intended to be the default, with the brute damage secondary mode being an inferior alternative in terms of damage.

Feedback is very much appreciated. Thanks to @ProbablyCarl for some help with this PR.