### PR TITLE
slime man go brrr

### DIFF
--- a/code/modules/species/station/prometheans.dm
+++ b/code/modules/species/station/prometheans.dm
@@ -34,11 +34,10 @@ var/datum/species/shapeshifter/promethean/prometheans
 	blood_volume =        600
 	min_age =             18
 	max_age =             125
-	brute_mod =           0.8
-	burn_mod =            1.2
+	brute_mod =           2
+	burn_mod =            2
 	toxins_mod =          0.1
 	oxy_mod =             0
-	total_health =        400
 	siemens_coefficient = -1
 	rarity_value =        5
 	slowdown = 0.5

--- a/maps/away/ascent/ascent.dm
+++ b/maps/away/ascent/ascent.dm
@@ -10,12 +10,11 @@
 	id = "awaysite_ascent_seedship"
 	description = "A small Ascent colony ship."
 	suffixes = list("ascent/ascent-1.dmm", "ascent/ascent-2.dmm")
-	cost = 0//from 0.5
+	cost = 0.5
 	shuttles_to_initialise = list(
 		/datum/shuttle/autodock/overmap/ascent,
 		/datum/shuttle/autodock/overmap/ascent/two
 	)
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 // Overmap objects.
 /obj/effect/overmap/visitable/ship/ascent_seedship

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -10,10 +10,9 @@
 	id = "awaysite_voxship"
 	description = "Vox ship."
 	suffixes = list("voxship/voxship-1.dmm")
-	cost = 0//from 0.5
+	cost = 0.5
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_shuttle)
 	area_usage_test_exempted_root_areas = list(/area/voxship)
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 
 /obj/effect/overmap/visitable/ship/voxship


### PR DESCRIPTION
- - -
Balance:
 - Prometheans now take 200% brute damage, as opposed to the 80% prior.
 - Prometheans now take 200% burn damage, as opposed to the 120% prior.
 - Prometheans no longer have 400 health.
 - Ascent ship no longer a guaranteed spawn. Testing has concluded.
 - Vox ship no longer a guaranteed spawn. Testing has concluded.
- - -