### PR TITLE
Removes GAS antags.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -59,6 +59,7 @@
 
 /mob/living/carbon/human/nabber/New(var/new_loc)
 	pulling_punches = 1
+	status_flags = NO_ANTAG
 	..(new_loc,SPECIES_NABBER)
 
 /mob/living/carbon/human/monkey/New(var/new_loc)

--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -318,6 +318,7 @@
 /datum/species/nabber/handle_post_spawn(var/mob/living/carbon/human/H)
 	..()
 	return H.pulling_punches = TRUE
+	H.status_flags |= NO_ANTAG
 
 /datum/species/nabber/has_fine_manipulation(var/mob/living/carbon/human/H)
 	if(H.species.get_bodytype() == SPECIES_MONARCH_QUEEN)

--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -9,6 +9,7 @@
 	new environment."
 	hidden_from_codex = FALSE
 	silent_steps = TRUE
+	status_flags = NO_ANTAG
 
 	antaghud_offset_y = 8
 
@@ -318,7 +319,6 @@
 /datum/species/nabber/handle_post_spawn(var/mob/living/carbon/human/H)
 	..()
 	return H.pulling_punches = TRUE
-	H.status_flags |= NO_ANTAG
 
 /datum/species/nabber/has_fine_manipulation(var/mob/living/carbon/human/H)
 	if(H.species.get_bodytype() == SPECIES_MONARCH_QUEEN)

--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -9,7 +9,6 @@
 	new environment."
 	hidden_from_codex = FALSE
 	silent_steps = TRUE
-	status_flags = NO_ANTAG
 
 	antaghud_offset_y = 8
 


### PR DESCRIPTION
We gave it some time after reverting the GAS antag ban and it didn't really work out. Balancing GAS is impossible without taking away some of their more unique features, so the best way to cull murderbugs is to remove the possibility to acquire antag statuses, which, for GAS are A) OP as fuck, B) Completely senseless from an IC standpoint, and C) Always horribly executed.

