### PR TITLE
Fixes #1115

### DIFF
--- a/maps/torch/job/hestia_jobs.dm
+++ b/maps/torch/job/hestia_jobs.dm
@@ -46,9 +46,6 @@
 	allowed_ranks = list(
 		/datum/mil_rank/marine_corps/e6
 	)
-	access = list(access_maint_tunnels, access_solgov_crew, access_petrov, access_petrov_security,
-			            access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy, access_hangar, access_guppy_helm, access_infantry,
-			            access_infcom, access_inftech, access_aquila, access_eva)
 
 /datum/job/squad_lead
 	title = "Squad Lead"
@@ -74,6 +71,10 @@
 	max_skill = list(	SKILL_COMBAT      = SKILL_MAX,
 						SKILL_WEAPONS     = SKILL_MAX,
 						SKILL_EVA		  = SKILL_MAX)
+
+	access = list(access_maint_tunnels, access_solgov_crew, access_petrov, access_petrov_security,
+			            access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy, access_hangar, access_guppy_helm, access_infantry,
+			            access_infcom, access_inftech, access_infmed, access_aquila, access_eva)
 
 	software_on_spawn = list(/datum/computer_file/program/deck_management,
 							 /datum/computer_file/program/reports)


### PR DESCRIPTION
Adds infmed and inftech access to the infantry squad leader, so they should now be able to access the specialised lockers if required. Also moved the access list down to the same place every other role has it.

Fixes #1115.