### PR TITLE
Fixes & Stuff

### DIFF
--- a/maps/away/ascent/ascent-2.dmm
+++ b/maps/away/ascent/ascent-2.dmm
@@ -5188,9 +5188,6 @@
 /obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
-"Xt" = (
-/turf/space,
-/area/ship/ascent/shuttle_port)
 "XG" = (
 /obj/effect/wallframe_spawn/reinforced_phoron/hull,
 /turf/simulated/floor/ascent,
@@ -12046,7 +12043,7 @@ iS
 gT
 cN
 cN
-Xt
+XM
 aa
 aa
 aa
@@ -13388,7 +13385,7 @@ jc
 jl
 cN
 cN
-Xt
+XM
 aa
 aa
 aa

--- a/maps/torch/datums/supplypacks/security.dm
+++ b/maps/torch/datums/supplypacks/security.dm
@@ -71,7 +71,7 @@
 	containername = "ballistic sidearms crate"
 	access = access_armory
 	security_level = SUPPLY_SECURITY_ELEVATED
-
+/*
 /decl/hierarchy/supply_pack/security/laser
 	name = "Weapons - Laser carbines"
 	contains = list(/obj/item/weapon/gun/energy/laser/secure = 4)
@@ -107,10 +107,10 @@
 	containername = "energy marksman crate"
 	access = access_emergency_armory
 	security_level = SUPPLY_SECURITY_HIGH
-
+*/
 /decl/hierarchy/supply_pack/security/hornetsniper
 	name = "Weapons - Ballistic DMR"
-	contains = list(/obj/item/weapon/gun/projectile/hornetsniper = 2, 
+	contains = list(/obj/item/weapon/gun/projectile/hornetsniper = 2,
 					/obj/item/weapon/storage/box/ammo/hornetammo = 2,)
 	cost = 100
 	containertype = /obj/structure/closet/crate/secure/weapon

--- a/maps/torch/loadout/loadout_ec_skillbadges.dm
+++ b/maps/torch/loadout/loadout_ec_skillbadges.dm
@@ -3,7 +3,7 @@
 	sort_category = "Skill Badges"
 	category = /datum/gear/skill
 	slot = slot_tie
-	allowed_branches = NT_BRANCHES
+	allowed_branches = SOLGOV_BRANCHES
 
 /datum/gear/skill/botany
 	display_name = "Field Xenobotany Specialist badge"

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -116,7 +116,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/southright{
 	dir = 8;
-	name = "Supply Desk"
+	name = "Supply Desk";
+	req_access = list("ACCESS_CARGO")
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/shutters{

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -9598,6 +9598,7 @@
 /obj/effect/floor_decal/corner/blue/half{
 	dir = 8
 	},
+/obj/item/weapon/rig/command/sea/equipped,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea/marine)
 "aqu" = (

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -7663,6 +7663,7 @@
 	pixel_y = -24;
 	id = "sea_windows"
 	},
+/obj/item/weapon/rig/command/sea/equipped,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea)
 "mA" = (


### PR DESCRIPTION
- - -
Balance:
 - Laser weapons removed from Cargo until a rework of the system is complete.
- - -
Map:
 - SEA hardsuits placed in each office.
- - -
Bugfix:
 - Skill badges can now be selected once again.
 - Southern Ascent shuttle no longer pulls space tiles down to planets with it.
 - Cargo windoor now able to be opened again.
- - -