### PR TITLE
Quick and dirty adherent surgery fix (maybe)

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -166,6 +166,8 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	var/germ_level = user.germ_level
 	if(user.gloves)
 		germ_level = user.gloves.germ_level
+	if(user.get_species() == SPECIES_ADHERENT)
+		germ_level = E.germ_level
 
 	E.germ_level = max(germ_level,E.germ_level) //as funny as scrubbing microbes out with clean gloves is - no.
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -166,10 +166,8 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	var/germ_level = user.germ_level
 	if(user.gloves)
 		germ_level = user.gloves.germ_level
-	if(user.get_species() == SPECIES_ADHERENT)
-		germ_level = E.germ_level
-
-	E.germ_level = max(germ_level,E.germ_level) //as funny as scrubbing microbes out with clean gloves is - no.
+	if(user.get_species() != SPECIES_ADHERENT)
+		E.germ_level = max(germ_level,E.germ_level) //as funny as scrubbing microbes out with clean gloves is - no.
 
 /obj/item/proc/do_surgery(mob/living/carbon/M, mob/living/user, fuckup_prob)
 


### PR DESCRIPTION
- Adherents can (maybe) now do surgery without killing their patient from infection overload. This check _should_ make it so that the adherent's own `germ_level` is ignored in any surgery step, and was the only thing my tiny brain could think of implementing that was within my own level as a coder (read: not a coder) to do. I have tested this and it seems to work and also not break anything.