### PR TITLE
Makes roundstart vote percentages visible again.

### DIFF
--- a/code/datums/vote/gamemode.dm
+++ b/code/datums/vote/gamemode.dm
@@ -3,8 +3,8 @@
 	additional_header = "<td align = 'center'><b>Minimum Players</b></td></tr>"
 	win_x = 500
 	win_y = 1100
-	show_results = FALSE
-	show_precentages = FALSE
+	show_results = TRUE
+	show_precentages = TRUE
 
 /datum/vote/gamemode/can_run(mob/creator, automatic)
 	if(!automatic && (!config.allow_vote_mode || !is_admin(creator)))


### PR DESCRIPTION
Alright. Here's why this is good, it's simple statistics.

Are YOU tired of Spy vs. Spy _every single round_? Don't worry, ol' Torque is here to save the day.

Picture your standard hidden vote. You've got two sets, Set A and Set B. Now, Set A really, really likes Extended or really, really hates antagonists and will only vote Extended. Set B wants to have their antagonists. Now the problem comes from the fact there are many different gamemodes to vote for. Traitor, merc, raider, so on and so forth. Now, say Set B.1, a subgroup, likes traitor. So, they'll always vote traitor. Set B.2 likes raider and votes raider, etcetera. That causes a problem because it splits the Set B vote and instead of voting for the gamemode you like, or rallying behind a gamemode you'd be alright with playing that round, everybody in Set B just votes secret and it's a vicious cycle.

Feel free to strike me down if you think this is a dumb idea to re-allow seeing the percentages at roundstart, but I feel it would be better to show them during the vote.