### PR TITLE
Renames Passenger to Off-Duty and removes most of it's alt-titles

### DIFF
--- a/maps/torch/job/misc_jobs.dm
+++ b/maps/torch/job/misc_jobs.dm
@@ -30,7 +30,8 @@ Civilian
 	announced = FALSE
 	alt_titles = list(
 		"Journalist" = /decl/hierarchy/outfit/job/torch/passenger/passenger/journalist,
-		"Botanist")
+		"Botanist"
+		"Passenger" = /decl/hierarchy/outfit/job/torch/passenger/passenger)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/service/crewman
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(

--- a/maps/torch/job/misc_jobs.dm
+++ b/maps/torch/job/misc_jobs.dm
@@ -22,7 +22,7 @@ Civilian
 *******/
 
 /datum/job/assistant
-	title = "Passenger"
+	title = "Off-Duty"
 	total_positions = -1
 	spawn_positions = -1
 	supervisors = "the Executive Officer"
@@ -30,19 +30,8 @@ Civilian
 	announced = FALSE
 	alt_titles = list(
 		"Journalist" = /decl/hierarchy/outfit/job/torch/passenger/passenger/journalist,
-		"Historian",
-		"Botanist",
-		"Investor" = /decl/hierarchy/outfit/job/torch/passenger/passenger/investor,
-		"Psychologist" = /decl/hierarchy/outfit/job/torch/passenger/passenger/psychologist,
-		"Naturalist",
-		"Ecologist",
-		"Entertainer",
-		"Independent Observer",
-		"Sociologist",
-		"Off-Duty" = /decl/hierarchy/outfit/job/torch/crew/service/crewman,
-		"Trainer",
-		"Assistant")
-	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/passenger
+		"Botanist")
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/service/crewman
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/civ,


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Its a Sol Gov Military ship. No more will there be random bums laying about doing nothing. If you like sociologist or psychologist, just play counselor and RP being a researcher.
Keeps journalist and botanist because journalist is cool and botanist has utility.
EDIT: Passenger has been readded as an alt-title for rescued crash survivor RP or whatever. 