### PR TITLE
Shamelessly buffs drop pouches

### DIFF
--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -80,7 +80,7 @@
 	slots = 5
 
 /obj/item/clothing/accessory/storage/drop_pouches
-	slots = 4 //to accomodate it being slotless
+	slots = 5
 
 /obj/item/clothing/accessory/storage/drop_pouches/create_storage()
 	hold = new/obj/item/weapon/storage/internal/pouch(src, slots*BASE_STORAGE_COST(max_w_class))


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Drop pouches are now on par with webbings instead of having 1 less slow. Many people think drop pouches are way sexier than webbings, they have personally gotten me four girlfriends. No one should have to choose between 1 storage slot and a girlfriend.

"but rock, drop pouches are slotless storage, making them slightly better!"
Do you have any idea how little that effects? The only jobs I can think of that would get benefit from this are like, doctors carrying 3 syringes and cargo techs carrying both stamps- But there's plenty of other things with slotless storage, like wallets or YOUR BACKPACK. All backpacks and boxes having slotless storage means the advantage is, at most, a convenience.

"but rock, why don't you just make webbing slotless as well?" Main reason being that it'd be snowflakey as fuck. the code for webbings is ass, so it'd be snowflakey as fuck, none of them are subtypes of the rest. you'd have to squeeze this proc in like 4 times. And again who CARES about slotless storage.
