### PR TITLE
Fixes deck 2 security directional signs.

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -7360,7 +7360,7 @@
 /area/vacant/prototype/engine)
 "nP" = (
 /obj/structure/sign/directions/security{
-	dir = 2;
+	dir = 1;
 	pixel_y = -4;
 	pixel_z = 0
 	},
@@ -7372,7 +7372,7 @@
 /area/hallway/primary/seconddeck/center)
 "nQ" = (
 /obj/structure/sign/directions/security{
-	dir = 2;
+	dir = 1;
 	pixel_y = -4;
 	pixel_z = 0
 	},


### PR DESCRIPTION
Directional signs in deck 2 stairwell have been pointing in the wrong direction since the beginning of Hestia. This should hopefully fix that. Currently untested.

