### PR TITLE
Removes the limit on adherents/round

### DIFF
--- a/code/modules/species/station/adherent.dm
+++ b/code/modules/species/station/adherent.dm
@@ -95,7 +95,6 @@
 		BP_COOLING_FINS = /obj/item/organ/internal/powered/cooling_fins
 		)
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/snake
-	max_players = 3
 
 	base_skin_colours = list(
 		"Turquoise"   = "",


### PR DESCRIPTION
:cl:Roland410
tweak:Removes the max limit of adherents in a round.
/:cl:
Not like there are 3 adherent players total in the community, but one less thing that people can complain about.