### PR TITLE
Fleet Beret/Patch Adjustments

### DIFF
--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -820,7 +820,7 @@
 /obj/structure/closet{
 	name = "emergency response team wardrobe"
 	},
-/obj/item/clothing/accessory/solgov/fleet_patch/fifth,
+/obj/item/clothing/accessory/solgov/fleet_patch/third,
 /obj/item/clothing/head/solgov/utility/fleet,
 /obj/item/clothing/accessory/badge/solgov/tags,
 /turf/unsimulated/floor{

--- a/maps/torch/items/clothing/solgov-accessory.dm
+++ b/maps/torch/items/clothing/solgov-accessory.dm
@@ -108,30 +108,30 @@ patches
 	check_codex_val = FACTION_EXPEDITIONARY
 
 /obj/item/clothing/accessory/solgov/fleet_patch
-	name = "\improper First Fleet patch"
-	desc = "A fancy shoulder patch carrying insignia of First Fleet."
+	name = "\improper Group 40 patch"
+	desc = "A fancy shoulder patch carrying insignia of Naval Group 40."
 	icon_state = "fleetpatch1"
 	on_rolled = list("down" = "none")
 	slot = ACCESSORY_SLOT_INSIGNIA
 
 /obj/item/clothing/accessory/solgov/fleet_patch/second
-	name = "\improper Second Fleet patch"
-	desc = "A well-worn shoulder patch carrying insignia of Second Fleet."
+	name = "\improper Patrol Group patch"
+	desc = "A well-worn shoulder patch carrying insignia of the Border Patrol Group."
 	icon_state = "fleetpatch2"
 
 /obj/item/clothing/accessory/solgov/fleet_patch/third
-	name = "\improper Third Fleet patch"
-	desc = "A scuffed shoulder patch carrying insignia of Third Fleet."
+	name = "\improper Special Operations Group patch"
+	desc = "A tactical shoulder patch carrying insignia of the SolGov Fleet S.O.G. task force."
 	icon_state = "fleetpatch3"
 
 /obj/item/clothing/accessory/solgov/fleet_patch/fourth
-	name = "\improper Fourth Fleet patch"
-	desc = "A pristine shoulder patch carrying insignia of Fourth Fleet."
+	name = "\improper Sol Defence Group patch"
+	desc = "A pristine shoulder patch carrying insignia of S.D.G."
 	icon_state = "fleetpatch4"
 
 /obj/item/clothing/accessory/solgov/fleet_patch/fifth
-	name = "\improper Fifth Fleet patch"
-	desc = "A tactical shoulder patch carrying insignia of Fifth Fleet."
+	name = "\improper NWB patch"
+	desc = "A shiny shoulder patch carrying insignia of the Non-Conventional Warfare Board."
 	icon_state = "fleetpatch5"
 
 /*****

--- a/maps/torch/items/clothing/solgov-head.dm
+++ b/maps/torch/items/clothing/solgov-head.dm
@@ -328,28 +328,28 @@
 	icon_state = "beret_whiterim_com"
 
 /obj/item/clothing/head/beret/solgov/fleet/branch
-	name = "first fleet beret"
-	desc = "A SolGov Fleet beret carrying insignia of First Fleet. For personnel that are more inclined towards style than safety."
+	name = "Group 40 beret"
+	desc = "A SolGov Fleet beret carrying the insignia of Naval Group 40, an as needed task force operating under short term orders. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_first"
 
 /obj/item/clothing/head/beret/solgov/fleet/branch/second
-	name = "second fleet beret"
-	desc = "A SolGov Fleet beret carrying insignia of Second Fleet. For personnel that are more inclined towards style than safety."
+	name = "Border Patrol beret"
+	desc = "A SolGov Fleet beret carrying the insignia of the Naval Border Patrol Group. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_second"
 
 /obj/item/clothing/head/beret/solgov/fleet/branch/third
-	name = "third fleet beret"
-	desc = "A SolGov Fleet beret carrying insignia of Third Fleet. For personnel that are more inclined towards style than safety."
+	name = "Special Operations Group beret"
+	desc = "A SolGov Fleet beret carrying the insignia of the S.O.G. naval organization. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_third"
 
 /obj/item/clothing/head/beret/solgov/fleet/branch/fourth
-	name = "fourth fleet beret"
-	desc = "A SolGov Fleet beret carrying insignia of Fourth Fleet. For personnel that are more inclined towards style than safety."
+	name = "Sol Defense Group beret"
+	desc = "A SolGov Fleet beret carrying the insignia of the S.D.G. which provides internal Solarian space security, from Earth outwards to Alpha-Centurai. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_fourth"
 
 /obj/item/clothing/head/beret/solgov/fleet/branch/fifth
-	name = "fifth fleet beret"
-	desc = "A SolGov Fleet beret carrying insignia of Fifth Fleet. For personnel that are more inclined towards style than safety."
+	name = "NWB beret"
+	desc = "A SolGov beret carrying the insignia of the Non-Conventional Warfare Board. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_fifth"
 
 //ushanka

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -71,10 +71,11 @@
 
 /datum/gear/accessory/fleetpatch/New()
 	..()
-	var/solmajors = list()
+	var/fleetpatch = list()
 	fleetpatch["Group 40 patch"] = /obj/item/clothing/accessory/solgov/fleet_patch
 	fleetpatch["Border Patrol patch"] = /obj/item/clothing/accessory/solgov/fleet_patch/second
 	fleetpatch["Sol Defense Group patch"] = /obj/item/clothing/accessory/solgov/fleet_patch/fourth
+	gear_tweaks += new/datum/gear_tweak/path(fleetpatch)
 
 /datum/gear/accessory/armband_ma
 	display_name = "master-at-arms brassard"

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -69,6 +69,13 @@
 	cost = 0
 	allowed_branches = list(/datum/mil_branch/fleet)
 
+/datum/gear/accessory/fleetpatch/New()
+	..()
+	var/solmajors = list()
+	fleetpatch["Group 40 patch"] = /obj/item/clothing/accessory/solgov/fleet_patch
+	fleetpatch["Border Patrol patch"] = /obj/item/clothing/accessory/solgov/fleet_patch/second
+	fleetpatch["Sol Defense Group patch"] = /obj/item/clothing/accessory/solgov/fleet_patch/fourth
+
 /datum/gear/accessory/armband_ma
 	display_name = "master-at-arms brassard"
 	path = /obj/item/clothing/accessory/armband/solgov/ma

--- a/maps/torch/loadout/loadout_head.dm
+++ b/maps/torch/loadout/loadout_head.dm
@@ -81,23 +81,21 @@
 
 /datum/gear/head/fleetberet
 	display_name = "Fleet branch beret selection"
-	description = "A beret denoting service in one of the fleets within the SolGov Fleet."
+	description = "A beret denoting service in one of the branches within the SolGov Fleet."
 	path = /obj/item/clothing/head/beret/solgov/fleet/branch
 	allowed_branches = list(/datum/mil_branch/fleet)
 
 /datum/gear/head/fleetberet/New()
 	..()
 	var/berets = list()
-	berets["first fleet beret"] = /obj/item/clothing/head/beret/solgov/fleet/branch
-	berets["second fleet beret"] = /obj/item/clothing/head/beret/solgov/fleet/branch/second
-	berets["third fleet beret"] = /obj/item/clothing/head/beret/solgov/fleet/branch/third
-	berets["fourth fleet beret"] = /obj/item/clothing/head/beret/solgov/fleet/branch/fourth
-	berets["fifth fleet beret"] = /obj/item/clothing/head/beret/solgov/fleet/branch/fifth
+	berets["group 40 beret"] = /obj/item/clothing/head/beret/solgov/fleet/branch
+	berets["border patrol beret"] = /obj/item/clothing/head/beret/solgov/fleet/branch/second
+	berets["sol defense group beret"] = /obj/item/clothing/head/beret/solgov/fleet/branch/fourth
 	gear_tweaks += new/datum/gear_tweak/path(berets)
 
 /datum/gear/head/ECberet
 	display_name = "SC sections beret selection"
-	description = "A beret denoting service in one of the branches within the NTSC."
+	description = "An ancient beret bearing the insignias of the original expeditionary organization."
 	path = /obj/item/clothing/head/beret/solgov/expedition/branch
 	allowed_branches = NT_BRANCHES
 


### PR DESCRIPTION
Changes legacy SCG fleets 1-5 patches and berets to fit current lore, 3 available in loadout, 2 are for events/erts/etc for now.