### PR TITLE
Removal of GAS from Antagonistic Roles

### DIFF
--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -310,6 +310,7 @@
 /datum/species/nabber/handle_post_spawn(var/mob/living/carbon/human/H)
 	..()
 	H.pulling_punches = TRUE
+	H.status_flags |= NO_ANTAG
 
 /datum/species/nabber/has_fine_manipulation(var/mob/living/carbon/human/H)
 	return (..() && (H && H.pulling_punches))


### PR DESCRIPTION
- - -
Balance:
 - Completely prevents GAS from spawning as (& being chosen for) traitor.
- - -