### PR TITLE
General Balance Edit - Prommie/IPC

### DIFF
--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -11,8 +11,8 @@
 	//at 0.8 completely depleted after 60ish minutes of constant walking or 130 minutes of standing still
 	var/servo_cost = 0.8
 
-	min_broken_damage = 45//up from 5
-	max_damage = 125//up from 45. Easily destroyed still.
+	min_broken_damage = 15//up from 5
+	max_damage = 65//up from 45. Easily destroyed still.
 
 	relative_size = 70
 

--- a/code/modules/organs/internal/species/promethean.dm
+++ b/code/modules/organs/internal/species/promethean.dm
@@ -7,5 +7,8 @@
 	parent_organ = BP_CHEST
 	vital = 1
 
+	max_damage = 15
+	relative_size = 95//:)
+
 /obj/item/organ/internal/brain/slime/can_recover()
 	return 0

--- a/code/modules/species/station/prometheans.dm
+++ b/code/modules/species/station/prometheans.dm
@@ -34,7 +34,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 	blood_volume =        600
 	min_age =             18
 	max_age =             125
-	brute_mod =           2
+	brute_mod =           1.25
 	burn_mod =            2
 	toxins_mod =          0.1
 	oxy_mod =             0


### PR DESCRIPTION
- - -
Balance:
 - IPCs / FBPs should be easier to kill now, but not too easy as prior. This is touching the power cell's health values. Their cell's min damage was dropped from 45 to 15. Max cell's damage dropped from 125 to 65.
 - Promethean slimecore given a larger average size (95), up from the standard (85). What this means, is that it's easier to hit and should stop the faffing about we see currently.
 - Promethean slimecare now has a max damage modifier, capping it at 15, automatically adjusting the health to reasonable values.
 - Promethean 200% brute mod dropped to 125%.
- - -