### PR TITLE
CQC and Sniper gods no more

### DIFF
--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -286,7 +286,7 @@
 	if(affecting.confused)
 		break_strength--
 
-	if(break_strength < 1)
+	if(break_strength < 2)
 		to_chat(G.affecting, "<span class='warning'>You try to break free but feel that unless something changes, you'll never escape!</span>")
 		return
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1709,8 +1709,6 @@
 		. += 1
 	if(skill_check(SKILL_WEAPONS, SKILL_EXPERT))
 		. += 1
-	if(skill_check(SKILL_WEAPONS, SKILL_PROF))
-		. += 2
 
 /mob/living/carbon/human/can_drown()
 	if(!internal && (!istype(wear_mask) || !wear_mask.filters_water()))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1709,6 +1709,8 @@
 		. += 1
 	if(skill_check(SKILL_WEAPONS, SKILL_EXPERT))
 		. += 1
+	if(skill_check(SKILL_WEAPONS, SKILL_PROF))
+		. += 1
 
 /mob/living/carbon/human/can_drown()
 	if(!internal && (!istype(wear_mask) || !wear_mask.filters_water()))

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -53,7 +53,7 @@
 		is_jammed = 1
 		var/mob/user = loc
 		if(istype(user))
-			if(prob(user.skill_fail_chance(SKILL_WEAPONS, 75, 6, 0.22)))
+			if(prob(user.skill_fail_chance(SKILL_WEAPONS, 100, 6, 0.33)))
 				return null
 			else
 				to_chat(user, "<span class='notice'>You reflexively clear the jam on \the [src].</span>")

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -53,7 +53,7 @@
 		is_jammed = 1
 		var/mob/user = loc
 		if(istype(user))
-			if(prob(user.skill_fail_chance(SKILL_WEAPONS, 100, SKILL_PROF)))
+			if(prob(user.skill_fail_chance(SKILL_WEAPONS, 50, SKILL_PROF)))
 				return null
 			else
 				to_chat(user, "<span class='notice'>You reflexively clear the jam on \the [src].</span>")

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -53,7 +53,7 @@
 		is_jammed = 1
 		var/mob/user = loc
 		if(istype(user))
-			if(prob(user.skill_fail_chance(SKILL_WEAPONS, 50, SKILL_PROF)))
+			if(prob(user.skill_fail_chance(SKILL_WEAPONS, 75, 6, 0.22)))
 				return null
 			else
 				to_chat(user, "<span class='notice'>You reflexively clear the jam on \the [src].</span>")


### PR DESCRIPTION
- Weapons skill accuracy bonus for master rank is now +1 instead of the +2 ontop of the +2 already obtained from expert+trained.

- Master weapons skill now provides a 40% to fail auto-unjam isntead of 0%

- Expert has a 50% fail chance, 63% for trained, 79% for basic and 100% for none

- Close Combat has been changed so that a expert can still resist out of a masters blue grab and so on

Input is welcome and salt comments will be ignored. Civil discussion is welcome