### PR TITLE
Removes combat augs from loadout

### DIFF
--- a/maps/torch/loadout/loadout_augments.dm
+++ b/maps/torch/loadout/loadout_augments.dm
@@ -1,28 +1,4 @@
 //combat
-/datum/gear/augmentation/nanite_unit
-	display_name = "nanite MCU"
-	path = /obj/item/organ/internal/augment/active/nanounit
-	cost = 15
-	allowed_roles = SECURITY_ROLES
-
-/datum/gear/augmentation/target_comp
-	display_name = "tactical computer"
-	path = /obj/item/organ/internal/augment/boost/shooting
-	cost = 10
-	allowed_branches = MILITARY_BRANCHES
-
-/datum/gear/augmentation/cqc_booster
-	display_name = "close combat reflex booster"
-	path = /obj/item/organ/internal/augment/boost/reflex
-	cost = 15
-	allowed_branches = MILITARY_BRANCHES
-
-/datum/gear/augmentation/subdural_armor
-	display_name = "subdermal armor"
-	path = /obj/item/organ/internal/augment/armor
-	cost = 10
-	allowed_branches = MILITARY_BRANCHES
-
 //utility
 /datum/gear/augmentation/implanted_surgical
 	display_name = "surgical polytool - left arm (ROBOTIC)"


### PR DESCRIPTION
**About The Pull Request**

Removes combat augments from the character preferences loadout.

**Why It's Good For The Game**

Master combat skills now harder to attain, no more free armour for combat situations. Visit robotics and involve yourself in the round to get augments.

**Changelog**

:cl:
tweak: Combat augmentations removed from loadout.
/:cl: