### PR TITLE
Creeping now causes your footsteps to be silent

### DIFF
--- a/code/game/turfs/simulated/footsteps.dm
+++ b/code/game/turfs/simulated/footsteps.dm
@@ -41,7 +41,7 @@
 
 	if(!has_organ(BP_L_FOOT) && !has_organ(BP_R_FOOT))
 		return //no feet no footsteps
-	
+
 	return TRUE
 
 /mob/living/carbon/human/proc/handle_footsteps()
@@ -51,9 +51,12 @@
 	 //every other turf makes a sound
 	if((step_count % 2) && MOVING_QUICKLY(src))
 		return
-	
+
 	// don't need to step as often when you hop around
 	if((step_count % 3) && !has_gravity(src))
+		return
+
+	if(istype(move_intent, /decl/move_intent/creep)) //We don't make sounds if we're tiptoeing
 		return
 
 	var/turf/simulated/T = get_turf(src)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Creeping is a weird movement mode that doesn't really do anything walking doesn't, this gives it one purpose, letting you move silently. Ported from bay, original pr by Shadowtail117