### PR TITLE
Carl Balance Electric Boogaloo

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1073,6 +1073,7 @@
 #include "code\game\objects\items\weapons\grenades\flashbang.dm"
 #include "code\game\objects\items\weapons\grenades\grenade.dm"
 #include "code\game\objects\items\weapons\grenades\light.dm"
+#include "code\game\objects\items\weapons\grenades\neutron.dm"
 #include "code\game\objects\items\weapons\grenades\prank_grenades.dm"
 #include "code\game\objects\items\weapons\grenades\smokebomb.dm"
 #include "code\game\objects\items\weapons\grenades\spawnergrenade.dm"

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -39,7 +39,6 @@
 	. = ..()
 	desc = "A briefcase with 10,000 false [GLOB.using_map.local_currency_name]. This costs next to nothing, because it's worth next to nothing. Only an expert can tell the difference between these and the real deal."
 
-
 /datum/uplink_item/item/tools/clerical
 	name = "Morphic Clerical Kit"
 	desc = "Comes with everything you need to fake paperwork, assuming you know how to forge the required documents."

--- a/code/datums/uplink/grenades.dm
+++ b/code/datums/uplink/grenades.dm
@@ -37,6 +37,12 @@
 	item_cost = 24
 	path = /obj/item/weapon/storage/box/emps
 
+/datum/uplink_item/item/grenades/neutron
+	name = "Neutron Grenade"
+	desc = "This grenade acts as a 'dirty bomb' of sorts, weakly flashing people in view and irradiating them to the point of death if not treated immediately."
+	item_cost = 24
+	path = /obj/item/weapon/grenade/neutron
+
 /datum/uplink_item/item/grenades/frag_high_yield
 	name = "Fragmentation Bomb"
 	item_cost = 34

--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -225,3 +225,15 @@
 /obj/aura/regenerating/human/promethean/external_regeneration_effect(var/obj/item/organ/external/O, var/mob/living/carbon/human/H)
 	to_chat(H, "<span class='warning'>You feel a slithering sensation as your [O.name] reforms.</span>")
 	H.adjust_nutrition(-external_nutrition_mult)
+
+/////////
+// Armalis regen. Not soft-balanced by timers.
+/////////
+/obj/aura/regenerating/human/armalis
+	brute_mult = 1.5
+	fire_mult = 1.5
+	tox_mult = 1.5
+	oxy_mult = 2
+	nutrition_damage_mult = 0.1
+	organ_mult = 1
+	regen_message = "<span class='warning'>You sense your body shifting internally to regenerate your ORGAN..</span>"

--- a/code/game/objects/items/weapons/grenades/neutron.dm
+++ b/code/game/objects/items/weapons/grenades/neutron.dm
@@ -1,0 +1,41 @@
+/////////
+// Alternative to SM Grenade
+// Does not explosive damage. Kills via radiation exclusively.
+/////////
+/obj/item/weapon/grenade/neutron
+	name = "neutron grenade"
+	icon_state = "lyemp"
+	item_state = "flashbang"
+	origin_tech = list(TECH_BLUESPACE = 5, TECH_MAGNET = 4, TECH_ENGINEERING = 5)
+	arm_sound = 'sound/effects/scanbeep.ogg'
+	var/explode_at
+	var/radiation = 64//with how this is set up, and how rads caps-out anyway, 500 is what it'll jump to with how I have this.
+
+/obj/item/weapon/grenade/neutron/Destroy()
+	if(explode_at)
+		STOP_PROCESSING(SSobj, src)
+	. = ..()
+
+/obj/item/weapon/grenade/neutron/detonate()
+	..()
+	START_PROCESSING(SSobj, src)
+	explode_at = world.time + 1 SECONDS
+	update_icon()
+	playsound(src, 'sound/weapons/wave.ogg', 100)
+
+/obj/item/weapon/grenade/neutron/on_update_icon()
+	overlays.Cut()
+	if(explode_at)
+		overlays += image(icon = 'icons/obj/machines/power/fusion.dmi', icon_state = "emfield_s1")
+
+/obj/item/weapon/grenade/neutron/Process()
+	var/turf/T = get_turf(src)
+	playsound(T, 'sound/effects/phasein.ogg', 100, 1)
+	for(var/mob/living/carbon/human/M in viewers(T, null))//Everyone who can see it. Only way to balance this. Had it 12 tile range prior, which as you can imagine, wasn't too fun.
+		if(M.eyecheck() < FLASH_PROTECTION_MODERATE)
+			M.flash_eyes()//double flash?
+		M.apply_damage((radiation*24),IRRADIATE, damage_flags = DAM_DISPERSED)
+		M.updatehealth()
+	if(world.time > explode_at)
+		playsound(src, 'sound/effects/EMPulse.ogg', 100)
+		qdel(src)

--- a/code/modules/culture_descriptor/culture/cultures_vox.dm
+++ b/code/modules/culture_descriptor/culture/cultures_vox.dm
@@ -26,17 +26,15 @@
 
 /decl/cultural_info/culture/vox/tech
 	name = CULTURE_VOX_TECHNICIAN
-	description = "You are a Voidborne Vigilant, and you know this to be true; to be Vox is to be an enemy of those who covet the arks and their untold miracles of eons dead. \
-	You have served extensively aboard the ark fleets, massive sacred naval assemblies safeguarding each artifact-world in their voidborne flight. \
-	Your experience with outsiders comes twofold, in the Novalis and the Heretic. \
-	The Novalis are Non-Vox who have proven their loyalty and kinship to your people, and earned the honor of serving aboard the ships of the fleet. \
-	They are often spacers or of the lower-class of their societies, and easily find their feet on both repurposed frigates and bioship cruisers. \
-	To the Heretic, from the SAARE mercenaries to the Kharmanni purifiers, you give the blessing of silence. \
-	Not once has a Non-Vox found purchase aboard the Arks, and this will remain true."
+	description = "In the times before the Great Collapse, during the Era of Decay which has only so recently come to a close, and in these times of revival, one thing remains true above all else; without the work of the Sacred Technicians, your kin would be lost. \
+	Ranging from the salvage technician to the biotechnician, that which was left by the Auralis and made after by the Vox require constant maintenance. \
+	Among your kin, you are one who is most skilled in stripping salvage from dead ships and ruins, and not just maintaining but improving upon the sacred Auralis technology. \
+	Your experience with Non-Vox is mostly with spacers and colonists, with mixed results. Sanctified in oil and armed with wrench and steel, you halt entropy itself. \
+	The stars will die before the arks."
 
 /decl/cultural_info/culture/vox/light
 	name = CULTURE_VOX_LIGHT
-	description = "You are a Warrior of Light, and you know this to be true; to be Vox is to be an enemy of those who covet the arks and their untold miracles of eons dead. \
+	description = "You are a Voidborne Vigilant, and you know this to be true; to be Vox is to be an enemy of those who covet the arks and their untold miracles of eons dead. \
 	You have served extensively aboard the ark fleets, massive sacred naval assemblies safeguarding each artifact-world in their voidborne flight. \
 	Your experience with outsiders comes twofold, in the Novalis and the Heretic. \
 	The Novalis are Non-Vox who have proven their loyalty and kinship to your people, and earned the honor of serving aboard the ships of the fleet. \

--- a/code/modules/culture_descriptor/faction/factions_vox.dm
+++ b/code/modules/culture_descriptor/faction/factions_vox.dm
@@ -16,6 +16,6 @@
 
 /decl/cultural_info/faction/vox/ark
 	name = FACTION_VOX_ARK
-	description = "The majority of Vox live and serve the arkships. \
-	Artificers creating all that their civilization requires, acolytes keeping alive the flame of the Auralis, technicians maintaining the arcane works of eons past, merchants serving supply needs as they rejoin and depart for their duties beyond home and warriors that defend the sacred homeworlds from any outside threat. \
+	description = "The majority of Vox live on and serve the arkships. \
+	This includes artificers creating all that their civilization requires, acolytes keeping alive the flame of the Auralis, technicians maintaining the arcane works of eons past, merchants serving supply needs as they rejoin and depart for their duties beyond home and warriors that defend the sacred home worlds from any outside threat. \
 	Ark Vox are the closest their society has to civilians, living with a degree of ease and comfort, assured by the Apex guiding their construct world and the Ark Admiral that leads matters of local state."

--- a/code/modules/culture_descriptor/location/locations_vox.dm
+++ b/code/modules/culture_descriptor/location/locations_vox.dm
@@ -37,6 +37,6 @@
 	name = HOME_SYSTEM_VOX_PRODUCTION
 	description = "The Ark of the Vigilant Prophet is the heart of production among the relic-worlds, where great barges of ore, massive spools of wire, crates of biomass are fed to the hungry forges of the most calculating Apex, the Vigilant Prophet. \
 	Here the majority of newly forged starships take flight, and Quill-Captains make berths to unload that which they cannot use, and take what is needed for the long voyages away from the warmth of the home fleets. \
-	Biomatter, both the vacuum-sealed from Zeng-Hu laboratories to the raw flesh of slaughtered space carp, the scraps of exotic matter from abandoned foreign mines to entire space hulks drifting in the void, all feeds the ever gnawing heart of the Vigilant Prophet’s maw of industry. \
+	Biomatter, both the vacuum-sealed from Zeng-Hu laboratories to the raw flesh of slaughtered space carp, the scraps of exotic matter from abandoned foreign mines to entire space hulks drifting in the void, all feeds the ever gnawing heart of the Vigilant Prophets maw of industry. \
 	New biotech ships are born here, given life and sapience, and crews to make their new family-band. \
 	It is the largest shipyard of the Vox, much of the ark dedicated to general production and naval industry."

--- a/code/modules/culture_descriptor/location/locations_vox.dm
+++ b/code/modules/culture_descriptor/location/locations_vox.dm
@@ -36,4 +36,7 @@
 /decl/cultural_info/location/vox/production
 	name = HOME_SYSTEM_VOX_PRODUCTION
 	description = "The Ark of the Vigilant Prophet is the heart of production among the relic-worlds, where great barges of ore, massive spools of wire, crates of biomass are fed to the hungry forges of the most calculating Apex, the Vigilant Prophet. \
-	Here the majority of newly forged starships take flight, and Quill-Captains make berths to unload that which they cannot use, and take what is needed for the long voyages away from the warmth of the home fleets."
+	Here the majority of newly forged starships take flight, and Quill-Captains make berths to unload that which they cannot use, and take what is needed for the long voyages away from the warmth of the home fleets. \
+	Biomatter, both the vacuum-sealed from Zeng-Hu laboratories to the raw flesh of slaughtered space carp, the scraps of exotic matter from abandoned foreign mines to entire space hulks drifting in the void, all feeds the ever gnawing heart of the Vigilant Prophet’s maw of industry. \
+	New biotech ships are born here, given life and sapience, and crews to make their new family-band. \
+	It is the largest shipyard of the Vox, much of the ark dedicated to general production and naval industry."

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -18,13 +18,10 @@
 		/datum/unarmed_attack/bite/strong
 	)
 	rarity_value = 4
-	description = "The Vox are a people most ancient, each one having existed well before the evolution of\
-	humanity, led by the Auralis to guide the galaxy to a glorious evolution. Since the fall of the empire\
-	and the disappearance of the Auralis, the Vox have struggled to reclaim their lost influence and territory.\
-	Maintaining their remaining Arks are the revered Apex and their talons, the Ark-Admirals, and the Quill-Captains\
-	fielded under their command.</BR></BR>\
-	From battleship to corvette, Scavenger to Biotechnician, recent demand for action has seen new fleets formed\
-	and territory claimed by the long-dormant nation.</BR></BR>\
+	description = "The Vox are a people most ancient, each one having existed well before the evolution of humanity, led by the Auralis to guide the galaxy to a glorious evolution. \
+	Since the fall of the empire and the disappearance of the Auralis, the Vox have struggled to reclaim their lost influence and territory. \
+	Maintaining their remaining Arks are the revered Apex and their talons, the Ark-Admirals, and the Quill-Captains fielded under their command. <br/><br/>\
+	From battleship to corvette, Scavenger to Biotechnician, recent demand for action has seen new fleets formed and territory claimed by the long-dormant nation. <br/><br/>\
 	The Vox are a proud people, and face much distrust from the galactic community, but this does not seem to deter them."
 	codex_description = "The Vox are a cautious, defensive species from the outer systems and beyond human space. They\
 	reveal little to the outside world, but are known to trade and cooperate with those they find trustworthy. When\

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -155,6 +155,10 @@
 	strength = STR_HIGH
 	mob_size = MOB_LARGE
 
+	base_auras = list(
+		/obj/aura/regenerating/human/armalis
+		)
+
 	unarmed_types = list(
 		/datum/unarmed_attack/stomp/armalis,
 		/datum/unarmed_attack/claws/armalis,
@@ -188,6 +192,7 @@
 		to_chat(grabber, SPAN_WARNING("You drop everything in a rage as you seize \the [target]!"))
 		playsound(grabber.loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 	. = ..(grabber, target, GRAB_ARMALIS)
+
 
 /*
 /datum/species/vox/pariah

--- a/code/modules/species/species_attack.dm
+++ b/code/modules/species/species_attack.dm
@@ -191,7 +191,7 @@
 	delay = 60
 	attack_name = "venomous strike"
 
-/datum/unarmed_attack/bite/venom/get_damage_type()
+/datum/unarmed_attack/punch/venom/get_damage_type()
 	return TOX
 
 /datum/unarmed_attack/claws/armalis

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -1,10 +1,10 @@
 /datum/job/submap/voxship_vox
-	title = "Shoal Expeditionary"
+	title = "Shard Acolyte"
 	total_positions = 6
 	outfit_type = /decl/hierarchy/outfit/job/voxship/crew
 	supervisors = "Quill, The Apex and the arkship"
-	info = "The Auralis dictate that you are to reclaim areas of space, specifically for the purpose of subjugating the Meat. \
-	Your Quill knows more than you do, so be sure to listen to them."
+	info = "By the will of the dead creators, you must reclaim the lost territory of their fallen empire, and re-establish the domain of the Auralis no matter the cost. \
+	Honor their memory, obey your Quill-Captain."
 	whitelisted_species = list(SPECIES_VOX)
 	blacklisted_species = null
 	is_semi_antagonist = TRUE
@@ -32,9 +32,10 @@
 	skill_points = 40
 
 /datum/job/submap/voxship_vox/doc
-	title = "Shoal Biotechnician"
+	title = "Shard Biotechnician"
 	total_positions = 1
-	info = "You are the sawbones of your expeditionary crew. You are in charge of removing stacks, replacing limbs, and generally keeping your kin alive at all costs."
+	info = "Your sacred duty is to preserve the lives of your ship-band; \
+	save their stacks, stabilize wounded crew, replace missing components and ensure nobody messes with your patients or your workspace."
 	whitelisted_species = list(SPECIES_VOX)
 	min_skill = list(	SKILL_HAULING     = SKILL_BASIC,
 						SKILL_EVA         = SKILL_EXPERT,
@@ -68,9 +69,10 @@
 	skill_points = 26
 
 /datum/job/submap/voxship_vox/engineer
-	title = "Shoal Technician"
+	title = "Shard Technician"
 	total_positions = 2
-	info = "You are the mechanic of your expeditionary crew. Keep all your salvaged technology running, fix robotics, and disassemble some of the more complex devices your crew comes across."
+	info = "You are one among many billions who has kept the five sacred Arks operational over eons, such a small shard vessel is an easy task in comparison. \
+	Keep the tech operational, fix damage, and disassemble more complex devices or artefacts the acolytes come across on their expeditions."
 	whitelisted_species = list(SPECIES_VOX)
 	min_skill = list(	SKILL_HAULING      = SKILL_BASIC,
 						SKILL_COMPUTER     = SKILL_ADEPT,
@@ -106,11 +108,15 @@
 	skill_points = 26
 
 /datum/job/submap/voxship_vox/quill
-	title = "Shoal Quill"
+	title = "Shard Quill"
 	total_positions = 1
 	outfit_type = /decl/hierarchy/outfit/job/voxship/crew/captain
 	supervisors = "The Apex and the arkship"
-	info = "You're in charge. You fly the ship, and dictate what the crew does. You are in charge of keeping your subordinates in check, the Apex has given you authority to kill any that disobeys your orders. Do not disappoint the Apex."
+	info = "You are the Quill-Captain of a handsome shard-class frigate, a scout vessel for the Ark Fleets of the Vox. \
+	The dead empire is being reborn, new planets settled, alliances made. To one of the five ark admirals you are sworn, and they have your complete loyalty. \
+	The age of stagnancy is over, you have purpose anew, the crew must know this. \
+	Ensure they do not disgrace the memory of the Auralis, that they do not forget the faith, and that new territory is claimed and material secured for the arks. \
+	Measure your discipline lest you be challenged for being too lenient or harsh."
 	whitelisted_species = list(SPECIES_VOX)
 	min_skill = list(	SKILL_HAULING     = SKILL_BASIC,
 						SKILL_EVA         = SKILL_EXPERT,
@@ -150,7 +156,7 @@
 	r_ear = null
 
 /decl/hierarchy/outfit/job/voxship/crew
-	name = VOXSHIP_OUTFIT_JOB_NAME("Shoal Expeditionary")
+	name = VOXSHIP_OUTFIT_JOB_NAME("Shard Expeditionary")
 	uniform = /obj/item/clothing/under/vox/vox_robes
 	r_pocket = /obj/item/device/radio
 	shoes = /obj/item/clothing/shoes/magboots/vox
@@ -161,7 +167,7 @@
 	r_hand = /obj/item/weapon/tank/emergency/nitrogen/double
 
 /decl/hierarchy/outfit/job/voxship/crew/captain
-	name = VOXSHIP_OUTFIT_JOB_NAME("Shoal Quill")
+	name = VOXSHIP_OUTFIT_JOB_NAME("Shard Quill")
 	uniform = /obj/item/clothing/under/vox/vox_robes
 	r_pocket = /obj/item/device/radio
 	shoes = /obj/item/clothing/shoes/magboots/vox
@@ -171,15 +177,15 @@
 	r_hand = /obj/item/weapon/tank/emergency/nitrogen/double
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew
-	name = "Shoal Expeditionary"
+	name = "Shard Acolyte"
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew/doc
-	name = "Shoal Biotechnician"
+	name = "Shard Biotechnician"
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew/engineer
-	name = "Shoal Technician"
+	name = "Shard Technician"
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew/quill
-	name = "Shoal Quill"
+	name = "Shard Quill"
 
 #undef VOXSHIP_OUTFIT_JOB_NAME

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -1,10 +1,10 @@
 /datum/job/submap/voxship_vox
-	title = "Shoal Scavenger"
-	total_positions = 4
+	title = "Shoal Expeditionary"
+	total_positions = 6
 	outfit_type = /decl/hierarchy/outfit/job/voxship/crew
-	supervisors = "Quill,The Apex and the arkship"
-	info = "Scrap is thin. Not much food is left, but thankfully the sector is quite rich, and it's time to get some more supplies. \
-	although staying on base is tempting. Plenty of nitrogen, and not much hazards to worry about."
+	supervisors = "Quill, The Apex and the arkship"
+	info = "The Auralis dictate that you are to reclaim areas of space, specifically for the purpose of subjugating the Meat. \
+	Your Quill knows more than you do, so be sure to listen to them."
 	whitelisted_species = list(SPECIES_VOX)
 	blacklisted_species = null
 	is_semi_antagonist = TRUE
@@ -34,7 +34,7 @@
 /datum/job/submap/voxship_vox/doc
 	title = "Shoal Biotechnician"
 	total_positions = 1
-	info = "You are the sawbones of your scavenger crew. You are in charge of removing stacks, replacing limbs, and generally keeping your kin alive at all costs."
+	info = "You are the sawbones of your expeditionary crew. You are in charge of removing stacks, replacing limbs, and generally keeping your kin alive at all costs."
 	whitelisted_species = list(SPECIES_VOX)
 	min_skill = list(	SKILL_HAULING     = SKILL_BASIC,
 						SKILL_EVA         = SKILL_EXPERT,
@@ -70,7 +70,7 @@
 /datum/job/submap/voxship_vox/engineer
 	title = "Shoal Technician"
 	total_positions = 2
-	info = "You are the mechanic of your scavenger crew. Keep all your salvaged technology running, fix robotics, and disassemble some of the more complex devices your crew comes across."
+	info = "You are the mechanic of your expeditionary crew. Keep all your salvaged technology running, fix robotics, and disassemble some of the more complex devices your crew comes across."
 	whitelisted_species = list(SPECIES_VOX)
 	min_skill = list(	SKILL_HAULING      = SKILL_BASIC,
 						SKILL_COMPUTER     = SKILL_ADEPT,
@@ -150,7 +150,7 @@
 	r_ear = null
 
 /decl/hierarchy/outfit/job/voxship/crew
-	name = VOXSHIP_OUTFIT_JOB_NAME("Shoal Scavenger")
+	name = VOXSHIP_OUTFIT_JOB_NAME("Shoal Expeditionary")
 	uniform = /obj/item/clothing/under/vox/vox_robes
 	r_pocket = /obj/item/device/radio
 	shoes = /obj/item/clothing/shoes/magboots/vox
@@ -171,7 +171,7 @@
 	r_hand = /obj/item/weapon/tank/emergency/nitrogen/double
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew
-	name = "Shoal Scavenger"
+	name = "Shoal Expeditionary"
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew/doc
 	name = "Shoal Biotechnician"

--- a/maps/away/voxship/voxship_jobs_boh.dm
+++ b/maps/away/voxship/voxship_jobs_boh.dm
@@ -1,6 +1,6 @@
 /datum/job/submap/voxship_vox/armalis
-	title = "Shoal Armalis"
-	total_positions = 1
+	title = "Shard Armalis"
+	total_positions = 2
 	outfit_type = /decl/hierarchy/outfit/job/voxship/crew
 	supervisors = "apex and the arkship"
 	info = "Towering over their contemporaries, the Armalis are the muscle of the Vox. Not useful for much aside from rending the flesh of their foes."
@@ -14,4 +14,4 @@
 	skill_points = 4 //hahaha no not when you get min skills bucko
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew/armalis
-	name = "Shoal Armalis"
+	name = "Shard Armalis"

--- a/maps/away/voxship/voxship_jobs_boh.dm
+++ b/maps/away/voxship/voxship_jobs_boh.dm
@@ -1,9 +1,11 @@
 /datum/job/submap/voxship_vox/armalis
-	title = "Shard Armalis"
+	title = "Shard Martinet"
 	total_positions = 2
 	outfit_type = /decl/hierarchy/outfit/job/voxship/crew
 	supervisors = "apex and the arkship"
-	info = "Towering over their contemporaries, the Armalis are the muscle of the Vox. Not useful for much aside from rending the flesh of their foes."
+	info = "Loyal to your Quill-Captain, you enforce the will of the ark admirals; while you may be away from the main fleets, the crew must not forget they are subservient to the will of the Archon. \
+	You are the pinnacle of the navy's technology, training, and adapted designs of the Auralis. You are destruction. You are mercy. \
+	You are the shield between life and death."
 	whitelisted_species = list(SPECIES_VOX_ARMALIS)
 	blacklisted_species = null
 	is_semi_antagonist = TRUE
@@ -14,4 +16,4 @@
 	skill_points = 4 //hahaha no not when you get min skills bucko
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew/armalis
-	name = "Shard Armalis"
+	name = "Shard Martinet"


### PR DESCRIPTION
- - -
Balance:
 - Armalis given a rather 'meh-ish' regenerating aura, so they don't just drop dead of heart trauma.
 - Armalis slots raised back to 2. We'll try this for a bit.
 - Vox 'Scavenger' slots raised to 6, from 4.
- - -
Corrections:
 - Vox crew renamed appropriately. This is temporary.
 - Vox descriptions redone appropriately. This is temporary.
- - -
Bugfix:
 - Venomous claws now actually do toxin damage. This was not the case prior due to an incorrect subpath.
- - -
Content:
 - New item for traitors, the 'Neutron Grenade'. No damage to structures, only max cap irradiation for all in view. This isn't nearly as destructive as you'd think. Very cheap, too, sitting at 24 telecrystals.
- - -