### PR TITLE
Vox Ship Guarantee

### DIFF
--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -10,9 +10,10 @@
 	id = "awaysite_voxship"
 	description = "Vox ship."
 	suffixes = list("voxship/voxship-1.dmm")
-	cost = 0.5
+	cost = 0//From 0.5
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_shuttle)
 	area_usage_test_exempted_root_areas = list(/area/voxship)
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 
 /obj/effect/overmap/visitable/ship/voxship


### PR DESCRIPTION
- - -
Balance:
 - Vox ship returned to being a guaranteed spawn, post discussion internally. We're doing this for the sake of facilitating in round RP, among other things. This doesn't include the Skrell or Ascent, as we're retaining those as less common spawns for now.
- - -