### PR TITLE
Vox Rebalance & Minor Map Fix

### DIFF
--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -5,14 +5,14 @@
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs,/obj/item/weapon/tank)
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
-		bullet = ARMOR_BALLISTIC_PISTOL,
-		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_MINOR,
+		bullet = ARMOR_BALLISTIC_RESISTANT,
+		laser = ARMOR_LASER_MAJOR,
+		energy = ARMOR_ENERGY_STRONG,
 		bomb = ARMOR_BOMB_PADDED,
-		bio = ARMOR_BIO_SMALL,
-		rad = ARMOR_RAD_MINOR
+		bio = ARMOR_BIO_SHIELDED,
+		rad = ARMOR_RAD_SHIELDED
 		)
-	siemens_coefficient = 0.6
+	siemens_coefficient = 0.2
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	species_restricted = list(SPECIES_VOX,SPECIES_VOX_ARMALIS)
@@ -24,14 +24,14 @@
 /obj/item/clothing/head/helmet/space/vox
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
-		bullet = ARMOR_BALLISTIC_PISTOL,
-		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_MINOR,
+		bullet = ARMOR_BALLISTIC_RESISTANT,
+		laser = ARMOR_LASER_MAJOR,
+		energy = ARMOR_ENERGY_STRONG,
 		bomb = ARMOR_BOMB_PADDED,
-		bio = ARMOR_BIO_SMALL,
-		rad = ARMOR_RAD_MINOR
+		bio = ARMOR_BIO_SHIELDED,
+		rad = ARMOR_RAD_SHIELDED
 		)
-	siemens_coefficient = 0.6
+	siemens_coefficient = 0.2
 	item_flags = 0
 	flags_inv = 0
 	species_restricted = list(SPECIES_VOX,SPECIES_VOX_ARMALIS)

--- a/code/modules/clothing/spacesuits/rig/suits/vox.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vox.dm
@@ -4,10 +4,10 @@
 	suit_type = "alien rig"
 	icon_state = "vox_rig"
 	armor = list(
-		melee = ARMOR_MELEE_MAJOR,
-		bullet = ARMOR_BALLISTIC_RESISTANT,
-		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_RESISTANT,
+		melee = ARMOR_MELEE_VERY_HIGH,
+		bullet = ARMOR_BALLISTIC_RIFLE,
+		laser = ARMOR_LASER_RIFLES,
+		energy = ARMOR_ENERGY_SHIELDED,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED

--- a/code/modules/projectiles/guns/energy/vox.dm
+++ b/code/modules/projectiles/guns/energy/vox.dm
@@ -32,7 +32,7 @@
 	firemodes = list(
 		list(mode_name="stunning", burst=1, fire_delay=null, move_delay=null, burst_accuracy=list(30), dispersion=null, projectile_type=/obj/item/projectile/beam/stun/darkmatter, charge_cost = 50),
 		list(mode_name="focused", burst=1, fire_delay=null, move_delay=null, burst_accuracy=list(30), dispersion=null, projectile_type=/obj/item/projectile/beam/darkmatter, charge_cost = 75),
-		list(mode_name="scatter burst", burst=8, fire_delay=null, move_delay=4, burst_accuracy=list(0, 0, 0, 0, 0, 0, 0, 0), dispersion=list(0, 1, 2, 2, 3, 3, 3, 3, 3), projectile_type=/obj/item/projectile/energy/darkmatter, charge_cost = 10),
+		list(mode_name="scatter burst", burst=8, fire_delay=null, move_delay=null, burst_accuracy=list(0, 0, 0, 0, 0, 0, 0, 0), dispersion=list(0, 1, 2, 2, 3, 3, 3, 3, 3), projectile_type=/obj/item/projectile/energy/darkmatter, charge_cost = 10),
 		)
 
 /obj/item/weapon/gun/energy/darkmatter/Initialize()
@@ -51,7 +51,7 @@
 	w_class = ITEM_SIZE_LARGE
 	one_hand_penalty = 1
 	self_recharge = 1
-	recharge_time = 10
+	recharge_time = 8
 	fire_delay = 15
 	projectile_type=/obj/item/projectile/energy/plasmastun/sonic/weak
 	firemodes = list(

--- a/code/modules/projectiles/guns/launcher/alien.dm
+++ b/code/modules/projectiles/guns/launcher/alien.dm
@@ -1,8 +1,8 @@
 /obj/item/weapon/gun/launcher/alien
 	var/last_regen = 0
-	var/ammo_gen_time = 100
-	var/max_ammo = 3
-	var/ammo = 3
+	var/ammo_gen_time = 80
+	var/max_ammo = 6
+	var/ammo = 6
 	var/ammo_type
 	var/ammo_name
 
@@ -38,7 +38,6 @@
 
 //Vox pinning weapon.
 /obj/item/weapon/gun/launcher/alien/spikethrower
-
 	name = "spike thrower"
 	desc = "A vicious alien projectile weapon. Parts of it quiver gelatinously, as though the thing is insectile and alive."
 	w_class = ITEM_SIZE_LARGE

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -300,9 +300,9 @@
 /obj/item/projectile/beam/darkmatter
 	name = "dark matter bolt"
 	icon_state = "darkb"
-	damage = 40
+	damage = 50
 	armor_penetration = 65
-	damage_type = BRUTE
+	damage_flags = DAM_DISPERSED
 	muzzle_type = /obj/effect/projectile/darkmatter/muzzle
 	tracer_type = /obj/effect/projectile/darkmatter/tracer
 	impact_type = /obj/effect/projectile/darkmatter/impact
@@ -312,7 +312,7 @@
 	icon_state = "darkt"
 	damage_flags = 0
 	sharp = 0 //not a laser
-	agony = 40
+	agony = 50
 	damage_type = STUN
 	muzzle_type = /obj/effect/projectile/stun/darkmatter/muzzle
 	tracer_type = /obj/effect/projectile/stun/darkmatter/tracer

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -205,6 +205,6 @@
 	name = "dark matter pellet"
 	icon_state = "dark_pellet"
 	fire_sound = 'sound/weapons/eLuger.ogg'
-	damage = 20
+	damage = 35
 	armor_penetration = 35
-	damage_type = BRUTE
+	damage_flags = DAM_DISPERSED

--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -5676,6 +5676,10 @@
 /obj/item/weapon/gun/energy/darkmatter,
 /obj/item/weapon/gun/energy/sonic,
 /obj/item/weapon/gun/launcher/alien/spikethrower,
+/obj/item/weapon/gun/launcher/alien/spikethrower,
+/obj/item/weapon/gun/energy/sonic,
+/obj/item/weapon/gun/energy/darkmatter,
+/obj/item/weapon/gun/launcher/alien/slugsling,
 /turf/simulated/floor/plating/vox,
 /area/voxship/armory)
 "mI" = (
@@ -5781,14 +5785,12 @@
 /area/voxship/med)
 "mX" = (
 /obj/structure/table/rack,
-/obj/item/weapon/rig/vox,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/item/weapon/rig/vox,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/gun/projectile/dartgun/vox/raider,
-/obj/item/weapon/rig/vox,
 /turf/simulated/floor/plating/vox,
 /area/voxship/armory)
 "mY" = (

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -2772,6 +2772,29 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
+"eI" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/structure/hygiene/drain,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/recreation)
+"eJ" = (
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/beach/corner{
+	dir = 8;
+	icon_state = "beachbordercorner"
+	},
+/obj/structure/hygiene/drain,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/recreation)
 "eK" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2867,6 +2890,15 @@
 "eQ" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
+/area/crew_quarters/recreation)
+"eR" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/recreation)
 "eS" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2969,6 +3001,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
+"fc" = (
+/obj/structure/curtain/open/privacy,
+/obj/item/weapon/stool,
+/obj/structure/hygiene/shower{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/structure/hygiene/drain,
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/recreation)
 "fd" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -7155,15 +7197,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"mQ" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/recreation)
 "mR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -16091,17 +16124,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/rnd)
-"NV" = (
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/beach/corner{
-	dir = 8;
-	icon_state = "beachbordercorner"
-	},
-/obj/item/drain,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/recreation)
 "NW" = (
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
@@ -16958,15 +16980,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/analysis)
-"Sa" = (
-/obj/structure/curtain/open/privacy,
-/obj/item/weapon/stool,
-/obj/structure/hygiene/shower{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/mono,
-/turf/simulated/floor/tiled/monotile,
-/area/crew_quarters/recreation)
 "Sb" = (
 /obj/machinery/door/blast/regular{
 	density = 1;
@@ -17386,18 +17399,6 @@
 /obj/item/weapon/melee/baton/loaded,
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/analysis)
-"TK" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/item/drain,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/recreation)
 "TL" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/corner/brown{
@@ -31066,21 +31067,21 @@ dX
 eG
 mg
 iN
-TK
+eI
 RK
 RK
 RK
 ln
 lI
 lI
-NV
+eJ
 gb
 gb
 gb
 gb
 ml
 mO
-Sa
+fc
 Tv
 Tv
 aa
@@ -31281,7 +31282,7 @@ ik
 ik
 ik
 mo
-mQ
+eR
 Ly
 Tv
 Tv
@@ -31484,7 +31485,7 @@ jk
 jN
 mp
 mV
-Sa
+fc
 Tv
 Tv
 Tv


### PR DESCRIPTION
- - -
Map:
 - One additional weapon of each type provided to the Vox.
 - RIG count for Vox reduced to one. See why below.
 - Drains in pool corrected. They previously used the item state for construction, rather than the structure version.
- - -
Balance:
 - All Vox suits given higher armour ratings.
 - Vox RIG given much, much higher armour ratings.
 - Vox guns all around buffed. See below.
  - Darkmatter bursts no longer root the shooter in place.
  - Soundcannon recharge slightly tweaked lower.
  - Vox spike launcher ammo gen time slightly tweaked lower.
  - Vox spike launcher given three additional spikes per full 'mag'.
  - Darkmatter bolts upped in damage by ten. Made burn instead of brute. Given dispersed damage flag.
  - Darkmatter wave(stun bolts) given ten more agony damage.
  - Darkmatter pellets upped in damage by fifteen. Given dispersed damage flag.
- - -