### PR TITLE
fixes z level movey groovey

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -236,11 +236,18 @@
 
 	direction = mob.AdjustMovementDirection(direction)
 	var/turf/old_turf = get_turf(mob)
-	step(mob, direction)
 
 	// Something with pulling things
 	var/extra_delay = HandleGrabs(direction, old_turf)
 	mob.ExtraMoveCooldown(extra_delay)
+
+	if(direction & (UP|DOWN))
+		var/txt_dir = direction & UP ? "upwards" : "downwards"
+		old_turf.visible_message(SPAN_NOTICE("[mob] moves [txt_dir]."))
+		if(mob.pulling)
+			mob.zPull(direction)
+
+	step(mob, direction)
 
 	for (var/obj/item/grab/G in mob)
 		if (G.assailant_reverse_facing())
@@ -248,12 +255,6 @@
 		G.assailant_moved()
 	for (var/obj/item/grab/G in mob.grabbed_by)
 		G.adjust_position()
-
-	if(direction & (UP|DOWN))
-		var/txt_dir = direction & UP ? "upwards" : "downwards"
-		old_turf.visible_message(SPAN_NOTICE("[mob] moves [txt_dir]."))
-		if(mob.pulling)
-			mob.zPull(direction)
 
 	//Moving with objects stuck in you can cause bad times.
 	if(get_turf(mob) != old_turf)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
You can now move bodies up/down z levels. Thanks @Imienny1 