### PR TITLE
Vox guns

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/vox.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vox.dm
@@ -45,3 +45,19 @@
 /obj/item/clothing/gloves/rig/vox_rig
 	species_restricted = list(SPECIES_VOX)
 	siemens_coefficient = 0
+
+/obj/item/weapon/rig/vox/quill
+	name = "Quill's rig control module"
+	desc = "The quill's personal rig suit. Parts of it writhe and squirm as if alive. The visor looks more like a thick membrane."
+	cell_type =  /obj/item/weapon/cell/hyper
+	req_access = list(access_voxship_captain)
+
+	initial_modules = list(
+		/obj/item/rig_module/vision/meson,
+		/obj/item/rig_module/mounted/plasmacutter,
+		/obj/item/rig_module/maneuvering_jets,
+		/obj/item/rig_module/power_sink,
+		/obj/item/rig_module/cooling_unit,
+		/obj/item/rig_module/mounted/egun,
+		/obj/item/rig_module/chem_dispenser/combat
+		)

--- a/code/modules/clothing/spacesuits/rig/suits/vox.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vox.dm
@@ -45,19 +45,3 @@
 /obj/item/clothing/gloves/rig/vox_rig
 	species_restricted = list(SPECIES_VOX)
 	siemens_coefficient = 0
-
-/obj/item/weapon/rig/vox/quill
-	name = "Quill's rig control module"
-	desc = "The quill's personal rig suit. Parts of it writhe and squirm as if alive. The visor looks more like a thick membrane."
-	cell_type =  /obj/item/weapon/cell/hyper
-	req_access = list(access_voxship_captain)
-
-	initial_modules = list(
-		/obj/item/rig_module/vision/meson,
-		/obj/item/rig_module/mounted/plasmacutter,
-		/obj/item/rig_module/maneuvering_jets,
-		/obj/item/rig_module/power_sink,
-		/obj/item/rig_module/cooling_unit,
-		/obj/item/rig_module/mounted/egun,
-		/obj/item/rig_module/chem_dispenser/combat
-		)

--- a/code/modules/projectiles/guns/energy/vox.dm
+++ b/code/modules/projectiles/guns/energy/vox.dm
@@ -30,9 +30,9 @@
 	one_hand_penalty = 2 //a little bulky
 	self_recharge = 1
 	firemodes = list(
-		list(mode_name="stunning", burst=1, fire_delay=null, move_delay=null, burst_accuracy=list(30), dispersion=null, projectile_type=/obj/item/projectile/beam/stun/darkmatter, charge_cost = 50),
-		list(mode_name="focused", burst=1, fire_delay=null, move_delay=null, burst_accuracy=list(30), dispersion=null, projectile_type=/obj/item/projectile/beam/darkmatter, charge_cost = 75),
-		list(mode_name="scatter burst", burst=8, fire_delay=null, move_delay=null, burst_accuracy=list(0, 0, 0, 0, 0, 0, 0, 0), dispersion=list(0, 1, 2, 2, 3, 3, 3, 3, 3), projectile_type=/obj/item/projectile/energy/darkmatter, charge_cost = 10),
+		list(mode_name="stunning", burst=1, fire_delay=null, move_delay=null, burst_accuracy=list(30), dispersion=null, projectile_type=/obj/item/projectile/beam/stun/darkmatter, charge_cost = 15),
+		list(mode_name="focused", burst=1, fire_delay=null, move_delay=null, burst_accuracy=list(30), dispersion=null, projectile_type=/obj/item/projectile/beam/darkmatter, charge_cost = 25),
+		list(mode_name="scatter burst", burst=8, fire_delay=null, move_delay=null, burst_accuracy=list(0, 0, 0, 0, 0, 0, 0, 0), dispersion=list(0, 1, 2, 2, 3, 3, 3, 3, 3), projectile_type=/obj/item/projectile/energy/darkmatter, charge_cost = 5),
 		)
 
 /obj/item/weapon/gun/energy/darkmatter/Initialize()

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -191,6 +191,7 @@
 	options["Enforcer"] = list(/obj/item/weapon/gun/energy/darkmatter,/obj/item/weapon/gun/energy/plasmastun/vox,/obj/item/weapon/storage/firstaid/adv)
 	options["Controller"] = list(/obj/item/weapon/gun/energy/darkmatter,/obj/item/weapon/gun/launcher/alien/spikethrower,/obj/item/weapon/gun/energy/sonic,/obj/item/weapon/storage/box/stinger,/obj/item/weapon/storage/firstaid/adv)
 	options["Stolen Marine Gear"] = list(/obj/item/weapon/gun/projectile/automatic/bullpup_rifle,/obj/item/weapon/storage/firstaid/adv,/obj/item/ammo_magazine/mil_rifle,/obj/item/ammo_magazine/mil_rifle,/obj/item/ammo_magazine/mil_rifle,/obj/item/weapon/gun/energy/gun,/obj/item/weapon/storage/box/fragshells)
+	options["Sniper"] = list(/obj/item/weapon/gun/energy/darkmatter,/obj/item/weapon/gun/energy/sniperrifle/vox,/obj/item/weapon/storage/firstaid/adv,/obj/item/device/binoculars,/obj/item/weapon/gun/projectile/revolver,/obj/item/ammo_magazine/speedloader/magnum,/obj/item/ammo_magazine/speedloader/magnum,/obj/item/ammo_magazine/speedloader/magnum)
 	options["Melee"] = list(/obj/item/weapon/gun/energy/darkmatter,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/reagent_containers/hypospray/autoinjector/stim,/obj/item/weapon/reagent_containers/hypospray/autoinjector/stim,/obj/item/weapon/reagent_containers/hypospray/autoinjector/kompoton,/obj/item/weapon/storage/firstaid/adv)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)
@@ -205,6 +206,11 @@
 	desc = "The modified Hephaestus Industries MA21 Selkie is a weapon that uses a laser pulse to ionise the local atmosphere, creating a disorienting pulse of plasma and deafening shockwave as the wave expands. Without a local atmosphere to ionize, however, it becomes a very expensive paperweight. This model seems heavily modified, to use the power of biofuel."
 	self_recharge = 1
 	recharge_time = 20
+
+/obj/item/weapon/gun/energy/sniperrifle/vox
+	desc = "This is a modified Hephaestus Industries Baleful, the cell have been replaced by a vox variant, making it able to self charge. It's a designated marksman rifle capable of shooting powerful ionized beams, this is a weapon to kill from a distance."
+	self_recharge = 1
+	recharge_time = 60
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew
 	name = "Shard Acolyte"

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -162,19 +162,47 @@
 	shoes = /obj/item/clothing/shoes/magboots/vox
 	belt = /obj/item/weapon/storage/belt/utility/full
 	id_type = /obj/item/weapon/card/id/voxship
-	r_pocket = /obj/item/device/radio
 	l_pocket = /obj/item/weapon/crowbar/prybar
 	r_hand = /obj/item/weapon/tank/emergency/nitrogen/double
+	l_hand = /obj/item/voxbox
 
 /decl/hierarchy/outfit/job/voxship/crew/captain
 	name = VOXSHIP_OUTFIT_JOB_NAME("Shard Quill")
 	uniform = /obj/item/clothing/under/vox/vox_robes
-	r_pocket = /obj/item/device/radio
+	r_pocket = /obj/item/weapon/tank/emergency/nitrogen/double
 	shoes = /obj/item/clothing/shoes/magboots/vox
 	belt = /obj/item/weapon/storage/belt/utility/full
 	id_type = /obj/item/weapon/card/id/voxship_captain
 	l_pocket = /obj/item/weapon/crowbar/prybar
-	r_hand = /obj/item/weapon/tank/emergency/nitrogen/double
+	r_hand = /obj/item/weapon/rig/vox/quill
+	l_hand = /obj/item/voxbox
+
+/obj/item/voxbox
+	name = "Vox Combat Kit"
+	desc = "A secure box containing weapons."
+	icon = 'icons/obj/ascent_doodads.dmi'
+	icon_state = "box" //temp
+
+/obj/item/voxbox/attack_self(mob/living/user)
+	var/list/options = list()
+	options["Support"] = list(/obj/item/weapon/gun/energy/darkmatter,/obj/item/weapon/gun/launcher/alien/slugsling,/obj/item/weapon/storage/firstaid/combat,/obj/item/clothing/glasses/hud/health/visor,/obj/item/device/scanner/health)
+	options["Enforcer"] = list(/obj/item/weapon/gun/energy/darkmatter,/obj/item/weapon/gun/energy/plasmastun/vox,/obj/item/weapon/storage/firstaid/adv)
+	options["Controller"] = list(/obj/item/weapon/gun/energy/darkmatter,/obj/item/weapon/gun/launcher/alien/spikethrower,/obj/item/weapon/gun/energy/sonic,/obj/item/weapon/storage/box/stinger,/obj/item/weapon/storage/firstaid/adv)
+	options["Stolen Marine Gear"] = list(/obj/item/weapon/gun/projectile/automatic/bullpup_rifle,/obj/item/weapon/storage/firstaid/adv,/obj/item/ammo_magazine/mil_rifle,/obj/item/ammo_magazine/mil_rifle,/obj/item/ammo_magazine/mil_rifle,/obj/item/weapon/gun/energy/gun,/obj/item/weapon/storage/box/fragshells)
+	options["Melee"] = list(/obj/item/weapon/gun/energy/darkmatter,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/reagent_containers/hypospray/autoinjector/stim,/obj/item/weapon/reagent_containers/hypospray/autoinjector/stim,,/obj/item/weapon/reagent_containers/hypospray/autoinjector/kompoton,/obj/item/weapon/storage/firstaid/adv)
+	var/choice = input(user,"What type of equipment?") as null|anything in options
+	if(src && choice)
+		var/list/things_to_spawn = options[choice]
+		for(var/new_type in things_to_spawn)
+			var/atom/movable/AM = new new_type(get_turf(src))
+			if(istype(AM, /obj/item/weapon/gun/))
+				to_chat(user, "You have chosen \the [AM]. Make sure to keep it safe.")
+		qdel(src)
+
+/obj/item/weapon/gun/energy/plasmastun/vox
+	desc = "The modified Hephaestus Industries MA21 Selkie is a weapon that uses a laser pulse to ionise the local atmosphere, creating a disorienting pulse of plasma and deafening shockwave as the wave expands. Without a local atmosphere to ionize, however, it becomes a very expensive paperweight. This model seems heavily modified, to use the power of biofuel."
+	self_recharge = 1
+	recharge_time = 20
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew
 	name = "Shard Acolyte"

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -174,7 +174,7 @@
 	belt = /obj/item/weapon/storage/belt/utility/full
 	id_type = /obj/item/weapon/card/id/voxship_captain
 	l_pocket = /obj/item/weapon/crowbar/prybar
-	r_hand = /obj/item/weapon/rig/vox/quill
+	r_hand = /obj/item/device/radio
 	l_hand = /obj/item/voxbox
 
 /obj/item/voxbox

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -191,7 +191,7 @@
 	options["Enforcer"] = list(/obj/item/weapon/gun/energy/darkmatter,/obj/item/weapon/gun/energy/plasmastun/vox,/obj/item/weapon/storage/firstaid/adv)
 	options["Controller"] = list(/obj/item/weapon/gun/energy/darkmatter,/obj/item/weapon/gun/launcher/alien/spikethrower,/obj/item/weapon/gun/energy/sonic,/obj/item/weapon/storage/box/stinger,/obj/item/weapon/storage/firstaid/adv)
 	options["Stolen Marine Gear"] = list(/obj/item/weapon/gun/projectile/automatic/bullpup_rifle,/obj/item/weapon/storage/firstaid/adv,/obj/item/ammo_magazine/mil_rifle,/obj/item/ammo_magazine/mil_rifle,/obj/item/ammo_magazine/mil_rifle,/obj/item/weapon/gun/energy/gun,/obj/item/weapon/storage/box/fragshells)
-	options["Melee"] = list(/obj/item/weapon/gun/energy/darkmatter,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/reagent_containers/hypospray/autoinjector/stim,/obj/item/weapon/reagent_containers/hypospray/autoinjector/stim,,/obj/item/weapon/reagent_containers/hypospray/autoinjector/kompoton,/obj/item/weapon/storage/firstaid/adv)
+	options["Melee"] = list(/obj/item/weapon/gun/energy/darkmatter,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/reagent_containers/hypospray/autoinjector/stim,/obj/item/weapon/reagent_containers/hypospray/autoinjector/stim,/obj/item/weapon/reagent_containers/hypospray/autoinjector/kompoton,/obj/item/weapon/storage/firstaid/adv)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)
 		var/list/things_to_spawn = options[choice]

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -160,6 +160,7 @@
 	uniform = /obj/item/clothing/under/vox/vox_robes
 	r_pocket = /obj/item/device/radio
 	shoes = /obj/item/clothing/shoes/magboots/vox
+	l_ear = /obj/item/device/radio/headset
 	belt = /obj/item/weapon/storage/belt/utility/full
 	id_type = /obj/item/weapon/card/id/voxship
 	l_pocket = /obj/item/weapon/crowbar/prybar
@@ -171,6 +172,7 @@
 	uniform = /obj/item/clothing/under/vox/vox_robes
 	r_pocket = /obj/item/weapon/tank/emergency/nitrogen/double
 	shoes = /obj/item/clothing/shoes/magboots/vox
+	l_ear = /obj/item/device/radio/headset
 	belt = /obj/item/weapon/storage/belt/utility/full
 	id_type = /obj/item/weapon/card/id/voxship_captain
 	l_pocket = /obj/item/weapon/crowbar/prybar


### PR DESCRIPTION
Adds a kit that voxes get whenever they spawn.
This should hopefully help with having to rely on the armory and the problems that come from having high pop as voxes.
AHHHHHHH HEADSETS AHHHHHHHHH
Buffed the shots by a bit for the dark matter gun.

I also fixed a bug, where there was an extra handheld radio being spawned for the vox crew.

_I have tested all these changes on a local server, and they all should work._

Edit v1: Gave a radio for all of the voxes.
Edit v2: The dark matter gun is able to shoot 13 times in stun mode, 7 times in lethal mode, and 4 times in burst mode now.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->