### PR TITLE
Fixes LPA getting command headsets in their locker but not on spawn, adds infantry comms to SEAs and DO

### DIFF
--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -26,7 +26,7 @@
 /obj/item/device/encryptionkey/headset_deckofficer
 	name = "deck chief's encryption key"
 	icon_state = "qm_cypherkey"
-	channels = list("Supply" = 1, "Command" = 1, "Exploration" = 1)
+	channels = list("Supply" = 1, "Command" = 1, "Exploration" = 1, "Infantry" = 1)
 
 /obj/item/device/encryptionkey/bridgeofficer
 	name = "bridge officer's encryption key"
@@ -79,4 +79,4 @@
 /obj/item/device/encryptionkey/heads/sea
 	name = "senior enlisted advisor's encryption key"
 	icon_state = "com_cypherkey"
-	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "Exploration" = 1)
+	channels = list("Command" = 1, "Infantry" = 1, "Security" = 1, "Engineering" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "Exploration" = 1)

--- a/maps/torch/job/outfits/command_outfits.dm
+++ b/maps/torch/job/outfits/command_outfits.dm
@@ -97,7 +97,7 @@
 
 /decl/hierarchy/outfit/job/torch/passenger/corporate_bodyguard
 	name = OUTFIT_JOB_NAME("Loss Prevention Associate")
-	l_ear =    /obj/item/device/radio/headset/heads/torchcorp
+	l_ear =    /obj/item/device/radio/headset/heads/torchntcommand
 	uniform =  /obj/item/clothing/under/suit_jacket/corp
 	shoes =    /obj/item/clothing/shoes/laceup
 	id_type =  /obj/item/weapon/card/id/torch/passenger/corporate


### PR DESCRIPTION
- LPA got a PR recently that gave them the same headset as the corp exec, but this PR didn't change their roundstart spawn headset to match the ones in their locker. Fixed.
- The SEAs and deck officer now have infantry comms. SEAs are self-explanatory (especially the MSEA; I would have made it MSEA only if I could be bothered, but whatever), and the DO oversees pretty much all of the hangar deck as-is. Considering infantry are basically just exploration v2, he should have their comms as well.