### PR TITLE
Restricts GAS Insuls / Unrestricts Xynergy labcoat

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/xenowear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/xenowear.dm
@@ -88,7 +88,6 @@
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/xyn_machine
 	slot = slot_wear_suit
 	sort_category = "Xenowear"
-	whitelisted = list(SPECIES_IPC)
 
 // Misc clothing
 /datum/gear/uniform/harness

--- a/maps/torch/loadout/loadout_xeno.dm
+++ b/maps/torch/loadout/loadout_xeno.dm
@@ -37,5 +37,6 @@
 	path = /obj/item/clothing/gloves/nabber
 	description = "A set of insulated gloves meant for GAS."
 	whitelisted = list(SPECIES_NABBER)
+	allowed_branches = ENGINEERING_ROLES
 	sort_category = "Xenowear"
 


### PR DESCRIPTION
**About The Pull Request**

Restricts GAS insulated gloves to engineering roles, unrestricts Xynergy labcoat entirely

**Why It's Good For The Game**

No more free insulated gloves for all GAS. Xynergy labcoat can now be worn by all as it's no longer an IPC corp.

**Changelog**

🆑
tweak: Loadout restrictions changed for GAS insulated gloves and Xynergy labcoat.
/🆑