### PR TITLE
fucking makes the voidsuits work FUCK

### DIFF
--- a/code/game/machinery/suit_cycler_units.dm
+++ b/code/game/machinery/suit_cycler_units.dm
@@ -57,4 +57,3 @@
 	model_text = "Command"
 	req_access = list(access_bridge)
 	available_modifications = list(/decl/item_modifier/space_suit/command)
-	species = list(SPECIES_HUMAN,SPECIES_SKRELL)

--- a/modular_mithra/code/modules/clothing/spacesuits/void/void.dm
+++ b/modular_mithra/code/modules/clothing/spacesuits/void/void.dm
@@ -2,6 +2,10 @@
 
 
 //This override is to allow our snowflake species to use voidsuits. Keep this updated with whatever new species you add.
+
+//holy fucking shit I'm pretty sure all of this code was pointless in the fucking first place, if there is no sprite sheet listed it'll just use those that exist
+//if this does end up being needed for some reason in the future then I suggest having this ADD to the sprite sheet instead of REPLCACING it
+/*
 /obj/item/clothing/head/helmet/space/void/Initialize()
 	. = ..()
 	sprite_sheets |= list(
@@ -51,6 +55,9 @@
 		SPECIES_EASTERN = 'icons/mob/onmob/onmob_suit.dmi',
 		SPECIES_HUMAN2 = 'icons/obj/clothing/obj_suit.dmi'
 		)
+
+
+*/
 
 /* SHIT DOESNT WORK FOR WHATEVER REASON ITS CURSED
 /obj/item/clothing/head/helmet/space/void/excavation	//This fixes a literal year-old bug from upstream. Should probably bring it to bay directly but eh.


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

makes the  bridgie suit cycler work for all species as it should + makes the icons for voidsuits for other species actually work (trust me the code I am gutting does effectively nothing since not only is there no need to cycle them for all that jazz, but even if there were, the default sprite sheet is fine. I tested it and nothing crashed.)