### PR TITLE
Promethean torso fix

### DIFF
--- a/code/modules/organs/external/species/prometheans.dm
+++ b/code/modules/organs/external/species/prometheans.dm
@@ -1,7 +1,7 @@
 // Slime limbs.
 /obj/item/organ/external/chest/unbreakable/slime //The huge max_damage is necessary because if their chest breaks, they can't regen the damage unlike limbs, that can be cut off.
 	max_damage = 400
-	limb_flags = ORGAN_FLAG_GENDERED_ICON
+	limb_flags = ORGAN_FLAG_GENDERED_ICON | ORGAN_FLAG_HEALS_OVERKILL
 
 /obj/item/organ/external/groin/unbreakable/slime
 	max_damage = 30


### PR DESCRIPTION
Adds the ORGAN_FLAG_HEALS_OVERKILL flag to the torso allowing it to be healed

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->