### PR TITLE
adds a holopad to the merchant station

### DIFF
--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -11529,6 +11529,10 @@
 	},
 /turf/simulated/floor/holofloor/concrete,
 /area/holodeck/source_volleyball)
+"bWN" = (
+/obj/machinery/hologram/holopad/longrange,
+/turf/simulated/floor/wood,
+/area/merchant_station)
 "bXW" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/rods{
@@ -20809,7 +20813,7 @@ aMW
 aMC
 aNU
 aNU
-aNU
+bWN
 aQa
 aOw
 aab


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Merchant station's a big place to not have a holopad in. Main reason to add one, so that if another merchant latejoins and the first merchant's already gone, now they can yell at them to come pick them up.