### PR TITLE
Fix: Fleet Officer Fatigues for Fleeties!

### DIFF
--- a/maps/torch/loadout/loadout_uniform_boh.dm
+++ b/maps/torch/loadout/loadout_uniform_boh.dm
@@ -23,6 +23,6 @@
 	display_name = "fleet officer fatigues"
 	path = /obj/item/clothing/under/solgov/utility/fleet/officer
 	cost = 0
-	allowed_branches = NT_BRANCHES 
+	allowed_branches = list(/datum/mil_branch/fleet)
 	allowed_roles = COMMANDANDOFFICER_ROLES
 


### PR DESCRIPTION
Follow up to my previous change, turns fleet officer fatigue on for navy bois. 

Genuine question for someone reading, if I'm getting this correctly it's basically a checklist for 'In fleet' with list(/datum/mil_branch/fleet) and then another check for allowed_roles = COMMANDANDOFFICER_ROLES right?