### PR TITLE
Makes it so retractable pens can't fuck you over

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -280,11 +280,6 @@
 			to_chat(usr, "<span class='info'>There isn't enough space left on \the [src] to write anything.</span>")
 			return
 
-		var/t =  sanitize(input("Enter what you want to write:", "Write", null, null) as message, free_space, extra = 0, trim = 0)
-
-		if(!t)
-			return
-
 		var/obj/item/I = usr.get_active_hand() // Check to see if he still got that darn pen, also check what type of pen
 		var/iscrayon = 0
 		var/isfancy = 0
@@ -300,8 +295,8 @@
 				return
 
 		var/obj/item/weapon/pen/P = I
-		if(!P.pen_usable(usr))
-			return
+		if(!P.active)
+			P.toggle()
 
 		if(P.iscrayon)
 			iscrayon = 1
@@ -309,7 +304,10 @@
 		if(P.isfancy)
 			isfancy = 1
 
+		var/t =  sanitize(input("Enter what you want to write:", "Write", null, null) as message, free_space, extra = 0, trim = 0)
 
+		if(!t)
+			return
 		// if paper is not in usr, then it must be near them, or in a clipboard or folder, which must be in or near usr
 		if(src.loc != usr && !src.Adjacent(usr) && !((istype(src.loc, /obj/item/weapon/material/clipboard) || istype(src.loc, /obj/item/weapon/folder)) && (src.loc.loc == usr || src.loc.Adjacent(usr)) ) )
 			return

--- a/code/modules/paperwork/pen/pen.dm
+++ b/code/modules/paperwork/pen/pen.dm
@@ -13,6 +13,7 @@
 	var/colour = "black"	//what colour the ink is!
 	var/color_description = "black ink"
 
+	var/active = TRUE
 	var/iscrayon = FALSE
 	var/isfancy = FALSE
 
@@ -57,5 +58,5 @@
 		var/obj/item/organ/external/head/head = A
 		head.write_on(user, src.color_description)
 
-/obj/item/weapon/pen/proc/pen_usable()
-	return TRUE
+/obj/item/weapon/pen/proc/toggle()
+	return

--- a/code/modules/paperwork/pen/retractable_pen.dm
+++ b/code/modules/paperwork/pen/retractable_pen.dm
@@ -1,7 +1,7 @@
-/obj/item/weapon/pen/retractable
+/obj/item/weapon/pen/retractable //Worst addition ever, probably.
 	desc = "It's a retractable pen."
 	icon_state = "pen" //for map visibility
-	var/active = FALSE
+	active = FALSE
 	var/base_state = "ret_black"
 
 /obj/item/weapon/pen/retractable/blue
@@ -34,17 +34,13 @@
 
 /obj/item/weapon/pen/retractable/attack(atom/A, mob/user, target_zone)
 	if(!active)
-		to_chat(user, SPAN_NOTICE("You'll have to activate \the [src] if you wish to use it."))
-		return
+		toggle()
 	..()
 
 /obj/item/weapon/pen/retractable/attack_self(mob/user)
+	toggle()
+
+/obj/item/weapon/pen/retractable/toggle()
 	active = !active
 	playsound(src, 'sound/items/penclick.ogg', 5, 0, -4)
 	update_icon()
-
-/obj/item/weapon/pen/retractable/pen_usable(var/mob/living/user)
-	if(active)
-		return TRUE
-	else
-		to_chat(user, SPAN_NOTICE("You'll have to activate \the [src] if you wish to write with it."))


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Retractable pens are the spawn of satan. All they do is tell you after writing 3 paragraphs "haha you forgot to extend the pen first, start over ;)". bay is known for its shitty removals but retractable pens are its worst ADDITION. This makes it so that the pens will auto-extend instead of deleting three paragraphs because your shit-for-brains character tried to write with the pen retracted. You, as a player, can only tell if it's extended or not based on like 3 pixels. I know I've been making a lot of shitty prs lately but THIS ONE is good.
