### PR TITLE
Revert "Branch/rank tweaks for diona, adherent, and prometheans"

### DIFF
--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -1,7 +1,7 @@
 /datum/map/torch
 	species_to_job_whitelist = list(
 		/datum/species/adherent = list(/datum/job/ai, /datum/job/cyborg, /datum/job/assistant, /datum/job/janitor, /datum/job/chef, /datum/job/bartender, /datum/job/cargo_tech,
-										/datum/job/engineer, /datum/job/roboticist, /datum/job/senior_doctor, /datum/job/chemist, /datum/job/scientist_assistant, /datum/job/scientist, /datum/job/nt_pilot,
+										/datum/job/engineer, /datum/job/roboticist, /datum/job/chemist, /datum/job/scientist_assistant, /datum/job/scientist, /datum/job/nt_pilot,
 										/datum/job/mining),
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
 									 /datum/job/roboticist, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender),
@@ -16,7 +16,7 @@
 		/datum/species/unathi/yeosa = list(HUMAN_ONLY_JOBS, /datum/job/representative),
 		/datum/species/skrell  = list(HUMAN_ONLY_JOBS, /datum/job/representative),
 		/datum/species/machine = list(HUMAN_ONLY_JOBS, /datum/job/representative, /datum/job/psiadvisor),
-		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/officer, /datum/job/warden, /datum/job/liaison, /datum/job/bodyguard,),
+		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/officer, /datum/job/warden),
 		/datum/species/sergal = list(HUMAN_ONLY_JOBS, /datum/job/representative),
 		/datum/species/akula = list(HUMAN_ONLY_JOBS, /datum/job/representative),
 		/datum/species/humanathi= list(HUMAN_ONLY_JOBS, /datum/job/representative),

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -30,22 +30,6 @@
 	/datum/mil_rank/marine_corps/o2,\
 	/datum/mil_rank/marine_corps/o3,\
 	)
-#define NTEF_ENLISTED_ONLY /datum/mil_branch/fleet = list(\
-	/datum/mil_rank/fleet/e1, \
-	/datum/mil_rank/fleet/e2, \
-	/datum/mil_rank/fleet/e2_exp, \
-	/datum/mil_rank/fleet/e3, \
-	/datum/mil_rank/fleet/e3_exp, \
-	/datum/mil_rank/fleet/e4, \
-	/datum/mil_rank/fleet/e5, \
-	/datum/mil_rank/fleet/e5_exp, \
-	/datum/mil_rank/fleet/e6, \
-	/datum/mil_rank/fleet/e7, \
-	/datum/mil_rank/fleet/e7_exp, \
-	/datum/mil_rank/fleet/e8, \
-	/datum/mil_rank/fleet/e9, \
-	/datum/mil_rank/fleet/e9_alt1, \
-	)
 
 /datum/map/torch
 	branch_types = list(
@@ -85,12 +69,12 @@
 	)
 
 	species_to_branch_whitelist = list(
-		/datum/species/diona		= list(/datum/mil_branch/civilian, /datum/mil_branch/private_security, /datum/mil_branch/solgov),
+		/datum/species/diona		= list(UNRESTRICTED),
 		/datum/species/nabber		= list(/datum/mil_branch/civilian),
 		/datum/species/skrell		= list(UNRESTRICTED, /datum/mil_branch/skrell_fleet),
 		/datum/species/unathi		= list(UNRESTRICTED, SEMIRESTRICTED),
 		/datum/species/unathi/yeosa	= list(UNRESTRICTED, SEMIRESTRICTED),
-		/datum/species/adherent		= list(/datum/mil_branch/civilian),
+		/datum/species/adherent		= list(UNRESTRICTED),
 		/datum/species/sergal		= list(UNRESTRICTED, /datum/mil_branch/private_security),
 		/datum/species/akula		= list(UNRESTRICTED, SEMIRESTRICTED),
 		/datum/species/custom		= list(UNRESTRICTED, SEMIRESTRICTED),
@@ -110,7 +94,7 @@
 		/datum/species/unathi/yeosa	= list(SMC_TROOPERS_ONLY),
 		/datum/species/humanathi	= list(SMC_TROOPERS_ONLY),
 		/datum/species/tajaran		= list(SMC_TROOPERS_ONLY),
- 		/datum/species/shapeshifter/promethean	= list(SMC_TROOPERS_ONLY, NTEF_ENLISTED_ONLY)
+ 		/datum/species/shapeshifter/promethean	= list(SMC_TROOPERS_ONLY)
 	)
 
 /datum/mil_branch/fleet
@@ -731,4 +715,3 @@
 #undef SEMIRESTRICTED
 #undef SMC_TROOPERS_ONLY
 #undef SMC_LIMITED_RANKS
-#undef NTEF_ENLISTED_ONLY


### PR DESCRIPTION
Reverts BoHBranch/BoH-Bay#900
This PR was heavily biased against dionaea, adherents and especially prometheans, and should not have been merged in my opinion at all.