### PR TITLE
Fixes the ERT base not needing access.

### DIFF
--- a/maps/antag_spawn/ert/ert.dm
+++ b/maps/antag_spawn/ert/ert.dm
@@ -46,6 +46,7 @@
 	requires_power = 0
 	dynamic_lighting = 1
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	req_access = list(access_cent_specops)
 
 /area/map_template/rescue_base/base
 	name = "\improper Barracks"
@@ -53,6 +54,6 @@
 	dynamic_lighting = 0
 
 /area/map_template/rescue_base/start
-	name = "\improper Response Team Base"
+	name = "\improper Response Team Shuttle"
 	icon_state = "shuttlered"
 	base_turf = /turf/unsimulated/floor/rescue_base

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -3512,8 +3512,7 @@
 /obj/structure/window/reinforced/crescent{
 	dir = 1
 	},
-/obj/effect/paint/sun,
-/turf/simulated/wall/titanium,
+/turf/simulated/floor/plating,
 /area/map_template/rescue_base/start)
 "gY" = (
 /obj/structure/table/glass,
@@ -3563,8 +3562,7 @@
 /area/map_template/rescue_base/start)
 "he" = (
 /obj/structure/shuttle/engine/propulsion,
-/obj/effect/paint/sun,
-/turf/simulated/wall/titanium,
+/turf/simulated/floor/plating,
 /area/map_template/rescue_base/start)
 "hf" = (
 /obj/structure/table/glass,


### PR DESCRIPTION
🆑Roland410
bugfix:Makes the ERT base and shuttle need access to be used.
maptweak:Makes the shuttle's engines visible, as they were walled over.
/🆑
Fixes #1006 