### PR TITLE
Tweaks to the Bearcat's weight and speed

### DIFF
--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -18,9 +18,9 @@
 /obj/effect/overmap/visitable/ship/bearcat
 	name = "light freighter"
 	color = "#00ffff"
-	vessel_mass = 60
-	max_speed = 1/(10 SECONDS)
-	burn_delay = 10 SECONDS
+	vessel_mass = 4000
+	max_speed = 1/(2 SECONDS)
+	burn_delay = 1 SECONDS
 	contact_class = /decl/ship_contact_class/ship
 	initial_generic_waypoints = list(
 		"nav_bearcat_fore",

--- a/maps/away/bearcat/bearcat_shuttles.dm
+++ b/maps/away/bearcat/bearcat_shuttles.dm
@@ -10,15 +10,15 @@
 
 /datum/shuttle/autodock/overmap/bearcat_shuttle
 	name = "Cargo shuttle"
-	move_time = 10
+	move_time = 30 //Longer move delay to match other shuttles
 	shuttle_area = list(/area/ship/scrap/bearcat_shuttle)
 	dock_target = "bearcat_shuttle"
 	current_location = "nav_bearcat_dock"
 	landmark_transition = "nav_bearcat_transit"
 	range = 1
-	fuel_consumption = 4
+	fuel_consumption = 1 //small tiny ship, should not be using as much as the Charon/Gaunt
 	ceiling_type = /turf/simulated/floor/shuttle_ceiling/
-	skill_needed = SKILL_NONE
+	skill_needed = SKILL_BASIC
 	defer_initialisation = TRUE
 
 /obj/effect/overmap/visitable/ship/landable/bearcat_shuttle


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

This PR increases the weight of the Bearcat offship and instead decreases the forced input limit put into it. This should make its acceleration more comparable to other ships albeit still slower on average.

Some minor changes to the Bearcat's shuttle as well, like requiring at least a basic piloting skill to use properly. The Bearcat's shuttle is extremely taped on anyways so I don't recommend using it for anything other than landing.

🆑 
tweak: Increased the Bearcat's weight and removed the 10 second input delay.
tweak: Bearcat shuttle now requires basic piloting.
/:cl: