### PR TITLE
Modular computers no longer give off light when turned off.

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/dev_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_console.dm
@@ -41,6 +41,15 @@
 		os.ui_interact(user)
 	return TRUE
 
+/obj/machinery/computer/modular/on_update_icon()
+	. = ..()
+	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
+	if(os)
+		if(os.on)
+			set_light(light_max_bright_on, light_inner_range_on, light_outer_range_on, 2, light_color)
+		else
+			set_light(0)
+
 /obj/machinery/computer/modular/get_screen_overlay()
 	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
 	if(os)

--- a/code/modules/modular_computers/ntos/subtypes/device.dm
+++ b/code/modules/modular_computers/ntos/subtypes/device.dm
@@ -16,20 +16,20 @@
 /datum/extension/interactive/ntos/device/recalc_power_usage()
 	var/obj/item/modular_computer/C = holder
 	C.calculate_power_usage()
-	
+
 /datum/extension/interactive/ntos/device/emagged()
 	var/obj/item/modular_computer/C = holder
 	return C.computer_emagged
 
 /datum/extension/interactive/ntos/device/system_shutdown()
-	..()
 	var/obj/item/modular_computer/C = holder
 	C.enabled = FALSE
+	..()
 
 /datum/extension/interactive/ntos/device/system_boot()
-	..()
 	var/obj/item/modular_computer/C = holder
 	C.enabled = TRUE
+	..()
 
 /datum/extension/interactive/ntos/device/extension_act(href, href_list, user)
 	. = ..()
@@ -49,5 +49,5 @@
 	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
 	if(os)
 		return os.check_eye()
-	else 
+	else
 		return ..()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

PDAs, tablets etc, now only give offflight when the screen is on, allowing you to sneak around a bit better. Thanks to @Hubblenaut for letting me use their coode.