### PR TITLE
Radburncap

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -11,7 +11,7 @@ Specifically made to do radiation burns.
 		if(species.name == SPECIES_DIONA)
 			return FALSE
 		damage = 0.25 * damage * species.get_radiation_mod(src)
-		adjustFireLoss(clamp(damage,0,10))
+		adjustFireLoss(clamp(damage,0,5))
 
 	updatehealth()
 	return TRUE

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -11,7 +11,7 @@ Specifically made to do radiation burns.
 		if(species.name == SPECIES_DIONA)
 			return FALSE
 		damage = 0.25 * damage * species.get_radiation_mod(src)
-		adjustFireLoss(damage)
+		adjustFireLoss(clamp(damage,0,10))
 
 	updatehealth()
 	return TRUE


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

It is possible to deal over 2000 damage using radiation burns if you use certain methods. I am noticing that this PR also nerfs radiation based weaponry too but this code is making me cry. Carl if you have questions. I can DM you the meme I have discovered.

:cl: 
balance: Radiation burns are capped at 5.
/:cl: