### PR TITLE
STS Rebalance- Full auto, Accuracy changes, Dispersion

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -142,11 +142,13 @@
 	mag_insert_sound = 'sound/weapons/guns/interaction/ltrifle_magin.ogg'
 	mag_remove_sound = 'sound/weapons/guns/interaction/ltrifle_magout.ogg'
 
-	//Assault rifle, burst fire degrades quicker than SMG, worse one-handing penalty, slightly increased move delay
+	// Assault rifle, automatic fire fires 4 shots a second, burst fire is slightly faster in coming out, but overall automatic should feel faster.
+	// Semi auto is a bit more accurate here. It treats all accuracy checks as if they're a tile closer overall.
+
 	firemodes = list(
-		list(mode_name="semi auto",       burst=1, fire_delay=null,    move_delay=null, one_hand_penalty=8, burst_accuracy=null, dispersion=null),
-		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=6,    one_hand_penalty=9, burst_accuracy=list(0,-1,-1),       dispersion=list(0.0, 0.6, 1.0)),
-		list(mode_name="short bursts",   burst=5, fire_delay=null, move_delay=6,    one_hand_penalty=11, burst_accuracy=list(0,-1,-2,-3,-3), dispersion=list(0.6, 1.0, 1.2, 1.2, 1.5)),
+		list(mode_name="semi auto", automatic = FALSE, fire_delay= 4, burst=1, burst_delay = 2, move_delay=null, one_hand_penalty=8, accuracy = 2, burst_accuracy=null, dispersion=null),
+		list(mode_name="3-round bursts", automatic = FALSE, fire_delay= 4, burst_delay = 2, burst=4, move_delay=6, one_hand_penalty=9, accuracy = 1, burst_accuracy=list(0,-1,-1,-2,-2), dispersion=list(0.0, 0.6, 1.0)),
+		list(mode_name="automatic",  automatic = TRUE, fire_delay = 2.5, burst = 1, burst_delay = 0, move_delay=6, one_hand_penalty=11, accuracy = 1, burst_accuracy=list(0,0,-1,-1,-1,-1,-2,-2), dispersion=list(0.6, 1.0, 1.2, 1.2, 1.5)),
 		)
 
 /obj/item/weapon/gun/projectile/automatic/assault_rifle/on_update_icon()


### PR DESCRIPTION
## About The Pull Request
STS-35 Rebalance, Dispersion lowered a bit, Accuracy up on Semi auto to give a reason to use it, dispersion down overall.
Burst is a bit more accurate.
Full auto replaces long burst, as they fit the same idea.

2.5 means you'll get .25, which means your fire delay will

Need new sounds.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the STS more unique, other guns can get full auto in the future but this is a nice limited testbed for an assault rifle.

## Changelog
:cl:
Balance: STS-35 rebalance- Dispersion lowered a bit, Accuracy up on Semi auto to give a reason to use it, dispersion down overall. Burst is a bit more accurate, Full Auto replaces Long Burst.
/:cl: