### PR TITLE
Replaces rubbers in secarm (for pistol) with lethals

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1796,9 +1796,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/weapon/storage/box/ammo/solar/rubber,
-/obj/item/weapon/storage/box/ammo/solar/rubber,
-/obj/item/weapon/storage/box/ammo/solar/rubber,
+/obj/item/weapon/storage/box/ammo/solar/full,
+/obj/item/weapon/storage/box/ammo/solar/full,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "adi" = (


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
This doesn't change the smg ammo, and rubbers are still available in the equipment room. 
My reasoning:
TLDR; rubbers in the armory only encourages sec to use more powerful weapons, not less. If that's the goal, then they shouldn't be rubbers anyways.

There isn't a reason to keep rubbers in the secarm except for to dissuade security from using excessive force to crush antags. However, this is actually counterproductive- if sec does want lethals for any reason, no one has time to print lethal pistol ammo. It takes forever. Instead, they'll grab the readily available rifle or shotgun, both of which already have lethal ammo in the armory. If they do have time to print ammo, they'll print ammo for the rifle or smg instead. SMG's very different from the pistol, but it's overall better.


Might add revolver ammo boxes in general in the future, but I know the revolver might receive caliber changes so I'll wait.