### PR TITLE
Makes putting pills in beakers less CBT

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -195,12 +195,29 @@
 	if(zone == BP_MOUTH && target.can_eat())
 		user.visible_message("<span class='notice'>[user] pops a pill from \the [src].</span>")
 		playsound(get_turf(src), 'sound/effects/peelz.ogg', 50)
-		var/list/peelz = filter_list(contents,/obj/item/weapon/reagent_containers/pill/)
+		var/list/peelz = filter_list(contents,/obj/item/weapon/reagent_containers/pill)
 		if(peelz.len)
 			var/obj/item/weapon/reagent_containers/pill/P = pick(peelz)
 			remove_from_storage(P)
 			P.attack(target,user)
 			return 1
+
+
+/obj/item/weapon/storage/pill_bottle/afterattack(obj/target, mob/living/user, proximity)
+	if(!proximity)
+		return
+	if(target.is_open_container() && target.reagents)
+		if(!target.reagents.total_volume)
+			to_chat(user, SPAN_NOTICE("[target] is empty. Can't dissolve a pill."))
+			return
+
+		var/list/peelz = filter_list(contents,/obj/item/weapon/reagent_containers/pill)
+		if(peelz.len)
+			var/obj/item/weapon/reagent_containers/pill/P = pick(peelz)
+			remove_from_storage(P)
+			P.afterattack(target, user, proximity)
+	return
+
 
 /obj/item/weapon/storage/pill_bottle/attack_self(mob/living/user)
 	if(user.get_inactive_hand())


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

You can now click a beaker with a pill container to dissolve a pill in it instead of having to pull the pill out. I swear to god this matters. Thanks to @Kathyryals for letting me steal this