### PR TITLE
GAS Job Restrictions

### DIFF
--- a/code/modules/culture_descriptor/culture/cultures_serpentid.dm
+++ b/code/modules/culture_descriptor/culture/cultures_serpentid.dm
@@ -59,7 +59,7 @@
 
 /decl/cultural_info/culture/nabber/a
 	name = CULTURE_NABBER_A
-	valid_jobs = list(/datum/job/chemist, /datum/job/roboticist)
+	valid_jobs = list(/datum/job/chemist, /datum/job/roboticist, /datum/job/bartender, /datum/job/chef)
 
 /decl/cultural_info/culture/nabber/a/minus
 	name = CULTURE_NABBER_AMINUS

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -58,7 +58,7 @@
 	LAZYADD(valid_jobs, /datum/job/scientist_assistant)
 	..()
 	
-	/decl/cultural_info/culture/nabber/New()
+/decl/cultural_info/culture/nabber/New()
 	LAZYADD(valid_jobs, /datum/job/assistant)
 	..()
 

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -1,7 +1,7 @@
 /datum/map/torch
 	species_to_job_whitelist = list(
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
-									 /datum/job/roboticist, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender),
+									 /datum/job/roboticist, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender, /datum/job/explorer, /datum/job/assistant),
 		/datum/species/vox/ = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
 		/datum/species/vox/armalis = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
 		/datum/species/human/mule = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
@@ -55,7 +55,7 @@
 
 // Some jobs for nabber grades defined here due to map-specific job datums.
 /decl/cultural_info/culture/nabber/New()
-	LAZYADD(valid_jobs, /datum/job/scientist_assistant)
+	LAZYADD(valid_jobs, /datum/job/scientist_assistant, /datum/job/assistant)
 	..()
 
 /decl/cultural_info/culture/nabber/b/New()
@@ -67,7 +67,7 @@
 	..()
 
 /decl/cultural_info/culture/nabber/a/plus/New()
-	LAZYADD(valid_jobs, /datum/job/doctor)
+	LAZYADD(valid_jobs, /datum/job/doctor, /datum/job/explorer)
 	..()
 
 /datum/job

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -1,7 +1,7 @@
 /datum/map/torch
 	species_to_job_whitelist = list(
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
-									 /datum/job/roboticist, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender, /datum/job/explorer, /datum/job/assistant),
+									 /datum/job/roboticist, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender, /datum/job/assistant),
 		/datum/species/vox/ = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
 		/datum/species/vox/armalis = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
 		/datum/species/human/mule = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
@@ -72,10 +72,6 @@
 
 /decl/cultural_info/culture/nabber/a/plus/New()
 	LAZYADD(valid_jobs, /datum/job/doctor)
-	..()
-	
-	/decl/cultural_info/culture/nabber/a/plus/New()
-	LAZYADD(valid_jobs, /datum/job/explorer)
 	..()
 
 /datum/job

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -55,7 +55,11 @@
 
 // Some jobs for nabber grades defined here due to map-specific job datums.
 /decl/cultural_info/culture/nabber/New()
-	LAZYADD(valid_jobs, /datum/job/scientist_assistant, /datum/job/assistant)
+	LAZYADD(valid_jobs, /datum/job/scientist_assistant)
+	..()
+	
+	/decl/cultural_info/culture/nabber/New()
+	LAZYADD(valid_jobs, /datum/job/assistant)
 	..()
 
 /decl/cultural_info/culture/nabber/b/New()
@@ -67,7 +71,11 @@
 	..()
 
 /decl/cultural_info/culture/nabber/a/plus/New()
-	LAZYADD(valid_jobs, /datum/job/doctor, /datum/job/explorer)
+	LAZYADD(valid_jobs, /datum/job/doctor)
+	..()
+	
+	/decl/cultural_info/culture/nabber/a/plus/New()
+	LAZYADD(valid_jobs, /datum/job/explorer)
 	..()
 
 /datum/job


### PR DESCRIPTION
Allows all GAS to be civilians now that they are citizens under the lore. Adds Bartender and Chef to grade A, as before it was only grade B. This is my first PR in over six months so I'm keeping it simple. Playtested, looks like it works fine to me. May create another more expansive PR for reworking the shitcode that is GAS grading. I'd like feedback on what jobs you think GAS should or should not be in so feel free to comment it here incase I do make that PR.