### PR TITLE
Infantry Prep mapchanges

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -957,7 +957,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "ck" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/vault/bolted{
@@ -1485,7 +1485,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "dp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3002,7 +3002,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "fS" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/infantry/exterior)
@@ -3033,7 +3033,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "fW" = (
 /obj/machinery/light{
 	dir = 8
@@ -3154,7 +3154,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "gg" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 8;
@@ -3550,19 +3550,19 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "gU" = (
 /obj/machinery/door/airlock/sol{
 	name = "Infantry Storage"
 	},
 /turf/simulated/floor/plating,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "gV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "gW" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 5;
@@ -3889,7 +3889,7 @@
 	id = "mmgrayons"
 	},
 /turf/space,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "hw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3989,7 +3989,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "hF" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -4024,11 +4024,11 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "hM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "hN" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 6
@@ -4261,7 +4261,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "ii" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4720,7 +4720,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "iV" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -5221,7 +5221,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "jO" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5314,7 +5314,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "jW" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5362,7 +5362,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "kd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6371,7 +6371,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "lO" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6397,7 +6397,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "lQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6414,7 +6414,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "lR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -9444,7 +9444,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "uu" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -12810,7 +12810,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "Hm" = (
 /obj/structure/cable{
 	d1 = 16;
@@ -13323,6 +13323,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/infantry/exterior)
+"IS" = (
+/turf/simulated/wall/r_wall/hull,
+/area/security/infantry/armory)
 "IT" = (
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
@@ -17892,7 +17895,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/com)
+/area/security/infantry/armory)
 "Wf" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/shuttle_ceiling/torch/air,
@@ -17962,6 +17965,9 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
+"Wr" = (
+/turf/simulated/wall/prepainted,
+/area/security/infantry/armory)
 "Wv" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -47527,13 +47533,13 @@ aa
 aa
 aa
 aa
-fQ
-fQ
+IS
+IS
 gU
 hv
 hv
 hv
-ip
+Wr
 iu
 hD
 ke
@@ -47729,13 +47735,13 @@ aa
 aa
 aa
 aa
-fQ
-fQ
+IS
+IS
 jN
 kc
 ur
 We
-ip
+Wr
 dq
 ge
 gD
@@ -47931,8 +47937,8 @@ aa
 aa
 aa
 aa
-fQ
-fQ
+IS
+IS
 cj
 hM
 ih
@@ -48133,8 +48139,8 @@ aa
 aa
 aa
 aa
-fQ
-fQ
+IS
+IS
 hE
 do
 lP
@@ -48335,13 +48341,13 @@ aa
 aa
 aa
 aa
-fQ
-fQ
+IS
+IS
 lN
 gV
 lR
 lQ
-ip
+Wr
 fN
 gv
 gH
@@ -48537,13 +48543,13 @@ aa
 aa
 aa
 aa
-fQ
-fQ
+IS
+IS
 fR
 jU
 fV
 gT
-fQ
+IS
 iT
 iT
 gt
@@ -48740,12 +48746,12 @@ aa
 aa
 aa
 fT
-fQ
-fQ
-fQ
-fQ
-fQ
-fQ
+IS
+IS
+IS
+IS
+IS
+IS
 iT
 gq
 iI

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -45,8 +45,8 @@
 /area/maintenance/fourthdeck/forestarboard)
 "al" = (
 /obj/structure/sign/warning/docking_area{
-	icon_state = "securearea";
-	dir = 1
+	dir = 1;
+	icon_state = "securearea"
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fourthdeck/forestarboard)
@@ -205,8 +205,8 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 6
+	dir = 6;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
@@ -234,8 +234,8 @@
 /area/maintenance/fourthdeck/starboard)
 "aJ" = (
 /obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -299,8 +299,8 @@
 /area/quartermaster/office)
 "aQ" = (
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 4
+	dir = 4;
+	icon_state = "bordercolorhalf"
 	},
 /obj/structure/table/standard,
 /obj/machinery/camera/network/supply{
@@ -332,8 +332,8 @@
 "aT" = (
 /obj/structure/bed/chair/office/comfy/purple,
 /obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -414,9 +414,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/fourthdeck)
 "bd" = (
-/obj/effect/floor_decal/corner_techfloor_grid,
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/armory)
+/obj/effect/floor_decal/corner/green,
+/turf/simulated/floor/tiled,
+/area/security/infantry/com)
 "be" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4;
@@ -453,11 +453,15 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/fourthdeck)
 "bh" = (
-/obj/random/trash,
-/obj/random/illegal,
-/obj/random/illegal,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Fourth Deck Substation Bypass"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/fourthdeck)
 "bi" = (
 /obj/effect/shuttle_landmark/escape_pod/start/pod1,
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -485,8 +489,19 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/fore)
 "bl" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/substation/fourthdeck)
 "bm" = (
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/machinery/door/firedoor,
@@ -529,8 +544,8 @@
 	pixel_y = 0
 	},
 /obj/structure/bed/chair/padded/red{
-	icon_state = "chair_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_preview"
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/maintenance/aux_med)
@@ -689,8 +704,8 @@
 /area/maintenance/fourthdeck/starboard)
 "bG" = (
 /obj/structure/bed/chair/padded/red{
-	icon_state = "chair_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_preview"
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/maintenance/aux_med)
@@ -725,28 +740,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
 "bK" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
-	},
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "bL" = (
@@ -830,8 +836,8 @@
 /area/maintenance/aux_med)
 "bX" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/fourthdeck/starboard)
@@ -873,39 +879,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "ca" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/table/rack{
+	dir = 8
 	},
-/obj/structure/catwalk,
-/obj/random/torchcloset,
 /obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
-"cb" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
-"cc" = (
-/turf/simulated/wall/prepainted,
-/area/security/infantry/exterior)
+/obj/random/illegal,
+/turf/simulated/floor/tiled/techmaint,
+/area/maintenance/fourthdeck/forestarboard)
 "cd" = (
 /obj/structure/railing/mapped,
 /obj/structure/lattice,
@@ -924,12 +904,12 @@
 /area/maintenance/fourthdeck/starboard)
 "ce" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -952,8 +932,8 @@
 /area/maintenance/fourthdeck/starboard)
 "cg" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/techfloor,
@@ -973,11 +953,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/fourthdeck)
 "cj" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 9
+/obj/effect/floor_decal/corner_techfloor_gray{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/com)
 "ck" = (
 /obj/machinery/door/firedoor,
@@ -1037,14 +1016,26 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/captainmess)
 "cr" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/wall/prepainted,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/substation/fourthdeck)
 "cs" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/floor_decal/corner/green{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/monotile,
 /area/security/infantry)
 "ct" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -1073,9 +1064,9 @@
 	dir = 8
 	},
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (NORTH)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -1089,9 +1080,9 @@
 	dir = 4
 	},
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 8;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (WEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -1101,10 +1092,19 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod1/station)
 "cz" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/junction,
+/turf/simulated/floor/tiled,
 /area/security/infantry)
 "cA" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -1121,9 +1121,9 @@
 	dir = 8
 	},
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (NORTH)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -1137,9 +1137,9 @@
 	dir = 4
 	},
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 8;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (WEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -1237,24 +1237,24 @@
 /area/maintenance/fourthdeck/starboard)
 "cP" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/fourthdeck)
 "cQ" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/fourthdeck)
 "cR" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 5
+	dir = 5;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/fourthdeck)
@@ -1265,6 +1265,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/vending/snix,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/starboard)
 "cU" = (
@@ -1320,9 +1321,9 @@
 /area/maintenance/fourthdeck/starboard)
 "cX" = (
 /obj/machinery/vending/wallmed1{
-	name = "Emergency NanoMed";
-	icon_state = "wallmed";
 	dir = 8;
+	icon_state = "wallmed";
+	name = "Emergency NanoMed";
 	pixel_x = 28;
 	pixel_y = 0
 	},
@@ -1332,8 +1333,8 @@
 "cY" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
@@ -1427,9 +1428,9 @@
 /area/maintenance/aux_med)
 "dj" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (NORTH)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod1/station)
@@ -1438,9 +1439,9 @@
 	pixel_x = 32
 	},
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 8;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (WEST)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod1/station)
@@ -1449,17 +1450,17 @@
 	pixel_x = -32
 	},
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (NORTH)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod2/station)
 "dm" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 8;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (WEST)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod2/station)
@@ -1471,11 +1472,19 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
 "do" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/rig/military/infantry,
+/obj/item/weapon/rig/military/infantry,
+/obj/item/weapon/rig/military/infantry,
+/obj/item/weapon/rig/military/infantry,
+/obj/effect/floor_decal/corner_techfloor_gray{
+	dir = 9
 	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner_techfloor_gray{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/com)
 "dp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1485,17 +1494,9 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/warning/pods/west{
-	dir = 8;
-	icon_state = "podswest";
-	pixel_x = 40
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "dq" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -1570,13 +1571,6 @@
 	},
 /turf/simulated/open,
 /area/maintenance/fourthdeck/starboard)
-"dv" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/armory)
 "dw" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -1607,8 +1601,8 @@
 /area/crew_quarters/safe_room/fourthdeck)
 "dy" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -1723,9 +1717,9 @@
 /area/maintenance/fourthdeck/foreport)
 "dI" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 8;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (WEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -1736,8 +1730,8 @@
 /area/shuttle/escape_pod2/station)
 "dJ" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -1770,9 +1764,9 @@
 /area/maintenance/fourthdeck/foreport)
 "dM" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 8;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (WEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -1800,9 +1794,9 @@
 /area/maintenance/fourthdeck/foreport)
 "dP" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (NORTH)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -1949,8 +1943,8 @@
 /area/maintenance/fourthdeck/starboard)
 "dZ" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2013,12 +2007,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atm{
 	pixel_y = 32
@@ -2084,8 +2078,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
@@ -2108,8 +2102,8 @@
 /area/hallway/primary/fourthdeck/fore)
 "em" = (
 /obj/structure/bed/chair/wood/wings/mahogany{
-	icon_state = "wooden_chair_wings_preview";
-	dir = 8
+	dir = 8;
+	icon_state = "wooden_chair_wings_preview"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
@@ -2123,8 +2117,8 @@
 "eo" = (
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2257,8 +2251,8 @@
 /area/shuttle/escape_pod2/station)
 "ez" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/table/standard,
 /obj/item/device/radio/intercom{
@@ -2282,8 +2276,8 @@
 /area/command/captainmess)
 "eB" = (
 /obj/structure/bed/chair/wood/wings/mahogany{
-	icon_state = "wooden_chair_wings_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "wooden_chair_wings_preview"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
@@ -2300,8 +2294,8 @@
 /area/hallway/primary/fourthdeck/aft)
 "eE" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -2347,8 +2341,8 @@
 /area/hallway/primary/fourthdeck/aft)
 "eI" = (
 /obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2453,8 +2447,8 @@
 	icon_state = "map"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
@@ -2543,12 +2537,12 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/green/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
@@ -2583,14 +2577,26 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/lounge)
 "fb" = (
-/obj/random/maintenance,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green,
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Fourth Deck Subgrid";
+	name_tag = "Fourth Deck Subgrid"
+	},
+/obj/structure/catwalk,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/fourthdeck)
 "fc" = (
-/obj/random/trash,
-/obj/random/maintenance,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/turf/simulated/wall/prepainted,
+/area/maintenance/substation/fourthdeck)
 "fd" = (
 /turf/simulated/wall/mahogany,
 /area/command/captainmess)
@@ -2645,12 +2651,12 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
@@ -2720,8 +2726,8 @@
 /area/maintenance/fourthdeck/forestarboard)
 "fr" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -2731,16 +2737,16 @@
 /area/shuttle/escape_pod1/station)
 "fs" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/escape_pod1/station)
 "ft" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -2776,8 +2782,8 @@
 /area/maintenance/fourthdeck/forestarboard)
 "fw" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -2790,16 +2796,16 @@
 /area/shuttle/escape_pod2/station)
 "fx" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/escape_pod2/station)
 "fy" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -2861,8 +2867,8 @@
 /area/maintenance/fourthdeck/port)
 "fG" = (
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -2916,23 +2922,18 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
 "fL" = (
-/turf/simulated/wall/r_wall/hull,
-/area/security/infantry/armory)
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/infantry/com)
 "fM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/armory)
-"fN" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 5
 	},
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
+"fN" = (
+/obj/structure/table/steel,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -2954,15 +2955,19 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry)
 "fO" = (
-/obj/effect/floor_decal/techfloor{
+/obj/effect/floor_decal/corner/green/half{
+	dir = 8;
+	icon_state = "bordercolorhalf"
+	},
+/obj/effect/floor_decal/corner/green/half{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/armory)
+/turf/simulated/floor/tiled,
+/area/security/infantry/com)
 "fP" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -2982,10 +2987,6 @@
 /turf/simulated/wall/r_wall/hull,
 /area/security/infantry/com)
 "fR" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -2997,27 +2998,13 @@
 	pixel_y = 24;
 	req_access = list("ACCESS_ENGINE_EQUIP")
 	},
-/obj/structure/bed,
-/obj/effect/landmark/start{
-	name = "Squad Lead"
+/obj/effect/floor_decal/corner_techfloor_gray/full{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/com)
 "fS" = (
-/obj/machinery/door/airlock/hatch/maintenance,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall/prepainted,
 /area/security/infantry/exterior)
 "fT" = (
 /obj/machinery/pointdefense,
@@ -3032,39 +3019,44 @@
 /turf/simulated/floor/plating,
 /area/space)
 "fU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/security/infantry/armory)
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "fV" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/dispenser,
+/obj/effect/floor_decal/corner_techfloor_gray{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/com)
 "fW" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+/obj/effect/floor_decal/corner/green{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/table/steel,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/security/infantry)
 "fX" = (
-/obj/effect/floor_decal/techfloor,
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
@@ -3073,8 +3065,12 @@
 	name = "south bump";
 	pixel_y = -28
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/armory)
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
+/area/security/infantry/com)
 "fY" = (
 /obj/structure/table/rack,
 /obj/random/tech_supply,
@@ -3100,12 +3096,12 @@
 	},
 /obj/structure/flora/pottedplant/large,
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
@@ -3118,17 +3114,15 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
 "gc" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/armory)
+/obj/machinery/photocopier,
+/obj/effect/floor_decal/corner/green/mono,
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "gd" = (
 /obj/effect/floor_decal/corner/mauve/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3143,21 +3137,28 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "gf" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/corner_techfloor_gray{
 	dir = 10
 	},
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/storage/fancy/crayons,
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/com)
 "gg" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -3180,8 +3181,8 @@
 /obj/random/medical,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/forestarboard)
@@ -3203,9 +3204,9 @@
 	dir = 8
 	},
 /obj/machinery/vending/wallmed1{
-	name = "Emergency NanoMed";
-	icon_state = "wallmed";
 	dir = 8;
+	icon_state = "wallmed";
+	name = "Emergency NanoMed";
 	pixel_x = 28;
 	pixel_y = 0
 	},
@@ -3218,6 +3219,10 @@
 /obj/structure/sign/double/solgovflag/left{
 	pixel_z = 32
 	},
+/obj/effect/landmark/start{
+	name = "Rifleman"
+	},
+/obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry/bunk)
 "gm" = (
@@ -3311,17 +3316,17 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/captainmess)
 "gv" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
-	},
 /obj/machinery/button/blast_door{
 	id_tag = "inf_pres_shutters";
 	name = "Pressure Shutters";
 	pixel_x = 24;
 	pixel_y = -8
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/floor_decal/techfloor{
+	dir = 5;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "gw" = (
 /obj/structure/table/marble,
@@ -3335,9 +3340,11 @@
 /area/command/captainmess)
 "gx" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
+/obj/structure/closet/secure_closet/infantry,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry/bunk)
 "gy" = (
@@ -3352,37 +3359,29 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fourthdeck/starboard)
 "gA" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/green{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/corner/green{
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/security/infantry/exterior)
 "gB" = (
-/obj/machinery/vending/security/accessory{
-	req_access = list("ACCESS_INFANTRY")
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/armory)
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "gC" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled,
 /area/security/infantry)
 "gD" = (
 /obj/structure/cable/green{
@@ -3397,6 +3396,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/techfloor{
+	dir = 9;
+	icon_state = "techfloor_edges"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "gE" = (
@@ -3405,6 +3408,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "gF" = (
@@ -3412,42 +3416,60 @@
 /area/security/infantry/bunk)
 "gG" = (
 /obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 1
+	dir = 1;
+	icon_state = "shock"
 	},
 /turf/simulated/wall/prepainted,
 /area/quartermaster/storage/upper)
 "gH" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "gI" = (
-/obj/effect/floor_decal/techfloor,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/armory)
+/obj/machinery/button/windowtint{
+	id = "mmgrayons";
+	pixel_x = -5;
+	pixel_y = -22
+	},
+/obj/machinery/light_switch{
+	pixel_x = 4;
+	pixel_y = -21
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
+/area/security/infantry/com)
 "gJ" = (
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled,
 /area/security/infantry)
 "gK" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 6
+/obj/structure/table/standard,
+/obj/machinery/photocopier/faxmachine{
+	department = "INF"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/armory)
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "gL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -3470,7 +3492,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "gN" = (
-/obj/effect/floor_decal/techfloor,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -3484,93 +3505,71 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/light/spot,
+/obj/machinery/media/jukebox/old,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry)
 "gO" = (
-/turf/simulated/wall/prepainted,
-/area/security/infantry/armory)
+/obj/structure/flora/pottedplant/tropical,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "gP" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/weapon/storage/toolbox/mechanical,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/armory)
-"gQ" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/armory)
-"gR" = (
-/obj/structure/bed,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Rifleman"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/bunk)
-"gS" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/armory)
-"gT" = (
-/obj/effect/floor_decal/techfloor{
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/green{
 	dir = 6
 	},
+/turf/simulated/floor/tiled,
+/area/security/infantry/com)
+"gS" = (
+/obj/structure/closet/secure_closet/squad_lead,
+/obj/effect/floor_decal/corner/green/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
+"gT" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/closet/secure_closet/squad_lead,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/corner_techfloor_gray/full{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/com)
 "gU" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/armory)
-"gV" = (
-/obj/effect/catwalk_plated/dark,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/door/airlock/sol{
+	name = "Infantry Storage"
 	},
 /turf/simulated/floor/plating,
 /area/security/infantry/com)
+"gV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/infantry/com)
 "gW" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 5
+	dir = 5;
+	icon_state = "techfloor_edges"
 	},
+/obj/structure/table/standard,
+/obj/item/weapon/hand_labeler,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry/bunk)
 "gX" = (
@@ -3584,36 +3583,36 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/cyan{
-	icon_state = "up";
-	dir = 4
+	dir = 4;
+	icon_state = "up"
 	},
 /turf/simulated/open,
 /area/maintenance/fourthdeck/port)
 "gY" = (
 /obj/structure/closet/l3closet/general,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/auxillary/starboard)
 "gZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 9
+	dir = 9;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/auxillary/starboard)
 "ha" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /obj/machinery/button/blast_door{
 	id_tag = "starboardaux_warehouse";
@@ -3625,16 +3624,16 @@
 /area/storage/auxillary/starboard)
 "hb" = (
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "warningcorner"
 	},
 /obj/machinery/button/blast_door{
 	id_tag = "starboardaux_warehouse";
@@ -3666,8 +3665,8 @@
 /area/command/pathfinder)
 "he" = (
 /obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3678,8 +3677,8 @@
 /area/command/pathfinder)
 "hf" = (
 /obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/machinery/newscaster{
 	pixel_x = 0;
@@ -3705,20 +3704,19 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/commissary)
 "hh" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/item/weapon/material/ashtray/glass,
+/obj/effect/floor_decal/corner/green/mono,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/item/device/radio/intercom{
+	pixel_y = 23
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/security/infantry/exterior)
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "hi" = (
 /obj/structure/disposalpipe/up,
 /obj/effect/floor_decal/industrial/warning/full,
@@ -3777,8 +3775,8 @@
 /area/command/captainmess)
 "hn" = (
 /obj/structure/bed/chair/wood/wings/mahogany{
-	icon_state = "wooden_chair_wings_preview";
-	dir = 8
+	dir = 8;
+	icon_state = "wooden_chair_wings_preview"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3808,8 +3806,8 @@
 /area/command/captainmess)
 "hp" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 10
+	dir = 10;
+	icon_state = "spline_fancy"
 	},
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 1
@@ -3828,8 +3826,8 @@
 /area/command/captainmess)
 "hq" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3847,9 +3845,9 @@
 /area/crew_quarters/lounge)
 "hs" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (NORTH)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -3887,24 +3885,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/fore)
 "hv" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 6
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "mmgrayons"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "inf_sec_desk_storage";
-	name = "Desk Shutters";
-	pixel_x = 24;
-	pixel_y = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/armory)
+/turf/space,
+/area/security/infantry/com)
 "hw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3925,36 +3910,30 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/starboard)
 "hx" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/catwalk_plated,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/security/infantry/exterior)
-"hy" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
+"hy" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/obj/structure/closet/hydrant{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/security/infantry/exterior)
@@ -3984,97 +3963,77 @@
 /turf/simulated/open,
 /area/maintenance/fourthdeck/starboard)
 "hC" = (
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/armory)
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/metal,
+/obj/effect/floor_decal/corner/green/mono,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "hD" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 9;
+	icon_state = "techfloor_edges"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "hE" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/com)
-"hF" = (
-/obj/random/trash,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry)
-"hG" = (
-/obj/random/trash,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	frequency = 1331
-	},
-/turf/simulated/floor/tiled,
-/area/security/infantry/exterior)
-"hH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/corner_techfloor_gray{
 	dir = 5
 	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/infantry/com)
+"hF" = (
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
+/area/security/infantry)
+"hH" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/monotile,
 /area/security/infantry/exterior)
 "hI" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "hJ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/security/infantry/exterior)
 "hK" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/armory)
-"hL" = (
-/obj/effect/floor_decal/techfloor,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/effect/floor_decal/corner/green/half{
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled,
+/area/security/infantry/com)
+"hL" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner_techfloor_gray{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/com)
 "hM" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	external_pressure_bound = 101.325;
-	external_pressure_bound_default = 101.325
-	},
-/obj/machinery/recharger/wallcharger{
-	dir = 4;
-	icon_state = "wrecharger0";
-	pixel_x = -23;
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/com)
 "hN" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/green{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/monotile,
 /area/security/infantry/exterior)
 "hO" = (
 /obj/structure/table/rack,
@@ -4103,8 +4062,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/auxillary/starboard)
@@ -4116,15 +4075,15 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/auxillary/starboard)
 "hR" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/auxillary/starboard)
@@ -4139,16 +4098,16 @@
 /area/storage/auxillary/starboard)
 "hT" = (
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
@@ -4164,8 +4123,8 @@
 /area/hallway/primary/fourthdeck/fore)
 "hV" = (
 /obj/effect/floor_decal/corner/mauve/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/machinery/photocopier,
 /obj/machinery/alarm{
@@ -4232,8 +4191,17 @@
 /area/maintenance/fourthdeck/forestarboard)
 "ia" = (
 /obj/structure/window/reinforced,
-/obj/random/trash,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/security/infantry/exterior)
 "ib" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -4242,19 +4210,13 @@
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod1/station)
 "ic" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
-	},
 /obj/structure/table/steel,
 /obj/item/weapon/hand_labeler,
-/obj/machinery/recharger/wallcharger{
-	dir = 4;
-	icon_state = "wrecharger0";
-	pixel_x = -23;
-	pixel_y = -3
+/obj/effect/floor_decal/corner/green{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/monotile,
 /area/security/infantry)
 "id" = (
 /obj/structure/table/rack{
@@ -4265,15 +4227,27 @@
 /area/maintenance/fourthdeck/forestarboard)
 "ie" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/door/blast/regular/escape_pod,
 /turf/simulated/floor/reinforced,
 /area/maintenance/fourthdeck/starboard)
 "if" = (
 /obj/structure/window/reinforced,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/security/infantry/exterior)
 "ig" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -4282,28 +4256,27 @@
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod2/station)
 "ih" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/structure/table/steel,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/com)
 "ii" = (
-/obj/structure/table/steel,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id_tag = "inf_sec_desk_storage";
-	name = "Infantry Secure Storage Shutters"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/sol{
+	name = "Squad Leader Prep"
+	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/armory)
+/turf/simulated/floor/tiled/steel_ridged,
+/area/security/infantry/com)
 "ij" = (
 /obj/machinery/light{
 	dir = 8
@@ -4316,16 +4289,22 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/table/steel,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/weapon/storage/fancy/cigar,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/item/weapon/stool/padded,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "il" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -4338,16 +4317,20 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/cargo_lift)
 "im" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+/obj/effect/floor_decal/corner/green/mono,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/armory)
+/obj/structure/displaycase,
+/obj/item/weapon/storage/fancy/crayons,
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "in" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/machinery/alarm{
@@ -4359,8 +4342,8 @@
 /area/command/captainmess)
 "io" = (
 /obj/effect/floor_decal/corner/brown/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/machinery/light_switch{
 	pixel_x = 22;
@@ -4373,35 +4356,29 @@
 /turf/simulated/wall/prepainted,
 /area/security/infantry/com)
 "iq" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
 	},
-/obj/structure/table/steel,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id_tag = "inf_sec_desk_storage";
-	name = "Infantry Secure Storage Shutters"
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/armory)
+/obj/machinery/disposal,
+/obj/effect/floor_decal/corner/green/mono,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "ir" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/waterstore)
 "is" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/computer/modular/preset/civilian{
+	dir = 4;
+	icon_state = "console"
 	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/armory)
+/obj/effect/floor_decal/corner/green/mono,
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "it" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -4431,26 +4408,29 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "iu" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/noticeboard{
+	pixel_y = 30
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry)
 "iv" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4465,8 +4445,8 @@
 /area/security/infantry/gear)
 "iw" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 10
+	dir = 10;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/bed,
 /obj/effect/landmark/start{
@@ -4523,8 +4503,8 @@
 /area/maintenance/fourthdeck/starboard)
 "iz" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4543,19 +4523,17 @@
 /turf/simulated/floor/crystal,
 /area/crew_quarters/adherent)
 "iB" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry)
@@ -4631,34 +4609,15 @@
 /turf/simulated/floor/shuttle_ceiling,
 /area/space)
 "iK" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry)
 "iL" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry)
 "iM" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -4673,12 +4632,34 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/hallway/primary/fourthdeck/aft)
 "iN" = (
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/armory)
+/obj/structure/bed/chair/office/comfy/brown{
+	dir = 8;
+	icon_state = "comfyofficechair_preview"
+	},
+/obj/effect/landmark/start{
+	name = "Squad Lead"
+	},
+/obj/effect/floor_decal/corner/green/half,
+/obj/effect/floor_decal/corner/green/half{
+	dir = 8;
+	icon_state = "bordercolorhalf"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "iO" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -4712,8 +4693,8 @@
 "iQ" = (
 /obj/machinery/pointdefense,
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/green,
@@ -4729,21 +4710,18 @@
 /turf/simulated/wall/r_wall/hull,
 /area/security/infantry)
 "iU" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id_tag = "inf_sec_desk_storage";
+	name = "Infantry Secure Storage Shutters"
 	},
-/obj/machinery/door/airlock/sol{
-	name = "Squad Leader Prep"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/plating,
 /area/security/infantry/com)
 "iV" = (
-/obj/effect/floor_decal/techfloor,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -4755,6 +4733,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry)
 "iW" = (
@@ -4762,16 +4744,21 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 9
+	dir = 9;
+	icon_state = "techfloor_edges"
 	},
+/obj/structure/closet/secure_closet/infantry,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry/bunk)
 "iX" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
-	icon_state = "corner_techfloor_grid";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_techfloor_grid"
 	},
+/obj/structure/table/standard,
+/obj/random/snack,
+/obj/random/snack,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry/bunk)
 "iY" = (
@@ -4795,6 +4782,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/structure/table/standard,
+/obj/random/cash,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry/bunk)
 "iZ" = (
@@ -4819,8 +4808,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/auxillary/starboard)
@@ -4835,8 +4824,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/auxillary/starboard)
@@ -4854,8 +4843,8 @@
 /area/hallway/primary/fourthdeck/fore)
 "jf" = (
 /obj/effect/floor_decal/corner/mauve/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/machinery/papershredder,
 /obj/machinery/light{
@@ -4915,7 +4904,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/forestarboard)
 "jk" = (
-/obj/effect/floor_decal/techfloor,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -4927,10 +4915,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/vending/wallmed1{
+	dir = 1;
+	icon_state = "wallmed";
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry)
 "jl" = (
-/obj/effect/floor_decal/techfloor,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -4949,7 +4943,7 @@
 /obj/machinery/door/airlock/sol{
 	name = "Infantry Barracks"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/security/infantry/bunk)
 "jn" = (
 /obj/machinery/door/firedoor,
@@ -4970,7 +4964,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/security/infantry/gear)
 "jp" = (
 /obj/effect/floor_decal/techfloor{
@@ -5006,10 +5000,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "js" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -5019,21 +5009,25 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
+/obj/structure/table/rack/shelf,
+/obj/random/firstaid,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry/bunk)
 "jt" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
+/obj/structure/closet/secure_closet/infantry,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry/bunk)
 "ju" = (
@@ -5086,16 +5080,14 @@
 /turf/simulated/floor/crystal,
 /area/crew_quarters/adherent)
 "jA" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
-	},
-/obj/machinery/media/jukebox/old,
 /obj/machinery/camera/network/security{
 	c_tag = "Infantry Prep - Primary";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/security/infantry)
 "jB" = (
 /obj/structure/noticeboard{
@@ -5113,24 +5105,16 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/office)
-"jC" = (
-/obj/structure/closet/secure_closet/infantry,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 2;
-	health = 1e+007
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/bunk)
 "jD" = (
-/obj/structure/table/rack/shelf/steel,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/bunk)
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/security/infantry/com)
 "jE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5147,8 +5131,8 @@
 /area/hallway/primary/fourthdeck/aft)
 "jF" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -5165,18 +5149,13 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
 "jG" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/rig/military/infantry,
-/obj/item/weapon/rig/military/infantry,
-/obj/item/weapon/rig/military/infantry,
-/obj/item/weapon/rig/military/infantry,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/armory)
+/obj/structure/bed/chair/office/comfy/brown,
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "jH" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 9
+	dir = 9;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/storage/firstaid/stab,
@@ -5194,6 +5173,7 @@
 	external_pressure_bound = 101.325;
 	external_pressure_bound_default = 101.325
 	},
+/obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/bunk)
 "jJ" = (
@@ -5201,22 +5181,24 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /obj/effect/catwalk_plated/dark,
+/obj/item/weapon/stool/padded,
 /turf/simulated/floor/plating,
 /area/security/infantry/bunk)
 "jK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/bunk)
 "jL" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 5
+	dir = 5;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -5228,56 +5210,50 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry/gear)
 "jM" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/armory)
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/security/infantry/com)
 "jN" = (
-/obj/machinery/door/airlock/sol{
-	name = "Infantry Storage"
+/obj/effect/floor_decal/corner_techfloor_gray/full{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/com)
 "jO" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled,
 /area/security/infantry)
 "jP" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/catwalk_plated,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/security/infantry/exterior)
 "jQ" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 10
-	},
 /obj/structure/dogbed,
 /obj/random/plushie,
 /obj/machinery/alarm{
@@ -5286,39 +5262,44 @@
 	pixel_x = -22
 	},
 /mob/living/simple_animal/corgi/Lisa,
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/green,
+/obj/item/weapon/pen/crayon/blue,
+/turf/simulated/floor/tiled/monotile,
 /area/security/infantry)
 "jR" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry/bunk)
 "jS" = (
-/obj/machinery/suit_cycler/infantry,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/armory)
+/obj/machinery/button/blast_door{
+	id_tag = "sl_office";
+	name = "SL Shutter Control";
+	pixel_x = -26;
+	pixel_y = 9
+	},
+/obj/effect/floor_decal/corner/green/half{
+	dir = 8;
+	icon_state = "bordercolorhalf"
+	},
+/turf/simulated/floor/tiled,
+/area/security/infantry/com)
 "jT" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/rig/military/infantry,
-/obj/item/weapon/rig/military/infantry,
-/obj/item/weapon/rig/military/infantry,
-/obj/item/weapon/rig/military/infantry,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/armory)
+/turf/simulated/floor/tiled,
+/area/security/infantry/com)
 "jU" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -5327,24 +5308,22 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/security/infantry/com)
-"jV" = (
-/obj/structure/table/steel,
-/obj/machinery/photocopier/faxmachine{
-	department = "INF"
+/obj/machinery/suit_cycler/infantry,
+/obj/effect/floor_decal/corner_techfloor_gray{
+	dir = 6
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry)
+/area/security/infantry/com)
 "jW" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/table/steel,
-/obj/item/weapon/paper/inf,
-/obj/item/weapon/paper_bin,
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "jX" = (
@@ -5352,44 +5331,38 @@
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/fourthdeck/port)
 "jY" = (
-/obj/structure/bed,
 /obj/effect/landmark/start{
 	name = "Rifleman"
 	},
+/obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/bunk)
 "jZ" = (
-/obj/structure/bed/chair{
-	dir = 8
+/obj/effect/floor_decal/techfloor{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "ka" = (
-/obj/machinery/vending/security/infantry,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/armory)
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "kb" = (
-/obj/structure/closet/secure_closet/infantry,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/bunk)
+/turf/simulated/floor/tiled,
+/area/security/infantry/com)
 "kc" = (
-/obj/structure/bed,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/vending/security/infantry,
+/obj/effect/floor_decal/corner_techfloor_gray{
+	dir = 9
 	},
-/obj/effect/landmark/start{
-	name = "Rifleman"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/infantry/bunk)
+/area/security/infantry/com)
 "kd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5403,19 +5376,33 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/techfloor{
+	dir = 10;
+	icon_state = "techfloor_edges"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "ke" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "kf" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
+/obj/structure/table/standard,
+/obj/machinery/recharger/wallcharger{
+	dir = 8;
+	pixel_x = 23;
+	pixel_y = -3
+	},
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry/bunk)
 "kg" = (
@@ -5437,8 +5424,8 @@
 /area/command/pathfinder)
 "kh" = (
 /obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -5453,8 +5440,8 @@
 /area/command/pathfinder)
 "ki" = (
 /obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5489,8 +5476,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "kl" = (
@@ -5509,11 +5499,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/security/infantry/exterior)
+/turf/simulated/floor/tiled/steel_ridged,
+/area/security/infantry)
 "kn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5523,11 +5513,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/techfloor{
+	dir = 8
 	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "ko" = (
 /obj/machinery/power/apc{
@@ -5552,10 +5544,17 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/item/weapon/stool/padded,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "kq" = (
 /obj/structure/railing/mapped{
@@ -5587,15 +5586,16 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry/gear)
 "kt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/item/weapon/storage/fancy/cigar{
+	pixel_x = 6;
+	pixel_y = 11
 	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
+/obj/item/weapon/flame/lighter/random,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "ku" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -5607,9 +5607,11 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 10
+	dir = 10;
+	icon_state = "techfloor_edges"
 	},
+/obj/structure/closet/secure_closet/infantry,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry/bunk)
 "kw" = (
@@ -5650,8 +5652,8 @@
 /area/maintenance/fourthdeck/port)
 "ky" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/closet/secure_closet/inftech,
 /obj/structure/window/reinforced{
@@ -5717,9 +5719,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/table/steel,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/item/weapon/reagent_containers/food/condiment/infantry,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "kH" = (
@@ -5736,21 +5738,28 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 6
 	},
+/obj/structure/table/standard,
+/obj/machinery/recharger/wallcharger{
+	dir = 8;
+	pixel_x = 23;
+	pixel_y = -3
+	},
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/infantry/bunk)
 "kK" = (
-/obj/structure/bed/chair{
-	dir = 8
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/paper/inf{
+	pixel_x = -3;
+	pixel_y = 11
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
+/obj/item/weapon/deck/cards,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "kL" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/closet/secure_closet/inftech/ammo,
 /obj/structure/window/reinforced,
@@ -5888,13 +5897,22 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/aft)
 "kY" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/random/trash,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/security/infantry/exterior)
 "kZ" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -5920,8 +5938,8 @@
 	name = "Starboard Auxiliary Storage"
 	},
 /obj/effect/floor_decal/techfloor/corner{
-	icon_state = "techfloor_corners";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_corners"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/storage/auxillary/starboard)
@@ -5956,17 +5974,11 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/command/pathfinder)
 "lg" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+/obj/effect/floor_decal/corner/green{
+	dir = 9
 	},
-/obj/machinery/vending/wallmed1{
-	dir = 4;
-	name = "Emergency NanoMed";
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/monotile,
 /area/security/infantry)
 "lh" = (
 /obj/structure/cable/green{
@@ -5975,12 +5987,12 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
@@ -6001,15 +6013,14 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
-	},
 /obj/structure/reagent_dispensers/water_cooler{
-	icon_state = "water_cooler";
-	dir = 4
+	dir = 4;
+	icon_state = "water_cooler"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/security/infantry)
 "lj" = (
 /obj/structure/cable/green{
@@ -6020,11 +6031,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/random/trash,
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled,
 /area/security/infantry)
 "lk" = (
 /obj/structure/railing/mapped,
@@ -6045,7 +6056,28 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
 /area/security/infantry/exterior)
 "ln" = (
 /obj/item/device/radio/intercom{
@@ -6068,11 +6100,6 @@
 /turf/simulated/floor/tiled,
 /area/security/infantry/exterior)
 "lq" = (
-/obj/structure/sign/solgov{
-	pixel_x = 32;
-	pixel_y = 0;
-	pixel_z = 0
-	},
 /obj/machinery/camera/network/security{
 	c_tag = "Infantry Prep - Exterior";
 	dir = 8
@@ -6081,6 +6108,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/security/infantry/exterior)
@@ -6094,10 +6124,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/table/steel,
-/obj/item/weapon/deck/cards,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/weapon/stool/padded,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry)
 "lt" = (
@@ -6125,8 +6157,16 @@
 	dir = 1;
 	health = 1e+006
 	},
-/obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
 /area/security/infantry/exterior)
 "lw" = (
 /obj/structure/closet/jcloset_torch,
@@ -6169,11 +6209,16 @@
 	dir = 1;
 	health = 1e+006
 	},
-/obj/structure/mopbucket,
-/obj/item/weapon/storage/bag/trash,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/obj/item/weapon/mop,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
 /area/security/infantry/exterior)
 "lB" = (
 /obj/machinery/cryopod,
@@ -6183,18 +6228,28 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod2/station)
 "lC" = (
-/obj/random/trash,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/security/infantry/exterior)
 "lD" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
 	},
 /obj/machinery/washing_machine,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 6
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
 "lE" = (
@@ -6202,14 +6257,24 @@
 	name = "Infantry Prep"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/security/infantry/exterior)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/security/infantry)
 "lF" = (
-/obj/random/trash,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/security/infantry/exterior)
@@ -6235,7 +6300,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/security/infantry/exterior)
 "lJ" = (
 /obj/structure/cable/green{
@@ -6263,13 +6331,20 @@
 /area/maintenance/fourthdeck/aft)
 "lL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -28
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/security/infantry/exterior)
@@ -6289,10 +6364,13 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "lN" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
+/obj/effect/floor_decal/corner_techfloor_gray{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/com)
 "lO" = (
 /obj/effect/catwalk_plated/dark,
@@ -6303,29 +6381,46 @@
 /turf/simulated/floor/plating,
 /area/security/infantry/gear)
 "lP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/rig/military/infantry,
+/obj/item/weapon/rig/military/infantry,
+/obj/item/weapon/rig/military/infantry,
+/obj/item/weapon/rig/military/infantry,
+/obj/effect/floor_decal/corner_techfloor_gray{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner_techfloor_gray{
 	dir = 6
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/com)
 "lQ" = (
-/obj/effect/floor_decal/techfloor,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/button/blast_door{
+	id_tag = "inf_sec_desk_storage";
+	name = "Desk Shutters";
+	pixel_x = -1;
+	pixel_y = -25
+	},
+/obj/effect/floor_decal/corner_techfloor_gray{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/security/infantry/com)
 "lR" = (
-/obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/plating,
-/area/security/infantry/com)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/infantry/armory)
 "lS" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6375,8 +6470,8 @@
 /area/crew_quarters/lounge)
 "lY" = (
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 4
+	dir = 4;
+	icon_state = "bordercolorhalf"
 	},
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -6497,12 +6592,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -6523,12 +6618,12 @@
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -6540,12 +6635,12 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -6559,12 +6654,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -6646,8 +6741,8 @@
 "my" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/mauve/half{
-	icon_state = "bordercolorhalf";
-	dir = 4
+	dir = 4;
+	icon_state = "bordercolorhalf"
 	},
 /obj/item/weapon/paper_bin{
 	pixel_x = -3;
@@ -6710,8 +6805,8 @@
 /area/maintenance/fourthdeck/starboard)
 "mN" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6732,8 +6827,8 @@
 /area/crew_quarters/adherent)
 "mQ" = (
 /obj/effect/floor_decal/corner/green/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
@@ -6752,8 +6847,8 @@
 /area/hallway/primary/fourthdeck/aft)
 "mS" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -6786,9 +6881,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/aft)
 "mU" = (
-/obj/structure/grille,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/substation/fourthdeck)
 "mV" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6809,6 +6909,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"mW" = (
+/obj/item/weapon/stool/padded,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/infantry)
 "mY" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6845,8 +6952,8 @@
 /area/hallway/primary/fourthdeck/fore)
 "ni" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -6873,8 +6980,8 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -6921,8 +7028,8 @@
 /obj/structure/cable/green,
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -6943,8 +7050,8 @@
 	},
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -6959,15 +7066,15 @@
 	},
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
 "ns" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -7025,8 +7132,8 @@
 /area/hallway/primary/fourthdeck/fore)
 "ny" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -7034,6 +7141,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
 "nA" = (
@@ -7044,8 +7152,8 @@
 	},
 /obj/effect/floor_decal/corner/white,
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/structure/sign/deck/fourth{
 	dir = 8;
@@ -7150,13 +7258,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fourthdeck/aft)
 "od" = (
-/obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/fourthdeck/aft)
 "of" = (
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/papershredder,
@@ -7179,12 +7286,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
@@ -7197,8 +7304,8 @@
 /area/space)
 "ot" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/structure/table/gamblingtable,
 /obj/effect/catwalk_plated,
@@ -7219,8 +7326,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -7230,8 +7337,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/engineering{
-	name = "Docking Maintenance";
 	autoset_access = 0;
+	name = "Docking Maintenance";
 	req_access = list("ACCESS_MAINT")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -7254,8 +7361,8 @@
 	icon_state = "intact"
 	},
 /obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -7279,8 +7386,8 @@
 "oE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/fore)
@@ -7312,8 +7419,8 @@
 	},
 /obj/effect/floor_decal/corner/white,
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -7355,12 +7462,12 @@
 /area/quartermaster/hangar/top)
 "oZ" = (
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "Fourth Deck - Starboard Docking";
@@ -7432,6 +7539,27 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/janitor/aux)
+"pm" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/techfloor,
+/area/security/infantry/bunk)
 "po" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7478,8 +7606,8 @@
 	name = "plastic table frame"
 	},
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
 /obj/item/weapon/storage/firstaid/regular{
 	pixel_x = 6;
@@ -7497,6 +7625,13 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"pF" = (
+/obj/effect/wallframe_spawn/no_grille,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/infantry)
 "pG" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
 /obj/machinery/door/firedoor,
@@ -7538,8 +7673,8 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/teleporter/fourthdeck)
@@ -7557,12 +7692,12 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/fourthdeck)
@@ -7607,8 +7742,8 @@
 	pixel_y = 24
 	},
 /obj/machinery/vending/tool{
-	icon_state = "tool";
-	dir = 8
+	dir = 8;
+	icon_state = "tool"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/storage/primary)
@@ -7651,8 +7786,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
-	dir = 4
+	dir = 4;
+	icon_state = "bordercolorhalf"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -7731,8 +7866,8 @@
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
@@ -7750,8 +7885,8 @@
 "qn" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "warningcorner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -7815,23 +7950,18 @@
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fourthdeck/aft)
 "qC" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/bedsheetbin,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/turf/simulated/floor/tiled,
+/area/security/infantry/com)
 "qP" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
@@ -7851,15 +7981,15 @@
 	pixel_y = 23
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/fourthdeck/fore)
 "qR" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1331;
@@ -7879,8 +8009,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -7909,8 +8039,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -7921,8 +8051,8 @@
 	pixel_x = 32
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -7932,12 +8062,12 @@
 /area/teleporter/fourthdeck)
 "qX" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/fourthdeck)
@@ -8005,8 +8135,8 @@
 /area/command/captainmess)
 "rg" = (
 /obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8014,8 +8144,8 @@
 /area/hallway/primary/fourthdeck/center)
 "rh" = (
 /obj/effect/floor_decal/corner/green/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/center)
@@ -8050,8 +8180,8 @@
 /area/maintenance/fourthdeck/starboard)
 "rl" = (
 /obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
@@ -8097,15 +8227,15 @@
 /area/maintenance/fourthdeck/port)
 "ru" = (
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "rD" = (
 /obj/machinery/computer/ship/navigation{
-	icon_state = "computer";
-	dir = 4
+	dir = 4;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/flightcontrol)
@@ -8145,37 +8275,40 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
+"rM" = (
+/obj/effect/floor_decal/techfloor,
+/obj/effect/landmark/start{
+	name = "Rifleman"
+	},
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/techfloor,
+/area/security/infantry/bunk)
+"rN" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/infantry)
 "rO" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/effect/floor_decal/corner/green{
+	dir = 5
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/sensor{
-	name = "Powernet Sensor - Fourth Deck Subgrid";
-	name_tag = "Fourth Deck Subgrid"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
-	},
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/fourthdeck)
+/obj/structure/sign/warning/pods/west{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/fourthdeck/aft)
 "rP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green,
 /obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "rT" = (
@@ -8188,10 +8321,24 @@
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
+"rW" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 8;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
+/area/security/infantry/exterior)
+"sa" = (
+/obj/effect/floor_decal/corner/green/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/aft)
 "sc" = (
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 8
@@ -8228,18 +8375,22 @@
 "sh" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/sorting)
+"si" = (
+/obj/structure/sign/solgov,
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/infantry/exterior)
 "sj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage/upper)
 "sk" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8;
@@ -8290,8 +8441,8 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -8541,8 +8692,8 @@
 "sI" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -8577,13 +8728,31 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/center)
+"sM" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/aft)
 "sQ" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -27
 	},
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/machinery/vending/snack{
 	dir = 4
@@ -8619,7 +8788,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "sW" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -8627,25 +8795,22 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/junction{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/aft)
 "sX" = (
 /obj/machinery/computer/modular/preset/dock{
-	icon_state = "console";
-	dir = 4
+	dir = 4;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/flightcontrol)
 "sY" = (
 /obj/structure/bed/chair/padded/red{
-	icon_state = "chair_preview";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_preview"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -8815,7 +8980,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "tk" = (
-/obj/machinery/door/airlock/hatch/maintenance,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -8830,7 +8994,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "tl" = (
 /obj/structure/catwalk,
@@ -8848,7 +9012,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "tp" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -8859,56 +9022,72 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
-"tq" = (
-/obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 4
-	},
-/obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 8
-	},
-/turf/simulated/wall/prepainted,
-/area/maintenance/substation/fourthdeck)
-"tr" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/substation/fourthdeck)
-"ts" = (
-/obj/machinery/power/smes/buildable/preset/torch/substation{
-	RCon_tag = "Substation - Fourth Deck"
-	},
-/obj/structure/cable/green,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/catwalk_plated,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/substation/fourthdeck)
+/area/hallway/primary/fourthdeck/aft)
+"tq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/fourthdeck/aft)
+"ts" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/fourthdeck/aft)
 "tA" = (
 /obj/effect/floor_decal/corner/brown/half,
 /obj/structure/railing/mapped,
@@ -8931,8 +9110,8 @@
 /area/maintenance/fourthdeck/aft)
 "tG" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
@@ -9026,8 +9205,8 @@
 	req_access = list(list("ACCESS_EXTERNAL","ACCESS_TORCH_CREW"))
 	},
 /obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -9048,23 +9227,23 @@
 	pixel_y = 6
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/fourthdeck)
 "tW" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
-	icon_state = "corner_techfloor_grid";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_techfloor_grid"
 	},
 /obj/effect/floor_decal/techfloor/corner{
-	icon_state = "techfloor_corners";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_corners"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -9194,8 +9373,8 @@
 /area/hallway/primary/fourthdeck/center)
 "uj" = (
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 8
@@ -9255,25 +9434,17 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "ur" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+/obj/machinery/vending/security/accessory{
+	req_access = list("ACCESS_INFANTRY")
 	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner_techfloor_gray{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/bed/roller/ironingboard,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 6
-	},
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/laundry)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/infantry/com)
 "uu" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -9318,8 +9489,8 @@
 /area/command/captainmess)
 "uA" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 10
+	dir = 10;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/bed/chair{
 	dir = 1
@@ -9344,8 +9515,8 @@
 /area/quartermaster/hangar/top)
 "uC" = (
 /obj/machinery/computer/modular/preset/security{
-	icon_state = "console";
-	dir = 4
+	dir = 4;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/flightcontrol)
@@ -9384,6 +9555,23 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/flightcontrol)
+"uG" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/random/clipboard,
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "uH" = (
 /obj/effect/floor_decal/corner/brown,
 /obj/structure/cable{
@@ -9406,15 +9594,15 @@
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage/upper)
 "uK" = (
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -9445,36 +9633,35 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fourthdeck/forestarboard)
 "uM" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/aft)
 "uN" = (
-/obj/random/trash,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
-"uO" = (
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/aft)
 "uP" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -9488,19 +9675,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "uR" = (
-/obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Fourth Deck Substation Bypass"
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white"
 	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Substation - Fourth Deck";
-	dir = 1
+/obj/structure/sign/warning/pods/east{
+	dir = 1;
+	icon_state = "podseast";
+	pixel_y = -32
 	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/fourthdeck)
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/fourthdeck/aft)
 "uT" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -9598,8 +9783,8 @@
 /area/hallway/primary/fourthdeck/fore)
 "vl" = (
 /obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 4
+	dir = 4;
+	icon_state = "shock"
 	},
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fourthdeck/fore)
@@ -9615,8 +9800,8 @@
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -9747,8 +9932,8 @@
 /area/storage/primary)
 "vx" = (
 /obj/machinery/computer/modular/preset/civilian{
-	icon_state = "console";
-	dir = 8
+	dir = 8;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
@@ -9834,9 +10019,38 @@
 "vK" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/deckchief)
+"vM" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/aft)
+"vO" = (
+/obj/effect/floor_decal/corner/green/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled,
+/area/security/infantry/exterior)
 "vQ" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/office)
+"vY" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/security/infantry/exterior)
 "vZ" = (
 /obj/structure/sign/directions/infirmary{
 	dir = 1;
@@ -9939,8 +10153,8 @@
 	dir = 4
 	},
 /obj/structure/bed/chair/padded/blue{
-	icon_state = "chair_preview";
-	dir = 1
+	dir = 1;
+	icon_state = "chair_preview"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/fore)
@@ -9966,8 +10180,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass/command{
-	name = "Primary Docking Port Control";
 	autoset_access = 0;
+	name = "Primary Docking Port Control";
 	req_access = list("ACCESS_EXTERNAL","ACCESS_TORCH_CREW")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9996,8 +10210,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/fore)
@@ -10021,8 +10235,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/structure/disposalpipe/sortjunction{
@@ -10103,8 +10317,8 @@
 	c_tag = "Fourth Deck - Security Checkpoint"
 	},
 /obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/requests_console{
@@ -10118,8 +10332,8 @@
 "wL" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/fourthdeck)
@@ -10131,8 +10345,8 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /obj/machinery/computer/modular/preset/security{
-	icon_state = "console";
-	dir = 8
+	dir = 8;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/hangcheck)
@@ -10164,8 +10378,8 @@
 /area/maintenance/fourthdeck/starboard)
 "wX" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/fourthdeck/aft)
@@ -10194,8 +10408,8 @@
 	dir = 5
 	},
 /obj/structure/bed/chair/office/comfy/brown{
-	icon_state = "comfyofficechair_preview";
-	dir = 8
+	dir = 8;
+	icon_state = "comfyofficechair_preview"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/deckchief)
@@ -10215,9 +10429,23 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
 "xs" = (
-/obj/machinery/vending/snix,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/fourthdeck)
 "xu" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -10232,11 +10460,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
@@ -10259,6 +10482,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"xG" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/exterior)
 "xL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -10329,8 +10558,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -10498,12 +10727,12 @@
 /area/hallway/primary/fourthdeck/fore)
 "ye" = (
 /obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/structure/bed/chair/padded/red{
-	icon_state = "chair_preview";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_preview"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/hangcheck)
@@ -10532,8 +10761,8 @@
 /area/security/hangcheck)
 "yi" = (
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/structure/table/steel,
 /obj/machinery/recharger,
@@ -10549,6 +10778,25 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage/upper)
+"yk" = (
+/obj/machinery/power/smes/buildable/preset/torch/substation{
+	RCon_tag = "Substation - Fourth Deck"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/fourthdeck)
 "yl" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10570,8 +10818,8 @@
 /area/quartermaster/hangar/top)
 "yu" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -10637,9 +10885,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "yM" = (
-/obj/random/obstruction,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fourthdeck/aft)
+/obj/structure/sign/warning/high_voltage{
+	dir = 8;
+	icon_state = "shock"
+	},
+/turf/simulated/wall/prepainted,
+/area/maintenance/substation/fourthdeck)
 "yN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
@@ -10658,20 +10909,28 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "yQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0-1"
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"zb" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/infantry/bunk)
 "ze" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -10681,6 +10940,11 @@
 	dir = 8;
 	icon_state = "railing0-1";
 	tag = "icon-railing0 (EAST)"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
@@ -10773,8 +11037,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -10803,8 +11067,8 @@
 	},
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -10819,8 +11083,8 @@
 	},
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -10835,8 +11099,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -10887,8 +11151,8 @@
 	},
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10933,8 +11197,8 @@
 /area/crew_quarters/commissary)
 "zE" = (
 /obj/effect/floor_decal/corner/mauve/half{
-	icon_state = "bordercolorhalf";
-	dir = 4
+	dir = 4;
+	icon_state = "bordercolorhalf"
 	},
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/monotile,
@@ -10950,16 +11214,37 @@
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/security/hangcheck)
+"zL" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
+/area/security/infantry/exterior)
 "zM" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/deckchief)
+"zN" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 2;
+	name = "Squad Leader"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id_tag = "sl_office";
+	name = "SL Office Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/security/infantry/com)
 "zP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10990,9 +11275,9 @@
 /area/hallway/primary/fourthdeck/aft)
 "Aa" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 8;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (WEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -11023,8 +11308,8 @@
 	pixel_x = -21
 	},
 /obj/effect/floor_decal/corner/green/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "Fourth Deck Hallway - Port";
@@ -11106,8 +11391,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/techfloor/corner{
-	icon_state = "techfloor_corners";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_corners"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/storage/auxillary/port)
@@ -11185,6 +11470,10 @@
 /obj/effect/shuttle_landmark/lift/cargo_top,
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/cargo_lift)
+"Bg" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/r_wall/hull,
+/area/security/infantry/exterior)
 "Bm" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11193,8 +11482,8 @@
 	},
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -11206,7 +11495,7 @@
 "Bo" = (
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/prepainted,
-/area/hallway/primary/fourthdeck/aft)
+/area/maintenance/substation/fourthdeck)
 "Bs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -11276,8 +11565,8 @@
 	pixel_y = 23
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/auxillary/port)
@@ -11290,8 +11579,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/auxillary/port)
@@ -11310,16 +11599,16 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_diagonal"
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
@@ -11348,8 +11637,8 @@
 	},
 /obj/random/clipboard,
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/item/weapon/folder/blue,
 /turf/simulated/floor/tiled,
@@ -11360,6 +11649,21 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fourthdeck/aft)
+"Cd" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/maintenance/substation/fourthdeck)
 "Cg" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -11369,6 +11673,15 @@
 	},
 /turf/simulated/floor/shuttle_ceiling/torch/air,
 /area/quartermaster/hangar/top)
+"Cl" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/aft)
 "Cr" = (
 /obj/machinery/door/blast/shutters{
 	dir = 2;
@@ -11416,10 +11729,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"CG" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 10;
+	icon_state = "techfloor_edges"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/infantry)
 "CH" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
 /obj/structure/bed/chair/comfy/brown,
 /turf/simulated/floor/carpet,
@@ -11442,8 +11768,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/auxillary/port)
@@ -11459,15 +11785,15 @@
 	},
 /obj/random_multi/single_item/boombox,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/auxillary/port)
 "CR" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/auxillary/port)
@@ -11619,8 +11945,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/auxillary/port)
@@ -11632,8 +11958,8 @@
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/auxillary/port)
@@ -11685,6 +12011,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/sign/warning/pods/west{
+	dir = 8;
+	icon_state = "podswest";
+	pixel_x = 40
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "Eo" = (
@@ -11705,12 +12036,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -11751,8 +12082,8 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/auxillary/port)
@@ -11761,8 +12092,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 10
+	dir = 10;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/auxillary/port)
@@ -11771,8 +12102,8 @@
 	dir = 4
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/steel_grid,
@@ -11782,12 +12113,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
@@ -11807,16 +12138,16 @@
 /area/maintenance/fourthdeck/foreport)
 "EO" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	icon_state = "heater"
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod3/station)
 "EQ" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	icon_state = "heater"
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -11864,6 +12195,24 @@
 /obj/random_multi/single_item/runtime,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
+"Fa" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/fourthdeck/aft)
 "Fb" = (
 /obj/effect/landmark{
 	name = "lightsout"
@@ -11872,8 +12221,8 @@
 /area/quartermaster/office)
 "Fd" = (
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 4
+	dir = 4;
+	icon_state = "bordercolorhalf"
 	},
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
@@ -11890,8 +12239,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage/upper)
@@ -11914,12 +12263,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/green/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "warningcorner"
 	},
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "Fourth Deck - Port Escape Pods";
@@ -11932,8 +12281,8 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/auxillary/port)
@@ -11941,8 +12290,8 @@
 /obj/structure/closet/crate/freezer,
 /obj/random/medical,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/auxillary/port)
@@ -11963,8 +12312,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
@@ -11976,6 +12325,10 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
+"Fu" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled,
+/area/security/infantry)
 "Fv" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 4
@@ -11994,9 +12347,9 @@
 	dir = 8
 	},
 /obj/machinery/vending/wallmed1{
-	name = "Emergency NanoMed";
-	icon_state = "wallmed";
 	dir = 8;
+	icon_state = "wallmed";
+	name = "Emergency NanoMed";
 	pixel_x = 28;
 	pixel_y = 0
 	},
@@ -12032,6 +12385,20 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
+"FC" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/green,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled,
+/area/security/infantry/exterior)
 "FD" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
@@ -12074,6 +12441,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage/upper)
+"FN" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Fourth Deck Substation"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/maintenance/substation/fourthdeck)
 "FS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -12090,13 +12467,16 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "FV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white"
 	},
-/turf/simulated/wall/prepainted,
-/area/maintenance/substation/fourthdeck)
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/aft)
 "FY" = (
 /obj/structure/closet/crate,
 /obj/random/plushie,
@@ -12114,14 +12494,22 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
 "Ga" = (
 /turf/simulated/open,
 /area/quartermaster/hangar/top)
+"Gc" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/prepainted,
+/area/maintenance/substation/fourthdeck)
 "Gg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
@@ -12154,6 +12542,17 @@
 /obj/random/firstaid,
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/escape_pod3/station)
+"Gk" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/infantry)
 "Gl" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -12203,20 +12602,20 @@
 /area/crew_quarters/lounge)
 "Gq" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
 /obj/machinery/light/small,
 /obj/structure/reagent_dispensers/water_cooler{
-	icon_state = "water_cooler";
-	dir = 1
+	dir = 1;
+	icon_state = "water_cooler"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "Gu" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -12246,9 +12645,9 @@
 /area/hallway/primary/fourthdeck/aft)
 "Gw" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (NORTH)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -12288,9 +12687,9 @@
 /area/maintenance/fourthdeck/foreport)
 "GJ" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (NORTH)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod3/station)
@@ -12322,9 +12721,9 @@
 /area/shuttle/escape_pod4/station)
 "GS" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 8;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (WEST)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod4/station)
@@ -12354,8 +12753,8 @@
 /area/shuttle/escape_pod3/station)
 "GY" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
 /obj/item/weapon/storage/box/cups,
 /obj/structure/table/woodentable,
@@ -12363,11 +12762,22 @@
 /area/crew_quarters/lounge)
 "GZ" = (
 /obj/machinery/vending/games{
-	icon_state = "games";
-	dir = 8
+	dir = 8;
+	icon_state = "games"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
+"He" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/table/rack,
+/obj/random/mre,
+/obj/random/mre,
+/obj/random/mre,
+/obj/random/mre,
+/obj/random/mre,
+/obj/random/mre,
+/turf/simulated/floor/tiled/techfloor,
+/area/security/infantry/bunk)
 "Hg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -12382,6 +12792,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
+"Hk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id_tag = "inf_sec_desk_storage";
+	name = "Infantry Secure Storage Shutters"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/security/infantry/com)
 "Hm" = (
 /obj/structure/cable{
 	d1 = 16;
@@ -12391,8 +12820,8 @@
 	},
 /obj/structure/cable,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -12427,9 +12856,9 @@
 /area/hallway/primary/fourthdeck/fore)
 "Hr" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 8;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (WEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -12440,9 +12869,9 @@
 /area/shuttle/escape_pod3/station)
 "Hu" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (NORTH)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -12464,8 +12893,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -12485,6 +12914,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/lounge)
+"HD" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/security/infantry/exterior)
 "HE" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
@@ -12555,9 +12990,9 @@
 	pixel_x = 32
 	},
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 8;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (WEST)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod3/station)
@@ -12590,9 +13025,9 @@
 	pixel_x = -32
 	},
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (NORTH)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod4/station)
@@ -12721,9 +13156,9 @@
 	dir = 8
 	},
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (NORTH)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -12737,9 +13172,9 @@
 	dir = 4
 	},
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 8;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (WEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -12753,9 +13188,9 @@
 	dir = 8
 	},
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (NORTH)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -12769,9 +13204,9 @@
 	dir = 4
 	},
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 8;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (WEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -12818,8 +13253,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 4
+	dir = 4;
+	icon_state = "bordercolorhalf"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -12872,6 +13307,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
+"IP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/security/infantry/exterior)
 "IT" = (
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
@@ -12892,8 +13343,8 @@
 "IY" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -12903,13 +13354,30 @@
 "IZ" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/laundry)
+"Jd" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/table/rack,
+/obj/item/weapon/crowbar/prybar,
+/obj/item/weapon/crowbar/prybar,
+/obj/item/weapon/crowbar/prybar,
+/obj/item/weapon/crowbar/prybar,
+/obj/item/weapon/crowbar/prybar,
+/obj/item/weapon/crowbar/prybar,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/turf/simulated/floor/tiled/techfloor,
+/area/security/infantry/bunk)
 "Jh" = (
 /turf/simulated/wall/r_wall/hull,
 /area/space)
 "Ji" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/door/blast/regular/escape_pod,
 /turf/simulated/floor/reinforced,
@@ -12919,16 +13387,16 @@
 /area/quartermaster/office)
 "Jo" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
 "Js" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/sortjunction/untagged/flipped{
-	icon_state = "pipe-j2s";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-j2s"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -12959,8 +13427,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 8
@@ -13002,6 +13470,15 @@
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fourthdeck/foreport)
+"JE" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled,
+/area/security/infantry/exterior)
 "JG" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/donut,
@@ -13290,27 +13767,31 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "KA" = (
-/obj/random_multi/single_item/boombox,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Substation - Fourth Deck";
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/substation/fourthdeck)
 "KB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/sign/warning/pods/east{
-	dir = 8;
-	icon_state = "podseast";
-	pixel_x = 40
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
@@ -13438,18 +13919,30 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
+"KT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/infantry)
 "KU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/green/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -13473,8 +13966,8 @@
 	},
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -13496,8 +13989,8 @@
 /area/crew_quarters/safe_room/fourthdeck)
 "Lh" = (
 /obj/structure/bed/chair/padded/purple{
-	icon_state = "chair_preview";
-	dir = 1
+	dir = 1;
+	icon_state = "chair_preview"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13700,8 +14193,8 @@
 "LN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/sorting)
@@ -13746,12 +14239,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/green/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
@@ -13786,8 +14279,8 @@
 /area/crew_quarters/commissary)
 "Ma" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13839,8 +14332,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
@@ -13850,7 +14343,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/prepainted,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "Mp" = (
 /turf/simulated/wall/prepainted,
@@ -13895,8 +14392,8 @@
 /area/maintenance/fourthdeck/forestarboard)
 "Mu" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
 /obj/machinery/libraryscanner,
 /turf/simulated/floor/wood/walnut,
@@ -13912,11 +14409,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "Mw" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
-	},
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -13928,6 +14420,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -25;
+	pixel_y = 0
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "Mx" = (
@@ -13935,12 +14433,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/structure/sign/warning/docking_area{
 	name = "\improper ESCAPE POD LAUNCH PATHWAY";
@@ -14077,8 +14575,8 @@
 /area/command/captainmess)
 "MY" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
@@ -14418,19 +14916,6 @@
 /obj/random_multi/single_item/poppy,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
-"NV" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Fourth Deck Substation"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/substation/fourthdeck)
 "NX" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14462,8 +14947,8 @@
 /area/hallway/primary/fourthdeck/aft)
 "NZ" = (
 /obj/machinery/computer/modular/preset/civilian{
-	icon_state = "console";
-	dir = 8
+	dir = 8;
+	icon_state = "console"
 	},
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -14503,6 +14988,10 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
+"Oi" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/infantry/exterior)
 "Oj" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -14593,6 +15082,14 @@
 /obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
 /area/quartermaster/sorting)
+"Oz" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/item/weapon/reagent_containers/food/condiment/infantry,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/infantry)
 "OA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -14628,8 +15125,8 @@
 /area/command/captainmess)
 "OJ" = (
 /obj/machinery/computer/modular/preset/security{
-	icon_state = "console";
-	dir = 1
+	dir = 1;
+	icon_state = "console"
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -14752,6 +15249,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/corner/green/mono,
 /obj/structure/disposalpipe/segment,
+/obj/structure/sign/warning/pods/east{
+	dir = 8;
+	icon_state = "podseast";
+	pixel_x = 40
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "Pe" = (
@@ -14807,8 +15309,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/sorting)
@@ -14832,8 +15334,8 @@
 /area/maintenance/fourthdeck/foreport)
 "Pl" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -14869,8 +15371,8 @@
 /area/crew_quarters/laundry)
 "Pm" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 10
+	dir = 10;
+	icon_state = "warning"
 	},
 /obj/structure/disposalpipe/up{
 	dir = 8
@@ -14907,6 +15409,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
+"Ps" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/infantry/exterior)
 "Pu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14929,6 +15443,14 @@
 "Pw" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/command/pathfinder)
+"Px" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/wall/prepainted,
+/area/maintenance/substation/fourthdeck)
 "Pz" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15112,8 +15634,8 @@
 /area/maintenance/fourthdeck/foreport)
 "PS" = (
 /obj/effect/floor_decal/corner/green/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -15206,8 +15728,8 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage/upper)
@@ -15271,12 +15793,12 @@
 /area/maintenance/fourthdeck/starboard)
 "Qq" = (
 /obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
 /obj/structure/bed/chair/padded/red{
-	icon_state = "chair_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_preview"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/hangcheck)
@@ -15301,8 +15823,8 @@
 /area/maintenance/fourthdeck/starboard)
 "Qt" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
 /obj/machinery/recharger,
 /obj/structure/table/woodentable,
@@ -15371,8 +15893,8 @@
 /area/maintenance/fourthdeck/foreport)
 "QL" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -15440,11 +15962,15 @@
 /area/maintenance/fourthdeck/foreport)
 "QW" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
@@ -15541,8 +16067,8 @@
 /area/maintenance/fourthdeck/foreport)
 "Rm" = (
 /obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 4
+	dir = 4;
+	icon_state = "shock"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/hangcheck)
@@ -15599,8 +16125,8 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/white,
 /obj/structure/cable/green{
@@ -15612,14 +16138,16 @@
 /area/hallway/primary/fourthdeck/fore)
 "Rw" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
 	},
-/obj/structure/bed/roller/ironingboard,
-/obj/machinery/light,
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/structure/bedsheetbin,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
 "Rx" = (
@@ -15663,11 +16191,6 @@
 /area/hallway/primary/fourthdeck/aft)
 "RE" = (
 /obj/structure/catwalk,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -15675,6 +16198,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/hatch/maintenance,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "RG" = (
@@ -15682,11 +16207,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15711,8 +16231,8 @@
 	},
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
@@ -15764,12 +16284,12 @@
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
@@ -15855,8 +16375,8 @@
 /area/crew_quarters/lounge)
 "Se" = (
 /obj/effect/floor_decal/corner/paleblue/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -15869,8 +16389,8 @@
 "Sf" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/computer/modular/preset/civilian{
-	icon_state = "console";
-	dir = 8
+	dir = 8;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/hangar/top)
@@ -15902,19 +16422,6 @@
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
-"Sj" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Fourth Deck Substation"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/substation/fourthdeck)
 "Sl" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -15945,8 +16452,8 @@
 /area/maintenance/fourthdeck/foreport)
 "So" = (
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16008,8 +16515,8 @@
 /area/quartermaster/storage/upper)
 "Sy" = (
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 4
+	dir = 4;
+	icon_state = "bordercolorhalf"
 	},
 /obj/structure/table/standard,
 /obj/structure/noticeboard{
@@ -16022,8 +16529,8 @@
 /area/quartermaster/deckchief)
 "Sz" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcorner"
 	},
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -16045,8 +16552,8 @@
 /area/maintenance/fourthdeck/starboard)
 "SA" = (
 /obj/structure/sign/warning/airlock{
-	icon_state = "doors";
-	dir = 4
+	dir = 4;
+	icon_state = "doors"
 	},
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fourthdeck/fore)
@@ -16122,7 +16629,7 @@
 /area/maintenance/fourthdeck/starboard)
 "SI" = (
 /turf/simulated/wall/prepainted,
-/area/maintenance/substation/fourthdeck)
+/area/maintenance/fourthdeck/aft)
 "SK" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
@@ -16148,8 +16655,8 @@
 "SL" = (
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fourthdeck/aft)
@@ -16173,8 +16680,8 @@
 /area/hallway/primary/fourthdeck/aft)
 "SP" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -16202,6 +16709,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/office)
+"ST" = (
+/obj/effect/wallframe_spawn/no_grille,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id_tag = "sl_office";
+	name = "SL Office Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/security/infantry/com)
 "SU" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -16209,12 +16725,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -16342,6 +16858,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"Tk" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Fourth Deck Substation"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/substation/fourthdeck)
 "Tm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -16356,9 +16885,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/hangar/top)
 "To" = (
-/obj/structure/grille/broken,
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/substation/fourthdeck)
 "Tp" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -16418,6 +16951,20 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/storage/primary)
+"Ty" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/machinery/door/airlock/hatch/maintenance,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/aft)
 "Tz" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -16452,6 +16999,17 @@
 /obj/item/device/binoculars,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/hangcheck)
+"TC" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/table/rack,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/turf/simulated/floor/tiled/techfloor,
+/area/security/infantry/bunk)
 "TD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -16516,33 +17074,28 @@
 /area/quartermaster/deckchief)
 "TP" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
-	},
-/obj/structure/bed/chair{
-	icon_state = "chair_preview";
-	dir = 8
 	},
 /obj/item/modular_computer/telescreen/preset/generic{
 	pixel_x = 32;
 	pixel_y = 0
 	},
+/obj/structure/bed/roller/ironingboard,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
 "TQ" = (
-/obj/structure/grille/broken,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/standard,
+/obj/item/device/megaphone,
+/obj/effect/floor_decal/corner/green/mono,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fourthdeck/aft)
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry/com)
 "TS" = (
 /turf/simulated/open,
 /area/maintenance/fourthdeck/forestarboard)
@@ -16597,6 +17150,10 @@
 "TY" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
+"Ua" = (
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/infantry)
 "Ub" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/power/apc{
@@ -16621,8 +17178,8 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
@@ -16664,12 +17221,12 @@
 	dir = 8
 	},
 /obj/machinery/vending/cigarette{
-	icon_state = "cigs";
-	dir = 8
+	dir = 8;
+	icon_state = "cigs"
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
@@ -16793,8 +17350,8 @@
 	pixel_y = 23
 	},
 /obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/fore)
@@ -16898,8 +17455,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16928,8 +17485,8 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
@@ -17015,8 +17572,8 @@
 /area/maintenance/fourthdeck/forestarboard)
 "Vb" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/light/spot{
 	dir = 8
@@ -17060,8 +17617,8 @@
 /area/maintenance/waterstore)
 "Vi" = (
 /obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -17079,8 +17636,8 @@
 	dir = 5
 	},
 /obj/machinery/computer/modular/preset/dock{
-	icon_state = "console";
-	dir = 4
+	dir = 4;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/deckchief)
@@ -17121,8 +17678,8 @@
 /area/maintenance/fourthdeck/forestarboard)
 "Vy" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 6
+	dir = 6;
+	icon_state = "techfloor_edges"
 	},
 /obj/machinery/button/alternate/door/bolts{
 	id_tag = "supsafedoor";
@@ -17174,8 +17731,8 @@
 	pixel_x = -3
 	},
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/office)
@@ -17187,24 +17744,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "VF" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
-	},
-/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/green{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/turf/simulated/floor/tiled,
+/area/security/infantry/com)
 "VJ" = (
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment{
@@ -17226,6 +17778,18 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/aft)
+"VM" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
@@ -17273,8 +17837,8 @@
 /area/crew_quarters/commissary)
 "VU" = (
 /obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17292,8 +17856,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/cyan{
-	icon_state = "down";
-	dir = 8
+	dir = 8;
+	icon_state = "down"
 	},
 /turf/simulated/open,
 /area/maintenance/fourthdeck/port)
@@ -17321,19 +17885,14 @@
 /turf/simulated/open,
 /area/quartermaster/storage/upper)
 "We" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/effect/floor_decal/corner_techfloor_gray/full,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
-/obj/structure/cable/green,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/substation/fourthdeck)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/security/infantry/com)
 "Wf" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/shuttle_ceiling/torch/air,
@@ -17475,8 +18034,8 @@
 /area/maintenance/fourthdeck/port)
 "WC" = (
 /obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -17533,8 +18092,8 @@
 /area/quartermaster/sorting)
 "WK" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -17568,8 +18127,8 @@
 /area/maintenance/fourthdeck/aft)
 "WR" = (
 /obj/effect/floor_decal/corner/mauve/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/center)
@@ -17602,8 +18161,8 @@
 /area/hallway/primary/fourthdeck/aft)
 "Xd" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 9
+	dir = 9;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/bed/chair,
 /obj/machinery/newscaster{
@@ -17613,8 +18172,8 @@
 /area/crew_quarters/safe_room/fourthdeck)
 "Xe" = (
 /obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -17637,8 +18196,8 @@
 	dir = 4
 	},
 /obj/structure/bed/chair/wood/wings/mahogany{
-	icon_state = "wooden_chair_wings_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "wooden_chair_wings_preview"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
@@ -17652,8 +18211,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -17726,8 +18285,8 @@
 "Xo" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/corner/mauve/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
@@ -17881,8 +18440,8 @@
 /area/maintenance/fourthdeck/forestarboard)
 "XH" = (
 /obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -18030,8 +18589,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18118,8 +18677,8 @@
 /area/hallway/primary/fourthdeck/aft)
 "Yq" = (
 /obj/structure/sign/warning/docking_area{
-	icon_state = "securearea";
-	dir = 8
+	dir = 8;
+	icon_state = "securearea"
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fourthdeck/fore)
@@ -18136,30 +18695,9 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "Yt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/fourthdeck)
+/obj/effect/floor_decal/corner/green/half,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/aft)
 "Yu" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -18294,8 +18832,8 @@
 "YH" = (
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -18317,8 +18855,8 @@
 /area/hallway/primary/fourthdeck/aft)
 "YK" = (
 /obj/structure/sign/warning/docking_area{
-	icon_state = "securearea";
-	dir = 1
+	dir = 1;
+	icon_state = "securearea"
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fourthdeck/fore)
@@ -18350,12 +18888,12 @@
 /area/maintenance/fourthdeck/forestarboard)
 "YR" = (
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
@@ -18479,11 +19017,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
+"Zh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/infantry/exterior)
 "Zj" = (
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
@@ -18554,8 +19111,8 @@
 "Zu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/sorting)
@@ -18598,8 +19155,8 @@
 /area/maintenance/waterstore)
 "Zz" = (
 /obj/machinery/computer/modular/preset/cardslot/command{
-	icon_state = "console";
-	dir = 8
+	dir = 8;
+	icon_state = "console"
 	},
 /obj/effect/floor_decal/corner/mauve/mono,
 /obj/item/device/radio/intercom{
@@ -18618,6 +19175,10 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
+"ZD" = (
+/obj/structure/sign/solgov,
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/infantry)
 "ZE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -18702,8 +19263,8 @@
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/auxillary/starboard)
@@ -18791,8 +19352,8 @@
 	},
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -34444,7 +35005,7 @@ uY
 fv
 gm
 QX
-id
+ca
 fl
 gd
 he
@@ -43340,13 +43901,13 @@ vD
 vD
 pw
 vD
-vD
+rH
 tk
 Mo
-Xn
-Xn
-Xn
-Xn
+fc
+fc
+FN
+fc
 Bo
 OT
 wa
@@ -43541,14 +44102,14 @@ lD
 jF
 dJ
 QW
-ur
 vD
+Cl
 iM
 uM
 cr
 xs
 mU
-bl
+Cd
 fc
 ah
 DX
@@ -43743,15 +44304,15 @@ QL
 gg
 WK
 ny
-Rw
 vD
-iM
+rH
+Fa
 uN
-cr
+Tk
 bl
 To
 KA
-bl
+fc
 ah
 DY
 EQ
@@ -43941,19 +44502,19 @@ go
 hk
 ig
 IZ
-lD
+Rw
 mS
 TP
 Pl
-qC
 vD
-iM
-uO
-cr
+rH
+Fa
+Mo
+fc
 bh
-mU
+yk
 fb
-OB
+fc
 ah
 DY
 EQ
@@ -44148,14 +44709,14 @@ Yc
 vD
 vD
 vD
-vD
-iM
-uO
-cr
-cr
-cr
+sa
+tk
+VM
+Gc
+Gc
+Px
 yM
-cr
+fc
 ah
 DY
 EQ
@@ -44350,10 +44911,10 @@ mT
 od
 Mw
 RE
-OK
+vM
 tp
 sW
-Nx
+Ty
 xu
 rP
 yN
@@ -44550,9 +45111,9 @@ ah
 lH
 mT
 od
-VF
+JS
 SI
-SI
+sa
 tq
 FV
 SI
@@ -44751,20 +45312,20 @@ tC
 yl
 zP
 mV
-TQ
+wi
 bK
-NV
-We
-tr
+SI
+rH
+ts
 Yt
-Sj
+SI
 RG
 yP
 Aj
 MJ
 Nx
 uP
-uP
+sM
 uP
 uP
 uP
@@ -44954,13 +45515,13 @@ kH
 WG
 fe
 od
-cb
+od
 SI
 rO
 ts
 uR
 SI
-ca
+Vj
 yQ
 Ak
 Bu
@@ -45149,19 +45710,19 @@ Vr
 Vr
 Vr
 Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-bH
+ah
+ah
+ah
+ah
+ah
+ah
 fS
-bH
-bH
-bH
-bH
-bH
+fS
+Oi
+vO
+Zh
+JE
+Bg
 bH
 bH
 Vr
@@ -45350,27 +45911,27 @@ Vr
 Vr
 Vr
 Vr
+fQ
 fL
+ip
+ip
+ip
+ip
+ip
 fL
-gO
-gO
-gO
-gO
-gO
-cc
 gA
-hA
-hA
-kY
-hA
 lC
-hA
-cc
-gF
-gF
-gF
-gF
-gF
+HD
+kY
+rW
+lC
+FC
+fS
+zb
+zb
+zb
+zb
+zb
 fI
 kU
 Vr
@@ -45552,22 +46113,22 @@ Vr
 Vr
 Vr
 Vr
-fL
+fQ
 fL
 gS
 im
 gc
-im
+TQ
 is
-cc
-hh
-hG
+ST
 hA
+hJ
+IP
 lm
-hA
-hA
-hA
-cc
+Ps
+hJ
+zL
+fS
 iW
 gx
 jt
@@ -45754,27 +46315,27 @@ aa
 aa
 aa
 aa
-fL
+fQ
 fL
 fO
 hK
-hC
+hK
 jS
 iN
-cc
-hx
+zN
+hA
 hH
 ia
 lp
 lv
-hA
-hA
-cc
+xG
+vY
+fS
 gl
-gR
-jC
 jY
-kI
+jY
+jY
+rM
 fI
 fI
 aa
@@ -45956,26 +46517,26 @@ aa
 aa
 aa
 aa
+fQ
 fL
-fL
-fO
+gO
 jG
 fU
 jT
-iN
-cc
-hh
+uG
+ST
+hA
 hJ
 if
 hA
 lA
-hA
-lC
-cc
+hJ
+zL
+fS
 kV
 iR
-jD
-kb
+iR
+iR
 kI
 fI
 fI
@@ -46158,14 +46719,14 @@ aa
 aa
 aa
 aa
+fQ
 fL
-fL
-fO
+hh
 hC
 fM
 bd
 gK
-cc
+fL
 hy
 hN
 jP
@@ -46173,12 +46734,12 @@ lq
 lF
 lI
 lL
-cc
+fS
 gW
 iX
 jI
-kc
-kI
+iR
+Jd
 fI
 fI
 aa
@@ -46360,27 +46921,27 @@ aa
 aa
 aa
 aa
+fQ
 fL
-fL
-fO
+hx
 ka
 gB
 fX
-gO
-cc
-cc
-cc
+ip
+fL
+ZD
+pF
 km
-cc
+pF
 lE
-cc
-cc
-cc
+pF
+si
+fS
 gF
 iY
 jJ
-kb
-kI
+iR
+TC
 fI
 fI
 aa
@@ -46562,13 +47123,13 @@ aa
 aa
 aa
 aa
+fQ
 fL
-fL
-fO
-hC
-fM
+iq
+kb
+qC
 gI
-gO
+ip
 cs
 li
 ic
@@ -46579,10 +47140,10 @@ lg
 fW
 jQ
 gF
-jp
+pm
 jK
-kc
-kI
+iR
+He
 fI
 fI
 aa
@@ -46764,26 +47325,26 @@ aa
 aa
 aa
 aa
+fQ
 fL
-fL
-fO
+jD
 jM
 gP
-gI
+VF
 ii
 cz
 hF
-hD
-lj
-hD
-hD
-hD
 hF
+lj
+gJ
+gC
+Fu
+gC
 gJ
 jm
 jp
 iR
-kb
+iR
 kI
 fI
 fI
@@ -46966,21 +47527,21 @@ aa
 aa
 aa
 aa
-fL
-fL
+fQ
+fQ
 gU
-dv
-gQ
 hv
-iq
+hv
+hv
+ip
 iu
 hD
-hD
+ke
 kn
 ke
+KT
 ke
-hD
-hD
+CG
 iV
 kR
 js
@@ -47171,9 +47732,9 @@ aa
 fQ
 fQ
 jN
-ip
-ip
-ip
+kc
+ur
+We
 ip
 dq
 ge
@@ -47376,15 +47937,15 @@ cj
 hM
 ih
 gf
-ip
+Hk
 iB
-jV
+jZ
 kG
 kt
 kK
-jZ
+Oz
 gE
-hD
+Ua
 jk
 iE
 jH
@@ -47582,11 +48143,11 @@ iU
 iK
 jZ
 jW
-hD
-hD
-hF
-gE
-hD
+mW
+mW
+mW
+Gk
+Ua
 jl
 jo
 kr
@@ -47780,7 +48341,7 @@ lN
 gV
 lR
 lQ
-fQ
+ip
 fN
 gv
 gH
@@ -47788,7 +48349,7 @@ hI
 hI
 hI
 gH
-hI
+rN
 iL
 jy
 kT

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -31,7 +31,7 @@
 /area/hallway/primary/fourthdeck/aft)
 "ah" = (
 /turf/simulated/wall/r_wall/prepainted,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "ai" = (
 /obj/effect/shuttle_landmark/admin/out,
 /turf/space,
@@ -278,7 +278,7 @@
 "aN" = (
 /obj/machinery/porta_turret/exterior/dagon,
 /turf/simulated/floor/airless,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "aO" = (
 /obj/machinery/porta_turret/exterior/dagon,
 /turf/simulated/floor/airless,
@@ -645,7 +645,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "bB" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/bed/roller,
@@ -754,7 +754,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "bL" = (
 /turf/simulated/floor/tiled/white,
 /area/maintenance/aux_med)
@@ -2410,11 +2410,11 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "eN" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "eO" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled/monotile,
@@ -2567,7 +2567,7 @@
 /obj/random/maintenance,
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "fa" = (
 /obj/structure/bookcase,
 /obj/item/weapon/book/manual/solgov_law,
@@ -2604,7 +2604,7 @@
 /obj/structure/catwalk,
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "ff" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/alarm{
@@ -2627,7 +2627,7 @@
 /obj/structure/ladder/up,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "fi" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -3351,7 +3351,7 @@
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "gz" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Cyborg Charging Station"
@@ -5729,7 +5729,7 @@
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "kI" = (
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor,
@@ -6285,7 +6285,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "lH" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -6293,7 +6293,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "lI" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6328,7 +6328,7 @@
 /obj/random/trash,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "lL" = (
 /obj/machinery/light{
 	dir = 4;
@@ -6879,7 +6879,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "mU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6908,7 +6908,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "mW" = (
 /obj/item/weapon/stool/padded,
 /obj/effect/floor_decal/techfloor{
@@ -6934,7 +6934,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "ng" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/hull,
@@ -7183,7 +7183,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "nQ" = (
 /obj/machinery/button/blast_door{
 	id_tag = "sup_lift";
@@ -7259,7 +7259,7 @@
 /area/hallway/primary/fourthdeck/aft)
 "od" = (
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "of" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 1;
@@ -7275,7 +7275,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "ok" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
@@ -7573,7 +7573,7 @@
 "pp" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced/airless,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "pr" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset,
@@ -7624,7 +7624,7 @@
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "pF" = (
 /obj/effect/wallframe_spawn/no_grille,
 /obj/machinery/door/firedoor{
@@ -7751,7 +7751,7 @@
 /obj/random/junk,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "pU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -8310,7 +8310,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "rT" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/shutters{
@@ -8745,7 +8745,7 @@
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "sQ" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -27
@@ -8902,7 +8902,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "tf" = (
 /obj/structure/lattice,
 /obj/structure/railing/mapped,
@@ -9010,7 +9010,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "tp" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9088,6 +9088,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
+"tx" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/maintenance/fourthdeck/aftport)
 "tA" = (
 /obj/effect/floor_decal/corner/brown/half,
 /obj/structure/railing/mapped,
@@ -9107,7 +9110,7 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "tG" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9;
@@ -9673,7 +9676,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "uR" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10;
@@ -9686,6 +9689,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
+"uS" = (
+/obj/structure/sign/warning/docking_area,
+/turf/simulated/wall/r_wall/hull,
+/area/maintenance/fourthdeck/aftport)
 "uT" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -10077,7 +10084,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/door/blast/regular/escape_pod,
 /turf/simulated/floor/reinforced,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "wd" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Hangar Maintenance"
@@ -10116,11 +10123,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "wp" = (
 /obj/machinery/door/blast/regular/escape_pod,
 /turf/simulated/floor/reinforced/airless,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "wq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10382,7 +10389,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced/airless,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "xb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10462,7 +10469,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "xy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/monotile,
@@ -10481,7 +10488,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "xG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -10812,7 +10819,7 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "yp" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/hangar/top)
@@ -10895,7 +10902,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "yP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10915,7 +10922,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "yQ" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -10927,7 +10934,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "zb" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/infantry/bunk)
@@ -10947,7 +10954,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "zk" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -11258,7 +11265,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "zS" = (
 /turf/simulated/open,
 /area/maintenance/fourthdeck/foreport)
@@ -11327,7 +11334,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "Ak" = (
 /obj/structure/railing/mapped,
 /obj/structure/cable{
@@ -11337,7 +11344,7 @@
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "AC" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11415,7 +11422,7 @@
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "AN" = (
 /obj/random/maintenance/solgov/clean,
 /obj/structure/closet/secure_closet{
@@ -11466,6 +11473,9 @@
 	},
 /turf/simulated/floor/crystal,
 /area/crew_quarters/adherent)
+"Bb" = (
+/turf/simulated/wall/prepainted,
+/area/security/infantry/armory)
 "Bf" = (
 /obj/effect/shuttle_landmark/lift/cargo_top,
 /turf/simulated/floor/tiled/steel_grid,
@@ -11502,7 +11512,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "Bu" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -11511,7 +11521,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "By" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/door/blast/regular/escape_pod,
@@ -11719,7 +11729,7 @@
 "CB" = (
 /obj/machinery/status_display/supply_display,
 /turf/simulated/wall/r_wall/prepainted,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "CD" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable{
@@ -11728,7 +11738,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "CG" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10;
@@ -11889,7 +11899,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "DB" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/largecrate,
@@ -12076,7 +12086,7 @@
 "Ew" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "EE" = (
 /obj/structure/table/rack,
 /obj/random/tech_supply,
@@ -12829,7 +12839,7 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "Hn" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -12962,7 +12972,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "HR" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -13323,9 +13333,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/infantry/exterior)
-"IS" = (
-/turf/simulated/wall/r_wall/hull,
-/area/security/infantry/armory)
 "IT" = (
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
@@ -13357,6 +13364,21 @@
 "IZ" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/laundry)
+"Ja" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/maintenance/fourthdeck/aftport)
+"Jb" = (
+/turf/simulated/wall/r_wall/hull,
+/area/maintenance/fourthdeck/aftport)
 "Jd" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/table/rack,
@@ -13384,7 +13406,7 @@
 	},
 /obj/machinery/door/blast/regular/escape_pod,
 /turf/simulated/floor/reinforced,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "Jm" = (
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/office)
@@ -13425,6 +13447,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
+"Jv" = (
+/turf/simulated/wall/r_wall/hull,
+/area/security/infantry/armory)
 "Jx" = (
 /obj/machinery/light{
 	dir = 8
@@ -13505,7 +13530,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "JL" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13605,7 +13630,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "JU" = (
 /obj/effect/shuttle_landmark/escape_pod/start/pod3,
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -13692,7 +13717,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "Kj" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/corner/green{
@@ -14149,6 +14174,10 @@
 "LG" = (
 /turf/simulated/open,
 /area/maintenance/fourthdeck/port)
+"LH" = (
+/obj/machinery/door/blast/regular/escape_pod,
+/turf/simulated/floor/reinforced/airless,
+/area/maintenance/fourthdeck/aftport)
 "LJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14230,7 +14259,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "LU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -14430,7 +14459,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "Mx" = (
 /obj/machinery/light{
 	dir = 8
@@ -14533,7 +14562,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "MN" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG{
@@ -14784,7 +14813,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "Nu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -14824,7 +14853,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
+"Nz" = (
+/turf/simulated/wall/prepainted,
+/area/maintenance/fourthdeck/aftport)
 "NC" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp/green,
@@ -15102,7 +15134,7 @@
 /area/maintenance/fourthdeck/forestarboard)
 "OB" = (
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "OG" = (
 /obj/structure/railing/mapped,
 /obj/structure/sign/deck/fourth{
@@ -15144,7 +15176,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "OL" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/no_grille,
@@ -15386,7 +15418,7 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "Pn" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -15668,7 +15700,7 @@
 	},
 /obj/random/junk,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "PX" = (
 /obj/machinery/door/blast/shutters{
 	dir = 4;
@@ -15700,7 +15732,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "Qb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -15952,7 +15984,7 @@
 "QU" = (
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/r_wall/hull,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "QV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16204,7 +16236,7 @@
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "RG" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -16220,7 +16252,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "RH" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Maintenance"
@@ -16372,7 +16404,24 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
+"Sc" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/aftstarboard)
 "Sd" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/lounge)
@@ -16632,7 +16681,7 @@
 /area/maintenance/fourthdeck/starboard)
 "SI" = (
 /turf/simulated/wall/prepainted,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "SK" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
@@ -16822,7 +16871,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "Tg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16860,7 +16909,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "Tk" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Fourth Deck Substation"
@@ -16967,7 +17016,7 @@
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "Tz" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -17023,7 +17072,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "TE" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
@@ -17302,7 +17351,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "Us" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -17633,7 +17682,7 @@
 "Vj" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "Vm" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -17657,7 +17706,7 @@
 /area/crew_quarters/lounge)
 "Vr" = (
 /turf/simulated/wall/r_wall/hull,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "Vt" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -17965,9 +18014,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
-"Wr" = (
-/turf/simulated/wall/prepainted,
-/area/security/infantry/armory)
 "Wv" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -18077,7 +18123,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "WH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18107,6 +18153,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
+"WL" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/aftport)
 "WN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18130,7 +18191,7 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftport)
 "WR" = (
 /obj/effect/floor_decal/corner/mauve/half{
 	dir = 1;
@@ -18903,6 +18964,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
+"YS" = (
+/obj/machinery/porta_turret/exterior/dagon,
+/turf/simulated/floor/airless,
+/area/maintenance/fourthdeck/aftport)
 "YV" = (
 /obj/machinery/computer/modular/preset/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -19248,7 +19313,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
+/area/maintenance/fourthdeck/aftstarboard)
 "ZM" = (
 /turf/simulated/wall,
 /area/crew_quarters/adherent)
@@ -44117,7 +44182,7 @@ xs
 mU
 Cd
 fc
-ah
+tx
 DX
 DX
 DX
@@ -44129,9 +44194,9 @@ DX
 DX
 DX
 wc
-JS
+WL
 Ki
-wp
+LH
 pp
 aa
 aa
@@ -44319,7 +44384,7 @@ bl
 To
 KA
 fc
-ah
+tx
 DY
 EQ
 Fy
@@ -44331,9 +44396,9 @@ It
 Sq
 DX
 wc
-JS
+WL
 PV
-wp
+LH
 pp
 aa
 aa
@@ -44521,7 +44586,7 @@ bh
 yk
 fb
 fc
-ah
+tx
 DY
 EQ
 Fz
@@ -44533,9 +44598,9 @@ lo
 GR
 JX
 wc
-JS
+WL
 eZ
-wp
+LH
 pp
 aa
 aa
@@ -44723,7 +44788,7 @@ Gc
 Px
 yM
 fc
-ah
+tx
 DY
 EQ
 FA
@@ -44735,9 +44800,9 @@ Iu
 oM
 DX
 wc
-JS
+WL
 OB
-wp
+LH
 pp
 aa
 aa
@@ -44925,7 +44990,7 @@ xu
 rP
 yN
 Bs
-ah
+tx
 DX
 DX
 DX
@@ -44937,9 +45002,9 @@ DX
 DX
 DX
 wc
-JS
+WL
 OB
-wp
+LH
 pp
 aa
 aa
@@ -45122,27 +45187,27 @@ SI
 sa
 tq
 FV
-SI
+Nz
 tl
 ze
 WO
 og
 CB
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+tx
+tx
+tx
+tx
+tx
+tx
+tx
+tx
+tx
+tx
+tx
 mY
 OB
-Vr
-QU
+Jb
+uS
 aa
 aa
 aa
@@ -45308,7 +45373,7 @@ Nx
 xA
 wi
 wi
-wi
+Sc
 wi
 wi
 JI
@@ -45324,12 +45389,12 @@ SI
 rH
 ts
 Yt
-SI
+Nz
 RG
 yP
 Aj
 MJ
-Nx
+Ja
 uP
 sM
 uP
@@ -45342,9 +45407,9 @@ OK
 OK
 TD
 Ur
-Vr
-Vr
-Vr
+Jb
+Jb
+Jb
 aa
 aa
 aa
@@ -45526,7 +45591,7 @@ SI
 rO
 ts
 uR
-SI
+Nz
 Vj
 yQ
 Ak
@@ -45542,11 +45607,11 @@ Pm
 pD
 pT
 Vj
-Vr
-Vr
-Vr
-Vr
-Vr
+Jb
+Jb
+Jb
+Jb
+Jb
 aa
 aa
 aa
@@ -45731,24 +45796,24 @@ JE
 Bg
 bH
 bH
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-aN
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+YS
 aa
 aa
 aa
@@ -45940,15 +46005,15 @@ zb
 zb
 fI
 kU
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
 aa
 aa
 aa
@@ -46142,15 +46207,15 @@ gx
 kv
 fI
 fI
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-Vr
-aN
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+Jb
+YS
 aa
 aa
 aa
@@ -47533,13 +47598,13 @@ aa
 aa
 aa
 aa
-IS
-IS
+Jv
+Jv
 gU
 hv
 hv
 hv
-Wr
+Bb
 iu
 hD
 ke
@@ -47735,13 +47800,13 @@ aa
 aa
 aa
 aa
-IS
-IS
+Jv
+Jv
 jN
 kc
 ur
 We
-Wr
+Bb
 dq
 ge
 gD
@@ -47937,8 +48002,8 @@ aa
 aa
 aa
 aa
-IS
-IS
+Jv
+Jv
 cj
 hM
 ih
@@ -48139,8 +48204,8 @@ aa
 aa
 aa
 aa
-IS
-IS
+Jv
+Jv
 hE
 do
 lP
@@ -48341,13 +48406,13 @@ aa
 aa
 aa
 aa
-IS
-IS
+Jv
+Jv
 lN
 gV
 lR
 lQ
-Wr
+Bb
 fN
 gv
 gH
@@ -48543,13 +48608,13 @@ aa
 aa
 aa
 aa
-IS
-IS
+Jv
+Jv
 fR
 jU
 fV
 gT
-IS
+Jv
 iT
 iT
 gt
@@ -48746,12 +48811,12 @@ aa
 aa
 aa
 fT
-IS
-IS
-IS
-IS
-IS
-IS
+Jv
+Jv
+Jv
+Jv
+Jv
+Jv
 iT
 gq
 iI

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -695,8 +695,8 @@
 	pixel_y = 22
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig/perma)
@@ -1012,8 +1012,8 @@
 	},
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig/perma)
@@ -2230,8 +2230,8 @@
 "adQ" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig/perma)
@@ -2505,8 +2505,8 @@
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/computer/modular/preset/security{
-	icon_state = "console";
-	dir = 8
+	dir = 8;
+	icon_state = "console"
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -2855,8 +2855,8 @@
 /area/medical/subacute)
 "aeZ" = (
 /obj/machinery/computer/modular/preset/medical{
-	icon_state = "console";
-	dir = 4
+	dir = 4;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue/autopsy)
@@ -3490,8 +3490,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
@@ -3885,8 +3885,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -4117,8 +4117,8 @@
 	sort_type = "Forensics Office"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
@@ -4254,8 +4254,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/flasher{
 	id_tag = "permflash";
@@ -5017,8 +5017,8 @@
 "aiJ" = (
 /obj/structure/hygiene/drain,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig/perma)
@@ -5970,8 +5970,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -6707,8 +6707,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/effect/landmark{
 	name = "JoinLateCyborg"
@@ -6977,8 +6977,8 @@
 "alP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen/multi,
@@ -7347,8 +7347,8 @@
 /area/engineering/auxpower)
 "amx" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -7368,8 +7368,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -7436,8 +7436,8 @@
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/orange,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig/perma)
@@ -7961,8 +7961,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -7976,12 +7976,12 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -8054,8 +8054,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -8165,8 +8165,8 @@
 	dir = 5
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -8318,8 +8318,8 @@
 "aod" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
-	dir = 4
+	dir = 4;
+	icon_state = "map_connector"
 	},
 /turf/simulated/floor/plating,
 /area/rnd/anom_storage/gas)
@@ -8742,8 +8742,8 @@
 	},
 /obj/effect/floor_decal/corner/research/mono,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/anom_storage)
@@ -8778,9 +8778,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 4;
 	icon_state = "corner_white";
-	dir = 4
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10032,12 +10032,12 @@
 /area/security/brig/psionic)
 "arg" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig/psionic)
@@ -10168,8 +10168,8 @@
 	dir = 5
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10186,8 +10186,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -10363,8 +10363,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -10412,8 +10412,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -10553,8 +10553,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig/psionic)
@@ -10731,8 +10731,8 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "Security Hallway - Psionic Holding Aft";
@@ -10742,8 +10742,8 @@
 /area/security/brig/psionic)
 "ash" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -10753,8 +10753,8 @@
 /area/rnd/anom_storage/gas)
 "asi" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
@@ -10840,8 +10840,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -10956,8 +10956,8 @@
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
-	dir = 4
+	dir = 4;
+	icon_state = "map_connector"
 	},
 /turf/simulated/floor/plating,
 /area/rnd/anom_storage/gas)
@@ -11728,8 +11728,8 @@
 	sensor_tag = "a1_sensor"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 10
+	dir = 10;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/anom_storage/living)
@@ -11756,8 +11756,8 @@
 /area/medical/chemistry)
 "auc" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/anom_storage/living)
@@ -11883,8 +11883,8 @@
 /area/rnd/anom_storage/living)
 "aus" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 10
+	dir = 10;
+	icon_state = "warning"
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/dark,
@@ -12325,8 +12325,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/mauve/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
@@ -12369,8 +12369,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/mauve/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -12383,8 +12383,8 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/mauve/half{
-	icon_state = "bordercolorhalf";
-	dir = 4
+	dir = 4;
+	icon_state = "bordercolorhalf"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
@@ -12474,15 +12474,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/mauve/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
 "avq" = (
 /obj/effect/floor_decal/corner/mauve/half{
-	icon_state = "bordercolorhalf";
-	dir = 4
+	dir = 4;
+	icon_state = "bordercolorhalf"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
@@ -12496,15 +12496,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/mauve/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorhalf"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
 "avs" = (
 /obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
@@ -12677,8 +12677,8 @@
 /area/rnd/locker)
 "avG" = (
 /obj/machinery/computer/modular/preset/security{
-	icon_state = "console";
-	dir = 8
+	dir = 8;
+	icon_state = "console"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -16109,8 +16109,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/dark,
@@ -16276,8 +16276,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
@@ -22005,8 +22005,8 @@
 "hKb" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -22208,8 +22208,8 @@
 /area/rnd/development)
 "ibb" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -24628,8 +24628,8 @@
 "lym" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/machinery/microscope,
 /turf/simulated/floor/tiled/white,
@@ -24754,8 +24754,8 @@
 	dir = 8
 	},
 /obj/machinery/computer/modular/preset/medical{
-	icon_state = "console";
-	dir = 4
+	dir = 4;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmreception)
@@ -26018,8 +26018,8 @@
 /area/rnd/entry)
 "nLb" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/ladder,
 /obj/effect/catwalk_plated,
@@ -27633,8 +27633,8 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/detectives_office)

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -60,8 +60,12 @@
 	name = "Fourth Deck Maintenance"
 	icon_state = "maintcentral"
 
-/area/maintenance/fourthdeck/aft
-	name = "Fourth Deck Aft Maintenance"
+/area/maintenance/fourthdeck/aftport
+	name = "Fourth Deck Aft Port Maintenance"
+	icon_state = "amaint"
+
+/area/maintenance/fourthdeck/aftstarboard
+	name = "Fourth Deck Aft Starboard Maintenance"
 	icon_state = "amaint"
 
 /area/maintenance/fourthdeck/foreport


### PR DESCRIPTION

![Fentanyl](https://user-images.githubusercontent.com/54181477/151827160-794240af-ce4f-46b5-88d3-324e9138ffe8.png)


D1 changes can be ignored. It's just SDMM re-ordering vars.

:cl:
maptweak: Infantry prep has been given a new visual
/:cl:  