### PR TITLE
Regeneration and minor balance changes.

### DIFF
--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -3,24 +3,28 @@
 	var/brute_mult = 1
 	var/fire_mult = 1
 	var/tox_mult = 1
-	var/oxy_mult = 0
+	var/oxy_mult = 1
+	var/clone_mult = 1
 
 /obj/aura/regenerating/life_tick()
 	user.adjustBruteLoss(-brute_mult)
 	user.adjustFireLoss(-fire_mult)
 	user.adjustToxLoss(-tox_mult)
+	user.adjustOxyLoss(-oxy_mult)
+	user.adjustCloneLoss(-clone_mult)
 
 /obj/aura/regenerating/human
 	var/nutrition_damage_mult = 1 //How much nutrition it takes to heal regular damage
 	var/external_nutrition_mult = 50 // How much nutrition it takes to regrow a limb
 	var/organ_mult = 2
+	var/organheal_nut = 380 //The minimum amount of nutriments stored when organs can heal themselves.
 	var/regen_message = "<span class='warning'>Your body throbs as you feel your ORGAN regenerate.</span>"
 	var/grow_chance = 0
 	var/grow_threshold = 0
-	var/ignore_tag//organ tag to ignore
+	var/ignore_tag //organ tag to ignore
 	var/last_nutrition_warning = 0
 	var/innate_heal = TRUE // Whether the aura is on, basically.
-
+	var/noregen = 0 //Used to count how long to toggle regen when hit.
 
 /obj/aura/regenerating/human/proc/external_regeneration_effect(var/obj/item/organ/external/O, var/mob/living/carbon/human/H)
 	return
@@ -30,11 +34,16 @@
 	if(!istype(H))
 		CRASH("Someone gave [user.type] a [src.type] aura. This is invalid.")
 		return 0
+	if (world.time < noregen)
+		innate_heal = FALSE
+	else
+		innate_heal = TRUE
 	if(!innate_heal || H.InStasis() || H.stat == DEAD)
 		return 0
 	if(H.nutrition < nutrition_damage_mult)
 		low_nut_warning()
 		return 0
+
 
 	if(brute_mult && H.getBruteLoss())
 		H.adjustBruteLoss(-brute_mult * config.organ_regeneration_multiplier)
@@ -46,7 +55,10 @@
 		H.adjustToxLoss(-tox_mult * config.organ_regeneration_multiplier)
 		H.adjust_nutrition(-nutrition_damage_mult)
 	if(oxy_mult && H.getOxyLoss())
-		H.adjustToxLoss(-oxy_mult * config.organ_regeneration_multiplier)
+		H.adjustOxyLoss(-oxy_mult * config.organ_regeneration_multiplier)
+		H.adjust_nutrition(-nutrition_damage_mult)
+	if(clone_mult && H.getCloneLoss())
+		H.adjustCloneLoss(-clone_mult * config.organ_regeneration_multiplier)
 		H.adjust_nutrition(-nutrition_damage_mult)
 
 	if(!can_regenerate_organs())
@@ -60,20 +72,20 @@
 					H.adjust_nutrition(-20)
 				else
 					low_nut_warning("head")
-
-		for(var/bpart in shuffle(H.internal_organs_by_name - BP_BRAIN))
-			var/obj/item/organ/internal/regen_organ = H.internal_organs_by_name[bpart]
-			if(BP_IS_ROBOTIC(regen_organ))
-				continue
-			if(istype(regen_organ))
-				if(regen_organ.damage > 0 && !(regen_organ.status & ORGAN_DEAD))
-					if (H.nutrition >= organ_mult)
-						regen_organ.damage = max(regen_organ.damage - organ_mult, 0)
-						H.adjust_nutrition(-organ_mult)
-						if(prob(5))
-							to_chat(H, replacetext(regen_message,"ORGAN", regen_organ.name))
-					else
-						low_nut_warning(regen_organ.name)
+		if (H.nutrition >= organheal_nut)
+			for(var/bpart in shuffle(H.internal_organs_by_name - BP_BRAIN))
+				var/obj/item/organ/internal/regen_organ = H.internal_organs_by_name[bpart]
+				if(BP_IS_ROBOTIC(regen_organ))
+					continue
+				if(istype(regen_organ))
+					if(regen_organ.damage > 0 && !(regen_organ.status & ORGAN_DEAD))
+						if (H.nutrition >= organ_mult)
+							regen_organ.damage = max(regen_organ.damage - organ_mult, 0)
+							H.adjust_nutrition(-organ_mult)
+							if(prob(10))
+								to_chat(H, replacetext(regen_message,"ORGAN", regen_organ.name))
+						else
+							low_nut_warning(regen_organ.name)
 
 	if(prob(grow_chance))
 		for(var/limb_type in H.species.has_limbs)
@@ -115,6 +127,15 @@
 /obj/aura/regenerating/human/proc/can_regenerate_organs()
 	return TRUE
 
+/obj/aura/regenerating/human/attackby()
+	noregen = max(world.time + 30 SECONDS, noregen)
+
+/obj/aura/regenerating/human/hitby()
+	noregen = max(world.time + 30 SECONDS, noregen)
+
+/obj/aura/regenerating/human/bullet_act()
+	noregen = max(world.time + 30 SECONDS, noregen)
+
 /obj/aura/regenerating/human/unathi
 	nutrition_damage_mult = 2
 	brute_mult = 2
@@ -146,6 +167,10 @@
 
 /obj/aura/regenerating/human/unathi/life_tick()
 	var/mob/living/carbon/human/H = user
+	if (world.time < noregen)
+		innate_heal = FALSE
+	else
+		innate_heal = TRUE
 	if(innate_heal && istype(H) && H.stat != DEAD && H.nutrition < 50)
 		H.apply_damage(5, TOX)
 		H.adjust_nutrition(3)
@@ -174,6 +199,7 @@
 	tox_mult = 0
 	nutrition_damage_mult = 2
 	organ_mult = 2
+	organheal_nut = 10
 	regen_message = "<span class='warning'>You sense your nymphs shifting internally to regenerate your ORGAN..</span>"
 	grow_chance = 5
 	grow_threshold = 100
@@ -190,6 +216,7 @@
 	oxy_mult = 3
 	nutrition_damage_mult = 2
 	organ_mult = 2
+	organheal_nut = 10
 	regen_message = "<span class='warning'>You feel a soothing sensation within your ORGAN.</span>"
 	grow_chance = 20
 	grow_threshold = 50

--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -2,8 +2,8 @@
 	name = "regenerating aura"
 	var/brute_mult = 1
 	var/fire_mult = 1
-	var/tox_mult = 1
-	var/oxy_mult = 1
+	var/tox_mult = 0
+	var/oxy_mult = 0
 	var/clone_mult = 1
 
 /obj/aura/regenerating/life_tick()
@@ -17,7 +17,7 @@
 	var/nutrition_damage_mult = 1 //How much nutrition it takes to heal regular damage
 	var/external_nutrition_mult = 50 // How much nutrition it takes to regrow a limb
 	var/organ_mult = 2
-	var/organheal_nut = 380 //The minimum amount of nutriments stored when organs can heal themselves.
+	var/organheal_nut = 350 //The minimum amount of nutriments stored when organs can heal themselves.
 	var/regen_message = "<span class='warning'>Your body throbs as you feel your ORGAN regenerate.</span>"
 	var/grow_chance = 0
 	var/grow_threshold = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1,7 +1,7 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:32
 
 //NOTE: Breathing happens once per FOUR TICKS, unless the last breath fails. In which case it happens once per ONE TICK! So oxyloss healing is done once per 4 ticks while oxyloss damage is applied once per tick!
-#define HUMAN_MAX_OXYLOSS 1 //Defines how much oxyloss humans can get per tick. A tile with no air at all (such as space) applies this value, otherwise it's a percentage of it.
+#define HUMAN_MAX_OXYLOSS 5 //Defines how much oxyloss humans can get per tick. A tile with no air at all (such as space) applies this value, otherwise it's a percentage of it.
 
 #define HUMAN_CRIT_TIME_CUSHION (10 MINUTES) //approximate time limit to stabilize someone in crit
 #define HUMAN_CRIT_HEALTH_CUSHION (config.health_threshold_crit - config.health_threshold_dead)

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -19,7 +19,7 @@
 	var/min_breath_pressure
 	var/last_int_pressure
 	var/last_ext_pressure
-	var/max_pressure_diff = 60
+	var/max_pressure_diff = 30
 
 	var/oxygen_deprivation = 0
 	var/safe_exhaled_max = 6

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -11,7 +11,7 @@
 	//at 0.8 completely depleted after 60ish minutes of constant walking or 130 minutes of standing still
 	var/servo_cost = 0.8
 
-	min_broken_damage = 5
+	min_broken_damage = 20
 	max_damage = 45
 
 	relative_size = 70

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -224,7 +224,7 @@
 	var/list/equip_adjust = list()
 	var/list/equip_overlays = list()
 
-	var/list/base_auras
+	var/list/base_auras = list(/obj/aura/regenerating/human)
 
 	var/sexybits_location	//organ tag where they are located if they can be kicked for increased pain
 


### PR DESCRIPTION
🆑Roland410
tweak:All species have the ability to regenerate damage.
rscadd:Being hit, shot etc. disables your regeneration for 30 seconds.
rscadd:Regeneration now heals clone damage as well.
tweak:Space does five times more oxygen damage now.
tweak:Lungs pop at 30kPa pressure difference now.
tweak:IPCs and FBPs' cell can take four times more damage now before breaking.
/🆑
The side-effect of giving all species regeneration is that their organs actually heal at 0.25 damage per second as well, not just their external damage, and I had to implement the organheal_nut variable as that part of the code means they heal EVEN MORE organ damage if they are above 380 out of 400. Dionaea and prometheans enjoy the advantage of that being basically always active considering their nature.