### PR TITLE
Makes Frag-Grenades deadly.

### DIFF
--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -1,5 +1,5 @@
 /obj/item/projectile/bullet/pellet/fragment
-	damage = 7
+	damage = 30
 	range_step = 2 //controls damage falloff with distance. projectiles lose a "pellet" each time they travel this distance. Can be a non-integer.
 
 	base_spread = 0 //causes it to be treated as a shrapnel explosion instead of cone
@@ -11,7 +11,7 @@
 	muzzle_type = null
 
 /obj/item/projectile/bullet/pellet/fragment/strong
-	damage = 15
+	damage = 50
 
 /obj/item/weapon/grenade/frag
 	name = "fragmentation grenade"
@@ -20,7 +20,7 @@
 
 	var/list/fragment_types = list(/obj/item/projectile/bullet/pellet/fragment = 1)
 	var/num_fragments = 124//total number of fragments produced by the grenade
-	var/explosion_size = 2   //size of the center explosion
+	var/explosion_size = 3   //size of the center explosion
 
 	//The radius of the circle used to launch projectiles. Lower values mean less projectiles are used but if set too low gaps may appear in the spread pattern
 	var/spread_range = 7 //leave as is, for some reason setting this higher makes the spread pattern have gaps close to the epicenter
@@ -88,7 +88,7 @@
 
 	fragment_types = list(/obj/item/projectile/bullet/pellet/fragment=1,/obj/item/projectile/bullet/pellet/fragment/strong=4)
 	num_fragments = 264  //total number of fragments produced by the grenade
-	explosion_size = 3
+	explosion_size = 4
 
 /obj/item/weapon/grenade/frag/high_yield/on_explosion(var/turf/O)
 	if(explosion_size)


### PR DESCRIPTION
* Changed: Normal Fragment Damage from 7 to 30
* Changed: Strong Fragment Damage from 15 to 50

Frag-Grenades are now in-line with other weaponry of their time, such as EMP grenades. Wearing armor will save you from a grenade, but if you're not, you are going to die. But it WILL hurt.
Basically.

In short.

Run.

https://youtu.be/9ZmhTb_l3eA video of them in action.