### PR TITLE
Psionic Advisor Access Nerf

### DIFF
--- a/maps/torch/job/hestia_jobs.dm
+++ b/maps/torch/job/hestia_jobs.dm
@@ -241,8 +241,7 @@
 		SKILL_WEAPONS     = SKILL_EXPERT
 	)
 	skill_points = 30
-	access = list(access_psiadvisor, access_security, access_medical, access_engine, access_maint_tunnels, access_external_airlocks,
-				access_eva, access_bridge, access_cargo, access_RC_announce, access_solgov_crew, access_hangar)
+	access = list(access_psiadvisor, access_security, access_medical, access_maint_tunnels, access_bridge, access_RC_announce, access_solgov_crew, access_hangar)
 	minimal_access = list()
 	software_on_spawn = list(
 		/datum/computer_file/program/comm,


### PR DESCRIPTION
This nerf helps to curtail the rather large access the Psi-Advisor was having. A quick evaluation brings them more in line with a medical doctor but with their obvious bridge permissions, retaining their access to some areas of medical but losing their ability to go EVA.

It removes their access from: 

- Engineering
- Cargo
- EVA
- External Airlocks