### PR TITLE
Inflatable Module to Security Borg

### DIFF
--- a/code/modules/mob/living/silicon/robot/modules/module_security.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_security.dm
@@ -55,6 +55,7 @@
 		/obj/item/device/megaphone,
 		/obj/item/device/holowarrant,
 		/obj/item/weapon/crowbar,
+		/obj/item/weapon/inflatable_dispenser/robot,
 		/obj/item/device/hailer
 	)
 	emag = /obj/item/weapon/gun/energy/laser/mounted


### PR DESCRIPTION
Adds a inflatable dispenser to the Security Borg, so it can attend atmospherically compromised situations without immediately venting the ship. Should just be a QOL for engineering players.