### PR TITLE
Psi should no longer risk instantly killing people

### DIFF
--- a/code/modules/psionics/complexus/complexus_latency.dm
+++ b/code/modules/psionics/complexus/complexus_latency.dm
@@ -13,6 +13,6 @@
 	to_chat(owner, SPAN_DANGER("You scream internally as your [faculty_decl.name] faculty is forced into operancy by [source]!"))
 	if(!redactive)
 		var/ClampThis = rand(trigger_strength * 2, trigger_strength * 4)
-		var/Clamped = Clamp(ClampThis,5,15) //Reduced from 40 temporarily -YAWET330
+		var/Clamped = Clamp(ClampThis,1,10) //Reduced from 40 temporarily -YAWET330
 		owner.adjustBrainLoss(Clamped)
 	return TRUE


### PR DESCRIPTION
New dex+ changes made it so if merged, psi was impossible to survive.
For some reason braindamage apply procs take into species resistances and were making even regular humans take 80 brain damage per faculty.