### PR TITLE
Traitor PDA Culling

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -100,14 +100,6 @@
 	item_cost = 6
 	path = /obj/item/ammo_magazine/magnum
 
-/*
-/datum/uplink_item/item/ammo/speedloader_magnum
-	name = "Magnum Speedloader"
-	desc = "A speedloader for magnum revolvers. Contains 6 rounds."
-	item_cost = 6
-	path = /obj/item/ammo_magazine/speedloader/magnum
-	*/
-
 /datum/uplink_item/item/ammo/flechette
 	name = "Flechette Rifle Magazine"
 	desc = "A  rifle magazine loaded with flechette rounds. Contains 9 rounds."

--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -14,7 +14,7 @@
 /datum/uplink_item/item/ammo/empslug
 	name = "Haywire Slug"
 	desc = "Single 12-gauge shotgun slug fitted with a single-use ion pulse generator"
-	item_cost = 1
+	item_cost = 3
 	path = /obj/item/ammo_casing/shotgun/emp
 
 /datum/uplink_item/item/ammo/holdout_speedloader
@@ -100,11 +100,13 @@
 	item_cost = 6
 	path = /obj/item/ammo_magazine/magnum
 
+/*
 /datum/uplink_item/item/ammo/speedloader_magnum
 	name = "Magnum Speedloader"
 	desc = "A speedloader for magnum revolvers. Contains 6 rounds."
 	item_cost = 6
 	path = /obj/item/ammo_magazine/speedloader/magnum
+	*/
 
 /datum/uplink_item/item/ammo/flechette
 	name = "Flechette Rifle Magazine"

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -125,7 +125,7 @@
 
 /datum/uplink_item/item/visible_weapons/deagle
 	name = "Magnum Pistol"
-	desc = "A high-caliber pistol that uses 15mm ammunition."
+	desc = "A high-caliber pistol that uses 15mm ammunition. Contains a spare magazine."
 	item_cost = 52
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/magnum
 

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -13,14 +13,16 @@
 /datum/uplink_item/item/visible_weapons/smallenergy_gun
 	name = "Small Energy Gun"
 	desc = "A pocket-sized energy based sidearm with three different lethality settings, stun, shock, kill."
-	item_cost = 16
+	item_cost = 10
 	path = /obj/item/weapon/gun/energy/gun/small
 
+/*
 /datum/uplink_item/item/visible_weapons/ancient
 	name = "Replica Pistol"
 	desc = "A cheap replica of an earth handgun. To reload, buy another."
 	item_cost = 16
 	path = /obj/item/weapon/gun/projectile/pistol/throwback
+	*/
 
 /datum/uplink_item/item/visible_weapons/dartgun
 	name = "Dart Gun"
@@ -58,39 +60,43 @@
 /datum/uplink_item/item/visible_weapons/energy_gun
 	name = "Energy Gun"
 	desc = "A energy based sidearm with three different lethality settings, stun, shock, kill."
-	item_cost = 24
+	item_cost = 20
 	path = /obj/item/weapon/gun/energy/gun
 
 /datum/uplink_item/item/visible_weapons/ionpistol
 	name = "Ion Pistol"
 	desc = "Ion rifle in compact form."
-	item_cost = 20
+	item_cost = 16
 	path = /obj/item/weapon/gun/energy/ionrifle/small
 
+/*
 /datum/uplink_item/item/visible_weapons/revolver
 	name = "Magnum Revolver"
 	desc = "A high-caliber revolver. Includes an extra speedloader of ammo."
 	item_cost = 52
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/revolver
+		*/
 
 /datum/uplink_item/item/visible_weapons/grenade_launcher
 	name = "Grenade Launcher"
-	desc = "A pump action grenade launcher loaded with a random assortment of grenades"
-	item_cost = 60
-	path = /obj/item/weapon/gun/launcher/grenade/loaded
+	desc = "A pump action grenade launcher."
+	item_cost = 40
+	path = /obj/item/weapon/gun/launcher/grenade
 
 //These are for traitors (or other antags, perhaps) to have the option of purchasing some merc gear.
 /datum/uplink_item/item/visible_weapons/submachinegun
 	name = "Black Market Submachine Gun"
 	desc = "A quick-firing weapon with three togglable fire modes. Much newer than the older C-20b, and featuring more advanced features."
-	item_cost = 64
+	item_cost = 48
 	path = /obj/item/weapon/gun/projectile/automatic/merc_smg
 
+/*
 /datum/uplink_item/item/visible_weapons/submachinegun/hacked
 	name = "Hacked SMG"
 	desc = "The Infantry's C-20b, hacked to fire aboard the vessel."
 	item_cost = 42
 	path = /obj/item/weapon/gun/projectile/automatic/merc_smg/hacked
+	*/
 
 /datum/uplink_item/item/visible_weapons/assaultrifle
 	name = "Assault Rifle"
@@ -145,18 +151,18 @@
 	name = "Magnum Pistol"
 	desc = "A high-caliber pistol that uses 15mm ammunition."
 	item_cost = 52
-	path = /obj/item/weapon/gun/projectile/pistol/magnum_pistol
+	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/magnum
 
 /datum/uplink_item/item/visible_weapons/sigsauer
 	name = "Standard Military Pistol"
 	desc = "A regularly used and reliable weapon that is standard issue in the Navy."
-	item_cost = 20
+	item_cost = 16
 	path = /obj/item/weapon/gun/projectile/pistol/military/alt
 
 /datum/uplink_item/item/visible_weapons/detective_revolver
 	name = "Small Revolver"
 	desc = "A pocket-sized holdout revolver. Easily concealable.."
-	item_cost = 12
+	item_cost = 10
 	path = /obj/item/weapon/gun/projectile/revolver/holdout
 
 /datum/uplink_item/item/visible_weapons/pulserifle

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -16,14 +16,6 @@
 	item_cost = 10
 	path = /obj/item/weapon/gun/energy/gun/small
 
-/*
-/datum/uplink_item/item/visible_weapons/ancient
-	name = "Replica Pistol"
-	desc = "A cheap replica of an earth handgun. To reload, buy another."
-	item_cost = 16
-	path = /obj/item/weapon/gun/projectile/pistol/throwback
-	*/
-
 /datum/uplink_item/item/visible_weapons/dartgun
 	name = "Dart Gun"
 	desc = "A gas-powered dart gun capable of delivering chemical payloads across short distances. \
@@ -69,14 +61,6 @@
 	item_cost = 16
 	path = /obj/item/weapon/gun/energy/ionrifle/small
 
-/*
-/datum/uplink_item/item/visible_weapons/revolver
-	name = "Magnum Revolver"
-	desc = "A high-caliber revolver. Includes an extra speedloader of ammo."
-	item_cost = 52
-	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/revolver
-		*/
-
 /datum/uplink_item/item/visible_weapons/grenade_launcher
 	name = "Grenade Launcher"
 	desc = "A pump action grenade launcher."
@@ -89,14 +73,6 @@
 	desc = "A quick-firing weapon with three togglable fire modes. Much newer than the older C-20b, and featuring more advanced features."
 	item_cost = 48
 	path = /obj/item/weapon/gun/projectile/automatic/merc_smg
-
-/*
-/datum/uplink_item/item/visible_weapons/submachinegun/hacked
-	name = "Hacked SMG"
-	desc = "The Infantry's C-20b, hacked to fire aboard the vessel."
-	item_cost = 42
-	path = /obj/item/weapon/gun/projectile/automatic/merc_smg/hacked
-	*/
 
 /datum/uplink_item/item/visible_weapons/assaultrifle
 	name = "Assault Rifle"

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -46,7 +46,7 @@ var/list/uplink_random_selections_
 	..()
 
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/visible_weapons/silenced)
-	items += new/datum/uplink_random_item(/datum/uplink_item/item/visible_weapons/revolver)
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/visible_weapons/deagle)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/visible_weapons/heavysniper, 15, 0)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/grenades/emp, 50)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/visible_weapons/crossbow, 33)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -151,8 +151,8 @@
 
 /obj/item/weapon/storage/backpack/satchel/syndie_kit/magnum
 	startswith = list(
-		/datum/uplink_item/item/visible_weapons/deagle,
-		/datum/uplink_item/item/ammo/magnum
+		/obj/item/weapon/gun/projectile/pistol/magnum_pistol,
+		/obj/item/ammo_magazine/magnum
 	)
 
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -149,6 +149,13 @@
 		/obj/item/ammo_magazine/speedloader/magnum
 	)
 
+/obj/item/weapon/storage/backpack/satchel/syndie_kit/magnum
+	startswith = list(
+		/datum/uplink_item/item/visible_weapons/deagle,
+		/datum/uplink_item/item/ammo/magnum
+	)
+
+
 /obj/item/weapon/storage/box/syndie_kit/toxin
 	startswith = list(
 		/obj/item/weapon/reagent_containers/glass/beaker/vial/random/toxin,


### PR DESCRIPTION
To make treason more meaningful, I've decided to remove the traitor PDA.

Do be warned, the removal will be quit-

*Explosions in the background*

Destructive....


Now the actual thing this does is cut down a few items that were redundant in the traitor PDA. I thought there was more, but it was a surprisingly low number of items. Also did a few tweaks, I'll mention here.

Removed:
Magnum Revolver: Oppress the revolver gang, gtfo cowboy! Removed in favor of the magnum pistol, which costed the same price.
Hacked SMG: So it's an SMG..... but hacked..... feelsgoodman. Removed in favor of the black market SMG, which had similar statistics.
Replica Pistol: Ah, don't you just love the New York reload? Removed in favor of the milpistol.

Tweaks:
Mini e gun was lowered to 10 TC (From 16). Because this is a piece of shit.
Holdout revolver was lowered to 10 TC (from 12). I honestly forgot this existed, lets make it a cheaper pocket pistol now.
E gun: Lowered to 20 TC (From 20). Because I almost made it cheaper to buy two mini e guns.
Magnum Pistol: Price remains unchanged, but it now comes with a spare mag on purchase, similar to it's sibling, the magnum revolver.
Black market SMG: Reduced to 50 TC (from 62). It was too expensive to be a serious contender with it's other siblings (being the AEG or the AR). Even at this price, I'll have a hard time seeing it used over the machine pistol or the magnum pistol, but it won't be an insane price now.
Milpistol: Reduced to 16 TC (from 20). This is now the new standard pistol, replacing the replica pistol.