### PR TITLE
Medkit tweaks

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -27,7 +27,7 @@
 	startswith = list(
 		/obj/item/stack/medical/bruise_pack = 2,
 		/obj/item/stack/medical/ointment = 2,
-		/obj/item/weapon/storage/pill_bottle/antidexafen,
+		/obj/item/device/scanner/health,
 		/obj/item/weapon/storage/pill_bottle/paracetamol,
 		/obj/item/stack/medical/splint
 		)

--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -70,7 +70,7 @@ Single Use Emergency Pouches
 	color = COLOR_RED
 
 	startswith = list(
-	/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline,
+	/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/bicaridine,
 	/obj/item/weapon/reagent_containers/pill/pouch_pill/inaprovaline,
 	/obj/item/weapon/reagent_containers/pill/pouch_pill/paracetamol,
 	/obj/item/stack/medical/bruise_pack = 2,
@@ -93,7 +93,7 @@ Single Use Emergency Pouches
 	startswith = list(
 	/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline,
 	/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/deletrathol,
-	/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/adrenaline,
+	/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/kelotane,
 	/obj/item/weapon/reagent_containers/pill/pouch_pill/paracetamol,
 	/obj/item/stack/medical/ointment = 2,
 		)
@@ -211,6 +211,14 @@ Single Use Emergency Pouches
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/dexalin
 	name = "emergency dexalin autoinjector"
 	reagents_to_add = list(/datum/reagent/dexalin = 5)
+
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/bicaridine
+	name = "emergency bicaridine autoinjector"
+	reagents_to_add = list(/datum/reagent/bicaridine = 5)
+
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/kelotane
+	name = "emergency kelotane autoinjector"
+	reagents_to_add = list(/datum/reagent/kelotane = 5)
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/adrenaline
 	name = "emergency adrenaline autoinjector"


### PR DESCRIPTION
Adds 5u bicard and kelo injector to trauma and burn pouches, respectively, as well as adds a health analyzer to the first aid kit in place of the cold medicine pill bottle.
Given that every other pouch has medicine for their respective damage type (dylovene for toxin pouch, dexaline for oxyloss and hyronalin for antirad), I figured the same should be reflected in burn/trauma pouches as they're currently bandages/ointment with painkillers. 
A 5u injector seemed generous enough, given that trauma and burn kits aren't too common and given that medical tends to have most of them in stock, allowing to patch a little bit of damage from it seemed fitting in the way that other pouches treat damage.

Also, given that viro was removed and we no longer have crew-wide sneeze fest epidemics anymore, I figured cold medicine in first aid kits could be replaced with something more functional.

Trauma pouch: 
![image](https://user-images.githubusercontent.com/43841046/86034808-1d1dc000-b9f0-11ea-8812-cb6ef7a74e0f.png)

Burn pouch: 
![image](https://user-images.githubusercontent.com/43841046/86034813-2313a100-b9f0-11ea-96a2-d85205bfdb5d.png)


First aid kit:
![image](https://user-images.githubusercontent.com/43841046/86034833-2a3aaf00-b9f0-11ea-82df-33dc4bb58ced.png)


Any suggestions, be it tweaks, addons or just leaving something in would be appreciated. 