### PR TITLE
Sidearm Buff

### DIFF
--- a/maps/torch/infantry/firearms.dm
+++ b/maps/torch/infantry/firearms.dm
@@ -102,8 +102,8 @@
 	name = "P10"
 	desc = "The Hephaestus Industries P10 - a mass produced kinetic sidearm in widespread service with the SCGDF. It has a slide restrictor, preventing quick-draw type shooting."
 	fire_delay = 12
-	req_access = list(access_hop)
-	authorized_modes = list(UNAUTHORIZED)
+//	req_access = list(access_hop)
+//	authorized_modes = list(UNAUTHORIZED)
 	firemodes = list(
 		list(mode_name="fire", burst=1, fire_delay=null, move_delay=null, one_hand_penalty=2, burst_accuracy=null, dispersion=null),
 		)


### PR DESCRIPTION
Because of standardization of sidearms for all military crew, Infantry no longer need to be arbitrarily restricted in this manner. Their primaries are still locked, same as Security's, because of the potential for destruction ICly.
- - -
Balance:
 - Infantry's P10 Sidearm no longer requires authorization to command.
- - -