### PR TITLE
Wallets can now hold E-Cig Cartridges: Issue #948 Fix

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -40,6 +40,7 @@
 		/obj/item/clothing/accessory/badge,
 		/obj/item/clothing/accessory/medal,
 		/obj/item/clothing/accessory/armor/tag,
+		/obj/item/weapon/reagent_containers/ecig_cartridge,
 		)
 	slot_flags = SLOT_ID
 


### PR DESCRIPTION
Hello! This is my third PR, sorry for any kind of mistake.

What does this PR do?

- Fixes #948 : Wallets can now hold e-cig cartridges, or as defined by the user, "e-cig ammo"

And that's it 😄