### PR TITLE
Gives the merchant shuttle a rear hatch that makes loading/unloading easier

### DIFF
--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -9889,6 +9889,12 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/merchant/home)
 "aSK" = (
+/obj/machinery/button/blast_door{
+	id_tag = "merchant_rear";
+	name = "Rear Hatch Control";
+	pixel_y = -24;
+	req_access = list("ACCESS_MERCHANT")
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/merchant/home)
 "aSL" = (
@@ -9916,6 +9922,11 @@
 	dir = 2;
 	frequency = 1380;
 	id_tag = "merchant_ship_vent"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "merchant_ship_sensor";
+	pixel_y = 38
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/merchant/home)
@@ -10075,12 +10086,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
 	icon_state = "map"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "merchant_ship_sensor";
-	pixel_x = 28;
-	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/merchant/home)
@@ -11054,8 +11059,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/mob/living/exosuit/premade/powerloader{
-	},
+/mob/living/exosuit/premade/powerloader,
 /turf/simulated/floor/tiled,
 /area/merchant_station)
 "aWJ" = (
@@ -12199,6 +12203,15 @@
 	},
 /turf/simulated/floor/holofloor/beach/sand,
 /area/holodeck/source_volleyball)
+"ocj" = (
+/obj/effect/paint/silver,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "merchant_rear";
+	name = "Rear Hatch"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/merchant/home)
 "oiM" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/laceup,
@@ -12254,6 +12267,15 @@
 	name = "Shuttle Bay Blast Door"
 	},
 /area/syndicate_elite_squad)
+"oOo" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "merchant_station_hatch";
+	name = "Loading Hatch"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/merchant_station)
 "pgJ" = (
 /obj/structure/holostool,
 /turf/simulated/floor/holofloor/tiled/stone,
@@ -12500,6 +12522,18 @@
 	},
 /turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_cafe)
+"tUB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/button/blast_door{
+	id_tag = "merchant_station_hatch";
+	name = "Loading Hatch Control";
+	pixel_x = -32;
+	pixel_y = -32;
+	req_access = list("ACCESS_MERCHANT")
+	},
+/turf/simulated/floor/tiled,
+/area/merchant_station)
 "ufC" = (
 /obj/structure/table/holo_woodentable,
 /turf/simulated/floor/holofloor/concrete,
@@ -12590,6 +12624,19 @@
 /obj/effect/paint/black,
 /turf/simulated/floor/plating,
 /area/shuttle/administration/centcom)
+"wsO" = (
+/obj/effect/paint/silver,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "merchantshuttle";
+	name = "Merchant Window Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/merchant/home)
 "wCv" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -12603,6 +12650,10 @@
 "wDD" = (
 /turf/simulated/floor/holofloor/beach/sand,
 /area/holodeck/source_temple)
+"wKN" = (
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/merchant_station)
 "xqW" = (
 /obj/structure/bed/chair/wood{
 	holographic = 1
@@ -23189,9 +23240,9 @@ aRo
 aOw
 aab
 aRA
-aRA
-aRA
-aRA
+wsO
+ocj
+wsO
 aRA
 aMf
 aUx
@@ -23391,8 +23442,8 @@ aRp
 aOw
 aOw
 aRn
-aMf
-aMf
+wKN
+oOo
 aMf
 aRn
 aMf
@@ -23594,7 +23645,7 @@ aRD
 aPd
 aPd
 aPd
-aPd
+tUB
 aPd
 aTZ
 aPd


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Someone brought to my attention that loading/unloading the merchant shuttle is a pain in the ASS. This adds a hatch to the merchant ship and the merchant station, which can be opened to practically half the distance you have to walk to load stuff onto the merchant ship. In retrospect i could've reorganized the merchant station but THIS IS FINE TOO.

The button is access locked so that nobody can just click the funny button and vent the merchant ship, and there's a window to help the merchant tell that they'll vent the merchant ship if they hit the funny button.