### PR TITLE
Additional Fixes & Balance

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -101,7 +101,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	var/custom_species
 	var/base_species = "Custom Human"
 	var/list/species_traits = list()
-	var/blood_color = "#f5e400"
+	var/blood_color = "#a10808"
 	// BastionStation CUSTOM SPECIES END
 
 	// New stuff

--- a/code/modules/boh_misc/munitions.dm
+++ b/code/modules/boh_misc/munitions.dm
@@ -80,7 +80,7 @@
 	name ="incendiary shell"
 	icon_state= "rod"
 	damage_type = BURN
-	damage = 95
+	damage = 165//It's a rocket and there's so few of them. We'll down this if it's too powerful. Up from 90, which was a tickle cannon.
 	armor_penetration = 65 //not 100, because recoilless rifles don't have that high of a velocity
 	damage_flags = DAM_EDGE | DAM_DISPERSED | DAM_EXPLODE
 

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -11,8 +11,8 @@
 	//at 0.8 completely depleted after 60ish minutes of constant walking or 130 minutes of standing still
 	var/servo_cost = 0.8
 
-	min_broken_damage = 5
-	max_damage = 45
+	min_broken_damage = 45//up from 5
+	max_damage = 125//up from 45. Easily destroyed still.
 
 	relative_size = 70
 

--- a/maps/torch/items/clothing/solgov-hands.dm
+++ b/maps/torch/items/clothing/solgov-hands.dm
@@ -9,12 +9,14 @@
 	desc = "These black duty gloves are made from durable synthetic materials, and have a lovely orange accent color."
 	icon_state = "duty_gloves_eng"
 	item_state = "duty_gloves_eng"
+	siemens_coefficient = 0
+	permeability_coefficient = 0.05
 
 /obj/item/clothing/gloves/thick/duty/solgov/cmd
 	name = "command duty gloves"
 	desc = "These black duty gloves are made from durable synthetic materials, and have a lovely gold accent color."
 	icon_state = "duty_gloves_cmd"
-	item_state = "duty_gloves_cmd"	
+	item_state = "duty_gloves_cmd"
 
 /obj/item/clothing/gloves/thick/duty/solgov/exp
 	name = "exploration duty gloves"

--- a/maps/torch/job/misc_jobs.dm
+++ b/maps/torch/job/misc_jobs.dm
@@ -40,7 +40,8 @@ Civilian
 		"Independent Observer",
 		"Sociologist",
 		"Off-Duty" = /decl/hierarchy/outfit/job/torch/crew/service/crewman,
-		"Trainer")
+		"Trainer",
+		"Assistant")
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/passenger
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -64,7 +64,7 @@
 
 #define CIVILIAN_BRANCHES list(/datum/mil_branch/civilian, /datum/mil_branch/solgov)
 
-#define SOLGOV_BRANCHES list(/datum/mil_branch/solgov, /datum/mil_branch/marine_corps)
+#define SOLGOV_BRANCHES list(/datum/mil_branch/solgov, /datum/mil_branch/fleet, /datum/mil_branch/marine_corps)
 
 #define TACTICOOL_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/solgov, /datum/mil_branch/private_security, /datum/mil_branch/marine_corps)
 

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -1522,6 +1522,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/machinery/light/spot{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry)
 "dr" = (
@@ -3479,6 +3482,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/light/spot,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry)
 "gO" = (
@@ -3486,13 +3490,13 @@
 /area/security/infantry/armory)
 "gP" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/random/toolbox,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/armory)
 "gQ" = (
@@ -4028,7 +4032,7 @@
 /turf/simulated/floor/tiled,
 /area/security/infantry/exterior)
 "hK" = (
-/obj/structure/closet/crate/med_crate/trauma,
+/obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/armory)
 "hL" = (
@@ -4045,12 +4049,21 @@
 "hM" = (
 /obj/effect/floor_decal/techfloor{
 	icon_state = "techfloor_edges";
-	dir = 9
+	dir = 8
 	},
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/storage/firstaid/stab,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	external_pressure_bound = 101.325;
+	external_pressure_bound_default = 101.325
+	},
+/obj/machinery/recharger/wallcharger{
+	dir = 4;
+	icon_state = "wrecharger0";
+	pixel_x = -23;
+	pixel_y = -3
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/gear)
+/area/security/infantry/com)
 "hN" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4228,16 +4241,19 @@
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod1/station)
 "ic" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
+	dir = 8
 	},
 /obj/structure/table/steel,
-/obj/item/weapon/deck/cards,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/item/weapon/hand_labeler,
+/obj/machinery/recharger/wallcharger{
+	dir = 4;
+	icon_state = "wrecharger0";
+	pixel_x = -23;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/security/infantry)
 "id" = (
 /obj/structure/table/rack{
@@ -5157,15 +5173,18 @@
 "jH" = (
 /obj/effect/floor_decal/techfloor{
 	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 9
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/firstaid/stab,
+/obj/machinery/recharger/wallcharger{
 	dir = 4;
-	external_pressure_bound = 101.325;
-	external_pressure_bound_default = 101.325
+	icon_state = "wrecharger0";
+	pixel_x = -23;
+	pixel_y = -3
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/com)
+/area/security/infantry/gear)
 "jI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -5322,6 +5341,7 @@
 	},
 /obj/structure/table/steel,
 /obj/item/weapon/paper/inf,
+/obj/item/weapon/paper_bin,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "jX" = (
@@ -6068,13 +6088,16 @@
 /turf/simulated/open,
 /area/quartermaster/hangar/top)
 "ls" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/table/steel,
-/obj/item/clothing/shoes/sandal,
-/turf/simulated/floor/tiled/techfloor,
+/obj/item/weapon/deck/cards,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "lt" = (
 /obj/structure/railing/mapped{
@@ -46547,7 +46570,7 @@ gI
 gO
 cs
 li
-ls
+ic
 jO
 jA
 gC
@@ -47155,7 +47178,7 @@ dq
 ge
 gD
 kp
-ic
+ls
 ik
 kd
 kk
@@ -47349,7 +47372,7 @@ aa
 fQ
 fQ
 cj
-jH
+hM
 ih
 gf
 ip
@@ -47363,7 +47386,7 @@ gE
 hD
 jk
 iE
-hM
+jH
 ky
 kL
 iw

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -12456,6 +12456,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
 	},
+/obj/item/weapon/hand_labeler,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "avp" = (


### PR DESCRIPTION
- - -
Balance:
 - Recoilless rifle made absurdly powerful, hopefully. We'll see. It was a tickle gun prior and I doubt this'll help much, given it's still dispersed damage.
 - Engineering Duty Gloves are now an equivalent to insulated gloves.
 - FBPs returned to being actual combat synthetics when required, instead of dropping in one hit.
- - -
Map:
 - Labeller added to Chemistry.
 - Labeller, rechargers and additional lighting added to Infantry barracks.
- - -
Fixes:
 - Genemodder blood corrected. No longer is it piss yellow upon being shot, and now looks identical to human blood by default.
 - Loadout items should be working properly again or something. Properly.
- - -