### PR TITLE
Adds the fleet officer coveralls to the loadout

### DIFF
--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -51,6 +51,9 @@
 //For members of the command and command support department. Why wasn't this here before?
 #define COMMAND_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/sea, /datum/job/sea/marine, /datum/job/bridgeofficer, /datum/job/liaison, /datum/job/bodyguard, /datum/job/bailiff, /datum/job/psiadvisor, /datum/job/adjudicator)
 
+//For jobs that have at least O-1 in either NTEF or SMC, but aren't considered Command or Command Support.
+#define MISCOFFICER_ROLES list(/datum/job/scientist, /datum/job/qm, /datum/job/chaplain, /datum/job/psychiatrist, /datum/job/senior_doctor, /datum/job/pathfinder)
+
 #define UNIFORMED_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/marine_corps)
 
 #define CASUAL_BRANCHES list(/datum/mil_branch/civilian, /datum/mil_branch/solgov, /datum/mil_branch/private_security)

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -52,7 +52,7 @@
 #define COMMAND_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/sea, /datum/job/sea/marine, /datum/job/bridgeofficer, /datum/job/liaison, /datum/job/bodyguard, /datum/job/bailiff, /datum/job/psiadvisor, /datum/job/adjudicator)
 
 //For jobs that have at least O-1 in either NTEF or SMC, but aren't considered Command or Command Support.
-#define MISCOFFICER_ROLES list(/datum/job/scientist, /datum/job/qm, /datum/job/chaplain, /datum/job/psychiatrist, /datum/job/senior_doctor, /datum/job/pathfinder)
+#define OFFICER_ROLES list(/datum/job/scientist, /datum/job/qm, /datum/job/chaplain, /datum/job/psychiatrist, /datum/job/senior_doctor, /datum/job/pathfinder)
 
 #define UNIFORMED_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/marine_corps)
 

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -1,4 +1,5 @@
 //The following is a list of defs to be used for the Torch loadout.
+//john_bigless here, trying to use multiple defines on one loadout items apparently breaks things. Just thought i'd leave a warning here.
 
 //For jobs that allow for decorative or ceremonial clothing
 #define FORMAL_ROLES list(/datum/job/liaison, /datum/job/bodyguard, /datum/job/bailiff, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/adjudicator, /datum/job/assistant, /datum/job/bartender, /datum/job/merchant, /datum/job/detective, /datum/job/chaplain, /datum/job/psiadvisor, /datum/job/submap/bearcat_captain, /datum/job/submap/bearcat_crewman, /datum/job/submap/unishi_crew, /datum/job/submap/unishi_researcher, /datum/job/submap/colonist, /datum/job/submap/pod)
@@ -53,6 +54,9 @@
 
 //For jobs that have at least O-1 in either NTEF or SMC, but aren't considered Command or Command Support.
 #define OFFICER_ROLES list(/datum/job/scientist, /datum/job/qm, /datum/job/chaplain, /datum/job/psychiatrist, /datum/job/senior_doctor, /datum/job/pathfinder)
+
+//For members of Command, Command Support and all other officer roles. Basically COMMAND_ROLES and OFFICER_ROLES merged together as a last resort.
+#define COMMANDANDOFFICER_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/sea, /datum/job/sea/marine, /datum/job/bridgeofficer, /datum/job/liaison, /datum/job/bodyguard, /datum/job/bailiff, /datum/job/psiadvisor, /datum/job/adjudicator, /datum/job/scientist, /datum/job/qm, /datum/job/chaplain, /datum/job/psychiatrist, /datum/job/senior_doctor, /datum/job/pathfinder)
 
 #define UNIFORMED_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/marine_corps)
 

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -48,6 +48,9 @@
 //For jobs that spawn with armor in their lockers
 #define ARMORED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/qm, /datum/job/sea, /datum/job/sea/marine, /datum/job/bridgeofficer, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/merchant, /datum/job/bodyguard, /datum/job/bailiff, /datum/job/submap/skrellscoutship_crew, /datum/job/submap/skrellscoutship_crew/leader, /datum/job/grunt, /datum/job/combat_tech, /datum/job/squad_lead, /datum/job/seccadet)
 
+//For members of the command and command support department. Why wasn't this here before?
+#define COMMAND_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/sea, /datum/job/sea/marine, /datum/job/bridgeofficer, /datum/job/liaison, /datum/job/bodyguard, /datum/job/bailiff, /datum/job/psiadvisor, /datum/job/adjudicator)
+
 #define UNIFORMED_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/marine_corps)
 
 #define CASUAL_BRANCHES list(/datum/mil_branch/civilian, /datum/mil_branch/solgov, /datum/mil_branch/private_security)

--- a/maps/torch/loadout/loadout_uniform_boh.dm
+++ b/maps/torch/loadout/loadout_uniform_boh.dm
@@ -19,7 +19,7 @@
 	cost = 0
 	allowed_branches = NT_BRANCHES
 
-/datum/gear/uniform/fleet
+/datum/gear/uniform/fleet/officer
 	display_name = "officer fleet fatigue"
 	path = /obj/item/clothing/under/solgov/utility/fleet/officer
 	cost = 0

--- a/maps/torch/loadout/loadout_uniform_boh.dm
+++ b/maps/torch/loadout/loadout_uniform_boh.dm
@@ -18,3 +18,11 @@
 	path = /obj/item/clothing/under/solgov/utility/fleet
 	cost = 0
 	allowed_branches = NT_BRANCHES
+
+/datum/gear/uniform/fleet
+	display_name = "officer fleet fatigue"
+	path = /obj/item/clothing/under/solgov/utility/fleet/officer
+	cost = 0
+	allowed_branches = NT_BRANCHES
+	allowed_roles = COMMAND_ROLES
+

--- a/maps/torch/loadout/loadout_uniform_boh.dm
+++ b/maps/torch/loadout/loadout_uniform_boh.dm
@@ -20,7 +20,7 @@
 	allowed_branches = NT_BRANCHES
 
 /datum/gear/uniform/fleet/officer
-	display_name = "officer fleet fatigue"
+	display_name = "fleet officer fatigues"
 	path = /obj/item/clothing/under/solgov/utility/fleet/officer
 	cost = 0
 	allowed_branches = NT_BRANCHES

--- a/maps/torch/loadout/loadout_uniform_boh.dm
+++ b/maps/torch/loadout/loadout_uniform_boh.dm
@@ -24,5 +24,5 @@
 	path = /obj/item/clothing/under/solgov/utility/fleet/officer
 	cost = 0
 	allowed_branches = NT_BRANCHES
-	allowed_roles = list(COMMAND_ROLES, OFFICER_ROLES)
+	allowed_roles = COMMANDANDOFFICER_ROLES
 

--- a/maps/torch/loadout/loadout_uniform_boh.dm
+++ b/maps/torch/loadout/loadout_uniform_boh.dm
@@ -24,5 +24,5 @@
 	path = /obj/item/clothing/under/solgov/utility/fleet/officer
 	cost = 0
 	allowed_branches = NT_BRANCHES
-	allowed_roles = COMMAND_ROLES
+	allowed_roles = list(COMMAND_ROLES, OFFICER_ROLES)
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Adds the fleet officer coveralls as an NTEF only, Command only uniform.
Also adds a few loadout defines. Check the code yourself, i can't be bothered to write them all here.