### PR TITLE
Merchant On-Ship QOL!

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -4811,6 +4811,11 @@
 	dir = 4;
 	icon_state = "techfloor_edges"
 	},
+/obj/machinery/button/alternate/door{
+	id_tag = "starboard_storage";
+	name = "Door Bolt";
+	pixel_y = -22
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/auxillary/starboard)
 "jd" = (
@@ -5933,7 +5938,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/mining{
-	id_tag = null;
+	id_tag = "starboard_storage";
 	name = "Starboard Auxiliary Storage"
 	},
 /obj/effect/floor_decal/techfloor/corner{
@@ -8231,14 +8236,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
-"rv" = (
-/obj/effect/floor_decal/corner/brown/mono,
-/obj/machinery/door/airlock/civilian{
-	id_tag = "shop_doors";
-	name = "Commissary Counter"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/crew_quarters/commissary)
 "rD" = (
 /obj/machinery/computer/ship/navigation{
 	dir = 4;
@@ -15108,6 +15105,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
+"Ov" = (
+/obj/effect/floor_decal/corner/brown/mono,
+/obj/machinery/door/airlock/civilian{
+	id_tag = "shop_doors";
+	name = "Commissary Counter"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/commissary)
 "Ow" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -18604,11 +18609,11 @@
 	pixel_x = -22;
 	pixel_y = 0
 	},
-/obj/machinery/button/blast_door{
+/obj/machinery/button/alternate/door{
 	id_tag = "shop_doors";
 	name = "Door Lockdown";
 	pixel_x = -24;
-	pixel_y = 7;
+	pixel_y = 6;
 	req_access = list(list("ACCESS_HEADS","ACCESS_TORCH_SHOP"))
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -31653,7 +31658,7 @@ aa
 YK
 WZ
 WZ
-rv
+Ov
 UO
 UO
 UO

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -5456,7 +5456,6 @@
 /area/command/pathfinder)
 "kj" = (
 /obj/machinery/door/airlock/glass/civilian{
-	autoset_access = 0;
 	name = "Commissary"
 	},
 /obj/machinery/door/firedoor,
@@ -8232,6 +8231,14 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
+"rv" = (
+/obj/effect/floor_decal/corner/brown/mono,
+/obj/machinery/door/airlock/civilian{
+	id_tag = "shop_doors";
+	name = "Commissary Counter"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/commissary)
 "rD" = (
 /obj/machinery/computer/ship/navigation{
 	dir = 4;
@@ -17160,6 +17167,7 @@
 /area/command/pathfinder)
 "TU" = (
 /obj/machinery/door/airlock/civilian{
+	id_tag = "shop_doors";
 	name = "Commissary Counter"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
@@ -18595,6 +18603,13 @@
 	icon_state = "alarm0";
 	pixel_x = -22;
 	pixel_y = 0
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "shop_doors";
+	name = "Door Lockdown";
+	pixel_x = -24;
+	pixel_y = 7;
+	req_access = list(list("ACCESS_HEADS","ACCESS_TORCH_SHOP"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/commissary)
@@ -31638,7 +31653,7 @@ aa
 YK
 WZ
 WZ
-UO
+rv
 UO
 UO
 UO


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Adds a brand new door leading into the commissary that the merchant can use to quickly get in the counter. Also removes the pointless access restriction from the front door and adds in a door bolt button for both the merchant's door and the front counter door. Now, the merchant can take stuff from their shuttle and post up in the ship's shop proper. 
Finally, adds a button to toggle the door bolt to the starboard aft auxiliary storage from the inside, allowing the merchant to use it as storage without risk of *easy* theft. There's a big fucking shutter door leading out into the merchant's hallway, I think it was meant for them to use it anyways.

This allows for ENTIRELY NEW, NEVER BEFORE SEEN gameplay for the merchant where they set shit up on the ship and use their shuttle for supply runs or escaping only. Nuts.
pic for lazy idiots
![image](https://user-images.githubusercontent.com/54787585/152631338-3134e8bf-bb8c-414f-b5bb-b9410b34a61b.png)

