### PR TITLE
guaranteed O2 closet supplies

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -114,8 +114,8 @@
 
 /obj/structure/closet/radiation/WillContain()
 	return list(
-		/obj/item/weapon/storage/med_pouch/toxin,
-		/obj/item/weapon/storage/med_pouch/radiation,
+		/obj/item/weapon/storage/med_pouch/toxin = 2,
+		/obj/item/weapon/storage/med_pouch/radiation =2,
 		/obj/item/clothing/suit/radiation,
 		/obj/item/clothing/head/radiation,
 		/obj/item/clothing/suit/radiation,

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -21,14 +21,17 @@
 
 /obj/structure/closet/emcloset/WillContain()
 	//Guaranteed kit - two tanks and masks
-	. = list(/obj/item/weapon/tank/emergency/oxygen = 2,
-			/obj/item/clothing/mask/breath = 2)
+	. = list(/obj/item/weapon/tank/emergency/oxygen/engi,
+			/obj/item/clothing/mask/breath,
+			/obj/item/clothing/suit/space/emergency,
+			/obj/item/clothing/head/helmet/space/emergency,
+			/obj/item/weapon/storage/med_pouch/oxyloss = 2,
+			)
 
 	. += new/datum/atom_creator/simple(list(/obj/item/weapon/storage/toolbox/emergency, /obj/item/inflatable/wall = 2), 75)
-	. += new/datum/atom_creator/simple(list(/obj/item/weapon/tank/emergency/oxygen/engi, /obj/item/clothing/mask/gas/half), 10)
-	. += new/datum/atom_creator/simple(/obj/item/device/oxycandle, 15)
-	. += new/datum/atom_creator/simple(/obj/item/weapon/storage/firstaid/o2, 25)
-	. += new/datum/atom_creator/simple(list(/obj/item/clothing/suit/space/emergency,/obj/item/clothing/head/helmet/space/emergency), 25)
+	. += new/datum/atom_creator/simple(list(/obj/item/weapon/tank/oxygen, /obj/item/clothing/mask/gas), 15)
+	. += new/datum/atom_creator/simple(/obj/item/device/oxycandle, 25)
+	. += new/datum/atom_creator/simple(/obj/item/weapon/storage/firstaid/regular, 10)
 
 /*
  * Fire Closet
@@ -111,7 +114,8 @@
 
 /obj/structure/closet/radiation/WillContain()
 	return list(
-		/obj/item/weapon/storage/med_pouch/toxin = 2,
+		/obj/item/weapon/storage/med_pouch/toxin,
+		/obj/item/weapon/storage/med_pouch/radiation,
 		/obj/item/clothing/suit/radiation,
 		/obj/item/clothing/head/radiation,
 		/obj/item/clothing/suit/radiation,

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -116,10 +116,8 @@
 	return list(
 		/obj/item/weapon/storage/med_pouch/toxin = 2,
 		/obj/item/weapon/storage/med_pouch/radiation =2,
-		/obj/item/clothing/suit/radiation,
-		/obj/item/clothing/head/radiation,
-		/obj/item/clothing/suit/radiation,
-		/obj/item/clothing/head/radiation,
+		/obj/item/clothing/suit/radiation =2,
+		/obj/item/clothing/head/radiation =2,
 		/obj/item/device/geiger = 2)
 
 /*


### PR DESCRIPTION
Changes the RNG spawns of the o2 closets, so that they're guaranteed basic gear for one person (a spacesuit, mask, extended oxygen tank, and 2 o2 pouches), as well as some tweaks. Also changes it so that radiation closets spawn with 1 toxin and 1 rad pouch as opposed to 2 toxin pouches, given that only engineering gets it. 

This ideally should end the usual loot box esque hunt that is frantically opening O2 closets for a space suit while there's a breach, as previously suits only had a 25% chance of spawning. Changes are as follows:

![image](https://user-images.githubusercontent.com/43841046/85964127-4c3f1d80-b96d-11ea-9542-3c0eca5978e9.png)

![TE4y66AXKR](https://user-images.githubusercontent.com/43841046/85964243-bce63a00-b96d-11ea-8306-b68d8143b4e5.gif)

![image](https://user-images.githubusercontent.com/43841046/85964163-70026380-b96d-11ea-9a45-66cca0fcae26.png)

![image](https://user-images.githubusercontent.com/43841046/85964167-742e8100-b96d-11ea-92b8-1f3fe98f0d9f.png)

![image](https://user-images.githubusercontent.com/43841046/85964172-785a9e80-b96d-11ea-8288-3119887b1421.png)
