### PR TITLE
Removes Sergal from suit cyclers.

### DIFF
--- a/code/game/machinery/suit_cycler.dm
+++ b/code/game/machinery/suit_cycler.dm
@@ -43,7 +43,7 @@
 	)
 
 	//Species that the suits can be configured to fit.
-	var/list/species = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_SERGAL)
+	var/list/species = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI)
 
 	var/decl/item_modifier/target_modification
 	var/target_species

--- a/maps/torch/items/machinery.dm
+++ b/maps/torch/items/machinery.dm
@@ -57,7 +57,7 @@
 	model_text = "Exploration"
 	req_access = list(access_explorer)
 	available_modifications = list(/decl/item_modifier/space_suit/explorer)
-	species = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_SERGAL)
+	species = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI)
 
 /obj/machinery/suit_storage_unit/explorer
 	name = "Exploration Voidsuit Storage Unit"


### PR DESCRIPTION
🆑Roland410
rscdel:Removes Sergal selection from the suit cycler.
/🆑
I have no idea where it loads the rest (Vulpkanin etc.) and any help locating that would be appreciated.