### PR TITLE
Protein bars have iron, the ones in protein mres have no sugar

### DIFF
--- a/code/game/objects/items/weapons/storage/mre.dm
+++ b/code/game/objects/items/weapons/storage/mre.dm
@@ -93,7 +93,7 @@ MRE Stuff
 	icon_state = "meatmre"
 	main_meal = /obj/item/weapon/storage/mrebag/menu10
 	startswith = list(
-	/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar,
+	/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar/protein,
 	/obj/item/weapon/reagent_containers/food/condiment/small/packet/protein,
 	/obj/random/mre/sauce/sugarfree,
 	/obj/item/weapon/material/kitchen/utensil/spoon/plastic

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3158,6 +3158,11 @@
 	icon_state = "proteinbar"
 	trash = /obj/item/trash/candy/proteinbar
 	bitesize = 6
+	reagents_to_add = list(/datum/reagent/nutriment = 10, /datum/reagent/nutriment/protein = 4, /datum/reagent/sugar=7, /datum/reagent/iron = 3)
+
+/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar/protein
+	name = "sugar-free protein bar"
+	desc = "SwoleMAX brand protein bars, guaranteed to get you feeling perfectly overconfident. Now with extra no sugar!"
 	reagents_to_add = list(/datum/reagent/nutriment = 10, /datum/reagent/nutriment/protein = 4, /datum/reagent/iron = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/donor

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -24,7 +24,7 @@
 	//Used to stop deepfried meat from looking like slightly tanned raw meat, and make it actually look cooked
 	center_of_mass = "x=16;y=16"
 	w_class = ITEM_SIZE_SMALL
-	
+
 	var/has_products = FALSE
 	var/list/attack_products //Items you can craft together. Like bomb making, but with food and less screwdrivers.
 	// Uses format list(ingredient = result_type). The ingredient can be a typepath or a kitchen_tag string (used for mobs or plants)
@@ -217,7 +217,7 @@
 				reagents.trans_to_obj(slice, reagents_per_slice)
 			qdel(src)
 			return
-			
+
 	if(!LAZYLEN(attack_products))
 		return
 	var/create_type
@@ -715,7 +715,7 @@
 	desc = "A heated Donk pocket, great for vendors on the go."
 	reagents_to_add = list(/datum/reagent/nutriment = 2, /datum/reagent/nutriment/protein = 2, /datum/reagent/tricordrazine = 5)
 	bitesize = 6
-	
+
 /obj/item/weapon/reagent_containers/food/snacks/donkpocket/warm/Initialize()
 	. = ..()
 	addtimer(CALLBACK(src, .proc/cool), 7 MINUTES)
@@ -3158,7 +3158,7 @@
 	icon_state = "proteinbar"
 	trash = /obj/item/trash/candy/proteinbar
 	bitesize = 6
-	reagents_to_add = list(/datum/reagent/nutriment = 10, /datum/reagent/nutriment/protein = 4, /datum/reagent/sugar = 7)
+	reagents_to_add = list(/datum/reagent/nutriment = 10, /datum/reagent/nutriment/protein = 4, /datum/reagent/iron = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/donor
 	name = "donor candy"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
iron is good for you, it gives you blood, good in an emergency. Sugar does a couple of things, but it's bad for unathi, which compose a large enough portion of the crew that emergency supplies probably shouldn't poison them. So this replaces the sugar with iron.

edit: that and protein bars are found in the PROTEIN MRE, which unathi are supposed to be able to eat.