### PR TITLE
gives fleet +1 athletics and eva skill (might actually be a good idea?)

### DIFF
--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -178,8 +178,9 @@
 	)
 
 	assistant_job = /datum/job/crew
-	min_skill = list(	SKILL_WEAPONS = SKILL_BASIC,
-						SKILL_EVA     = SKILL_BASIC)
+	min_skill = list(	SKILL_HAULING = SKILL_BASIC,
+						SKILL_WEAPONS = SKILL_BASIC,
+						SKILL_EVA     = SKILL_ADEPT)
 
 /datum/mil_branch/army
 	name = "Army"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
2 reasons:
1. athletics is probably a more logical skill for them to have than even the guns skill.
2.Marines get +1 athletics, weapons, cqc, AND eva. that's 4 skills and that's 6 points worth of them. before this fleet only had 3 worth of points in +1 eva and +1 weapons. this evens it out a bit while still having a distinction between the ranks.