### PR TITLE
Ascent equaliser

### DIFF
--- a/code/game/objects/structures/mineral_bath.dm
+++ b/code/game/objects/structures/mineral_bath.dm
@@ -104,7 +104,7 @@
 		var/repaired_organ
 
 		// Replace limbs for crystalline species.
-		if((H.species.name == SPECIES_ADHERENT || H.species.name == SPECIES_GOLEM) && prob(10))
+		if((H.species.name == SPECIES_ADHERENT || H.species.name == SPECIES_MANTID_ALATE || H.species.name == SPECIES_MANTID_GYNE || H.species.name == SPECIES_GOLEM) && prob(10))
 			for(var/limb_type in H.species.has_limbs)
 				var/obj/item/organ/external/E = H.organs_by_name[limb_type]
 				if(E && !E.is_usable() && !(E.limb_flags & ORGAN_FLAG_HEALS_OVERKILL))


### PR DESCRIPTION
Ascent now properly regenerate limbs in mineral baths (like synths and adherents + golems)


Technically a bug because it only partially worked before.