### PR TITLE
carl does a bad pt.2

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -977,6 +977,7 @@
 		/obj/item/weapon/handcuffs = 8,
 		/obj/item/weapon/grenade/flashbang = 4,
 		/obj/item/weapon/grenade/chem_grenade/teargas = 4,
+		/obj/item/weapon/grenade/frag/rubber = 4,
 		/obj/item/device/flash = 5,
 		/obj/item/weapon/reagent_containers/food/snacks/donut/normal = 12,
 		/obj/item/weapon/storage/box/evidence = 6,

--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -96,12 +96,60 @@
 
 /obj/item/weapon/grenade/frag/rubber
 	name = "stinger grenade"
-	desc = "A Stinger grenade, a grenade releasing a huge amount of tiny rubber balls made to cause extreme pain and trauma to anyone it hits to nonleathally disable them, but may still cause severe injuries."
+	desc = "A grenade designed to release hundreds of rubber balls. While less-than-lethal, it is still capable of injuring or horribly disfiguring a suspect."
 	icon_state = "concussion"
 	fragment_types = list(/obj/item/projectile/bullet/pellet/rubber=1)
-	num_fragments = 69
+	num_fragments = 224
 	explosion_size = 0 // Rubber grenade, doesn't have explosives.
 
 /obj/item/projectile/bullet/pellet/rubber // Rubber balls, deal agony and a tiny bit of damage.
+	name = "rubber ball"
 	damage = 5
 	agony = 25
+	embed = 1
+	sharp = 0
+
+/obj/item/projectile/bullet/pellet/rubber/on_hit(var/atom/target, var/blocked = 0, var/alien)
+	..()
+	var/eyes_covered = 0
+
+	var/effective_strength = 5
+
+	var/obj/item/safe_thing = null
+
+	if(!istype(target, /mob/living/carbon/human))
+		return
+	if(alien == IS_SKRELL)	//Larger eyes means bigger targets.
+		effective_strength = 8
+
+	if(alien == IS_DIONA)
+		effective_strength = 1
+
+	var/mob/living/carbon/human/M = target
+	if(istype(target, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = M
+		if(!H.can_feel_pain())
+			return
+		if(H.head)
+			if(H.head.body_parts_covered & EYES)
+				eyes_covered = 1
+				safe_thing = H.head
+		if(H.wear_mask)
+			if(!eyes_covered && H.wear_mask.body_parts_covered & EYES)
+				eyes_covered = 1
+				safe_thing = H.wear_mask
+		if(H.glasses && H.glasses.body_parts_covered & EYES)
+			if(!eyes_covered)
+				eyes_covered = 1
+				if(!safe_thing)
+					safe_thing = H.glasses
+	if(eyes_covered)
+		to_chat(M, "<span class='warning'>Your [safe_thing] protects you from the rubber ball!</span>")
+	else
+		if(prob(20) && EYES)
+//			M.apply_damage(EYES,15,BRUTE) //I was tired. Someone else fix this or something if you want it.
+			to_chat(M, "<span class='warning'>A rubber ball lodges itself into your eye!</span>")
+			to_chat(M, "<span class='warning'>Oh god, the pain!</span>")
+			M.eye_blurry = max(M.eye_blurry, effective_strength * 5)
+			M.eye_blind = max(M.eye_blind, effective_strength)
+			M.apply_effect(6 * effective_strength, PAIN, 0)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -259,6 +259,12 @@
 	icon_state = "radbox"
 	startswith = list(/obj/item/weapon/grenade/supermatter = 5)
 
+/obj/item/weapon/storage/box/stinger
+	name = "box of stinger grenades"
+	desc = "A box containing 6 stinger grenades. <br> WARNING: Device carries risk of serious injury or death when deployed."
+	icon_state = "flashbang"
+	startswith = list(/obj/item/weapon/grenade/frag/rubber = 6)
+
 /obj/item/weapon/storage/box/trackimp
 	name = "boxed tracking implant kit"
 	desc = "Box full of scum-bag tracking utensils."

--- a/code/modules/boh_misc/vending.dm
+++ b/code/modules/boh_misc/vending.dm
@@ -2,7 +2,7 @@
 // Sec
 /////////
 
-/obj/machinery/vending/security/accessory
+/obj/machinery/vending/accessory
 	name = "SecTech - Accessory"
 	desc = "A security accessory vendor."
 //	product_ads = "Crack capitalist skulls!;Beat some heads in!;Don't forget - harm is good!;Your weapons are right here.;Handcuffs!;Freeze, scumbag!;Don't tase me bro!;Tase them, bro.;Why not have a donut?"
@@ -10,7 +10,6 @@
 	icon_deny = "sec-deny"
 	icon_vend = "sec-vend"
 	vend_delay = 14
-	base_type = /obj/machinery/vending/security
 	req_access = list(access_security)
 	products = list(
 		/obj/item/clothing/accessory/armguards = 12,

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -55,7 +55,7 @@
 	siemens_coefficient = 0.2
 
 	species_flags = SPECIES_FLAG_NO_SCAN
-	spawn_flags = SPECIES_CAN_JOIN // | SPECIES_IS_WHITELISTED
+	spawn_flags = SPECIES_CAN_JOIN// | SPECIES_IS_WHITELISTED
 	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
 
 	blood_color = "#2299fc"
@@ -188,3 +188,64 @@
 		to_chat(grabber, SPAN_WARNING("You drop everything in a rage as you seize \the [target]!"))
 		playsound(grabber.loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 	. = ..(grabber, target, GRAB_ARMALIS)
+
+
+/datum/species/vox/pariah
+	name = SPECIES_VOXPARIAH
+	description = "Sickly biproducts of Vox society, these creatures are vilified by their own kind \
+	and taken advantage of by enterprising companies for cheap, disposable labor. \
+	They aren't very smart, smell worse than a vox, and vomit constantly, \
+	earning them the true title of 'shitbird'."
+	rarity_value = 0.1
+	speech_chance = 60        // No volume control.
+	siemens_coefficient = 0.5 // Ragged scaleless patches.
+	unarmed_types = list(
+		/datum/unarmed_attack/stomp,
+		/datum/unarmed_attack/kick,
+		/datum/unarmed_attack/claws/,
+		/datum/unarmed_attack/punch,
+		/datum/unarmed_attack/bite/
+	)
+
+	oxy_mod = 1.4
+	brute_mod = 1.3
+	burn_mod = 1.4
+	toxins_mod = 1.3
+
+	cold_level_1 = 130
+	cold_level_2 = 100
+	cold_level_3 = 60
+
+	warning_low_pressure = WARNING_LOW_PRESSURE
+	hazard_low_pressure = HAZARD_LOW_PRESSURE
+
+	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick,  /datum/unarmed_attack/claws, /datum/unarmed_attack/bite)
+
+	// Pariahs have no stack.
+	has_organ = list(
+		BP_STOMACH =    /obj/item/organ/internal/stomach/vox,
+		BP_HEART =      /obj/item/organ/internal/heart/vox,
+		BP_LUNGS =      /obj/item/organ/internal/lungs/vox,
+		BP_LIVER =      /obj/item/organ/internal/liver/vox,
+		BP_KIDNEYS =    /obj/item/organ/internal/kidneys/vox,
+		BP_BRAIN =      /obj/item/organ/internal/pariah_brain,
+		BP_EYES =       /obj/item/organ/internal/eyes/vox,
+		BP_HINDTONGUE = /obj/item/organ/internal/hindtongue
+		)
+
+	descriptors = list(
+		/datum/mob_descriptor/height = -1,
+		/datum/mob_descriptor/build = 1,
+		/datum/mob_descriptor/pariah_stink = 0
+	)
+
+	species_flags = SPECIES_FLAG_NO_SCAN//shouldn't be needed, but in game happenings have shown otherwise. For some reason.
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_NO_LACE
+	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
+
+/datum/species/vox/pariah/get_bodytype(var/mob/living/carbon/human/H)
+	return SPECIES_VOX
+
+// No combat skills for you.
+/datum/species/vox/pariah/can_shred(var/mob/living/carbon/human/H, var/ignore_intent)
+	return 0

--- a/maps/torch/infantry/firearms.dm
+++ b/maps/torch/infantry/firearms.dm
@@ -151,7 +151,7 @@
 		list(mode_name="fire", burst=1, fire_delay=null, move_delay=null, one_hand_penalty=12, burst_accuracy=null, dispersion=null),
 		)
 
-/obj/item/weapon/gun/launcher/projectile/recoilless/sec/free_fire()
+/obj/item/weapon/gun/projectile/rocket/recoilless/sec/free_fire()
 	var/my_z = get_z(src)
 	if(!GLOB.using_map.station_levels.Find(my_z))
 		return TRUE

--- a/maps/torch/infantry/storage.dm
+++ b/maps/torch/infantry/storage.dm
@@ -47,6 +47,7 @@
 	var/list/options = list()
 	options["Ballistic - GS-95"] = list(/obj/item/weapon/gun/projectile/shotgun/sabotgun,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/frag)
 	options["Ballistic - Z9"] = list(/obj/item/weapon/gun/projectile/automatic/bullpup_rifle/sec,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/frag)
+	options["Ballistic - C-20b"] = list(/obj/item/weapon/gun/projectile/automatic/merc_smg/sec,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/frag)
 	options["Energy - G40C"] = list(/obj/item/weapon/gun/energy/laser/infantry/sl,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/frag)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)
@@ -63,6 +64,7 @@
 
 /obj/item/gunbox/inftech/attack_self(mob/living/user)
 	var/list/options = list()
+	options["Explosive - L-19 Disposable Launcher"] = list(/obj/item/weapon/gun/projectile/rocket/oneuse/marine,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/frag)
 	options["Explosive - TVP-3, Recoilless Rifle"] = list(/obj/item/weapon/gun/projectile/rocket/recoilless/sec,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/frag)
 	options["Ballistic - Z6, Light Machinegun"] = list(/obj/item/weapon/gun/projectile/automatic/bullpup_rifle/sec/lmg,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/frag)
 	options["Energy - G40B"] = list(/obj/item/weapon/gun/energy/laser/infantry,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/frag)

--- a/maps/torch/infantry/vending.dm
+++ b/maps/torch/infantry/vending.dm
@@ -1,6 +1,10 @@
-/obj/machinery/vending/security/infantry
+/obj/machinery/vending/infantry
 	name = "InfTech"
 	desc = "A munition vendor."
+	icon_state = "sec"
+	icon_deny = "sec-deny"
+	icon_vend = "sec-vend"
+	vend_delay = 14
 	req_access = list(access_infantry)
 	products = list(
 		/obj/item/ammo_magazine/mil_rifle/sec = 12,

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -886,6 +886,22 @@
 /obj/random/illegal,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/fourthdeck/forestarboard)
+"cb" = (
+/obj/structure/dogbed,
+/obj/random/plushie,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/green,
+/obj/item/weapon/pen/crayon/blue,
+/mob/living/simple_animal/corgi/Lisa,
+/turf/simulated/floor/tiled/monotile,
+/area/security/infantry)
 "cd" = (
 /obj/structure/railing/mapped,
 /obj/structure/lattice,
@@ -5258,22 +5274,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/infantry/exterior)
-"jQ" = (
-/obj/structure/dogbed,
-/obj/random/plushie,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/mob/living/simple_animal/corgi/Lisa,
-/obj/effect/floor_decal/corner/green{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/green,
-/obj/item/weapon/pen/crayon/blue,
-/turf/simulated/floor/tiled/monotile,
-/area/security/infantry)
 "jR" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4;
@@ -5295,12 +5295,6 @@
 /obj/effect/floor_decal/corner/green/half{
 	dir = 8;
 	icon_state = "bordercolorhalf"
-	},
-/turf/simulated/floor/tiled,
-/area/security/infantry/com)
-"jT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/security/infantry/com)
@@ -5359,7 +5353,7 @@
 /turf/simulated/floor/tiled,
 /area/security/infantry/com)
 "kc" = (
-/obj/machinery/vending/security/infantry,
+/obj/machinery/vending/infantry,
 /obj/effect/floor_decal/corner_techfloor_gray{
 	dir = 9
 	},
@@ -9441,7 +9435,7 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "ur" = (
-/obj/machinery/vending/security/accessory{
+/obj/machinery/vending/accessory{
 	req_access = list("ACCESS_INFANTRY")
 	},
 /obj/effect/floor_decal/corner_techfloor_gray{
@@ -46614,7 +46608,7 @@ fL
 gO
 jG
 fU
-jT
+kb
 uG
 ST
 hA
@@ -47230,7 +47224,7 @@ jA
 gC
 lg
 fW
-jQ
+cb
 gF
 pm
 jK

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -559,7 +559,7 @@
 	health = 1e+006
 	},
 /obj/item/weapon/storage/box/ammo/pepperball/full,
-/obj/item/weapon/storage/box/ammo/pepperball/full,
+/obj/item/weapon/storage/box/ammo/solar/rubber,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "aaU" = (
@@ -2897,7 +2897,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/vending/security/accessory,
+/obj/machinery/vending/accessory,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "afe" = (
@@ -3447,25 +3447,24 @@
 /area/security/storage)
 "agd" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 1
 	},
 /obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
 /obj/structure/window/reinforced{
 	health = 1e+007
 	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/weapon/storage/box/flares,
-/obj/item/weapon/storage/box/flares,
+/obj/item/weapon/grenade/frag/rubber,
+/obj/item/weapon/grenade/frag/rubber,
+/obj/item/weapon/grenade/frag/rubber,
+/obj/item/weapon/grenade/frag/rubber,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "age" = (
@@ -4068,22 +4067,25 @@
 /area/maintenance/firstdeck/centralstarboard)
 "ahc" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/table/rack/shelf/steel,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
 /obj/structure/window/reinforced{
 	health = 1e+007
 	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/item/weapon/storage/box/flashbangs,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /obj/item/weapon/storage/box/teargas,
+/obj/item/weapon/storage/box/flashbangs,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "ahd" = (
@@ -9738,8 +9740,7 @@
 /obj/machinery/light,
 /obj/structure/window/reinforced,
 /obj/structure/table/rack,
-/obj/item/weapon/storage/box/greenglowsticks,
-/obj/item/weapon/storage/box/greenglowsticks,
+/obj/item/weapon/storage/box/stinger,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "aqJ" = (
@@ -12732,6 +12733,12 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/security/wing)
+"avJ" = (
+/obj/structure/sign/warning/secure_area{
+	dir = 1
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/armoury)
 "avS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -18560,12 +18567,6 @@
 /obj/item/weapon/bedsheet/blue,
 /turf/simulated/floor/carpet/orange,
 /area/crew_quarters/safe_room/firstdeck)
-"csy" = (
-/obj/structure/sign/warning/secure_area{
-	dir = 1
-	},
-/turf/simulated/wall/prepainted,
-/area/security/armoury)
 "ctb" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
@@ -30303,9 +30304,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
-"tiQ" = (
-/turf/simulated/wall/prepainted,
-/area/security/armoury)
 "tjb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -39388,7 +39386,7 @@ cZi
 cZi
 aLv
 aLv
-tiQ
+sHN
 aPu
 aPu
 aPu
@@ -39585,12 +39583,12 @@ sik
 sik
 sik
 nli
-ahc
+agd
 cZi
 cZi
 aLv
 abQ
-tiQ
+sHN
 hLf
 adm
 adm
@@ -39792,7 +39790,7 @@ huf
 enM
 enM
 enM
-csy
+avJ
 asM
 adh
 adH
@@ -39991,7 +39989,7 @@ daB
 hGs
 gGO
 aaV
-agd
+ahc
 afd
 bii
 hzl
@@ -40196,7 +40194,7 @@ agc
 aae
 aaT
 kCN
-tiQ
+sHN
 asO
 adl
 adO
@@ -40398,7 +40396,7 @@ uRO
 enM
 aLy
 aMC
-tiQ
+sHN
 hLf
 aPu
 aPu
@@ -40600,7 +40598,7 @@ cxk
 acU
 abK
 aga
-tiQ
+sHN
 amU
 ajj
 afl


### PR DESCRIPTION
- - -
Lets get the bad out of the way first -
Re-addition:
 - Pariahs. That's it. They exist. I'm sorry. May god have mercy on us all.
- - -
Map:
 - SL's office had a vestigel scrubber. This has been removed.
 - Security's armoury given reinforced walls.
 - Security's armoury updated slightly to add stinger grenades.
- - -
Balance:
 - Rubber mags now available in the soft armoury, replacing one box of pepperball mags.
 - Stingers now have BDE, while being available exclusively to Security.
 - Returns the C-20b to the SL.
 - An alternative to the recoilless rifle has been provided in the form of a disposable launcher, courtesy of Pariah919.
- - -
Bugfixes:
 - Path errors corrected for the recoilless rifle.
 - Vending machines for sectech/accessory/inftech separated, preventing conflicting products.
- - -