### PR TITLE
Stratcom *oorah

### DIFF
--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -17,8 +17,8 @@
 	station_name  = "SGV Dagon"
 	station_short = "Dagon"
 	dock_name     = "TBD"
-	boss_name     = "High Fleet Command"
-	boss_short    = "HighCom"
+	boss_name     = "Strategic Command"
+	boss_short    = "Stratcom"
 	company_name  = "SolGov"
 	company_short = "SG"
 


### PR DESCRIPTION
Wording was pointed out to be weirdly formatted for high command announcements, changed to represent lore after suggested.

Admin/Automatic announcements should now come from "Strategic Command"