### PR TITLE
Ascent and Skrell guns rebalance. Increases infantry rig laser armor ever so slightly.

### DIFF
--- a/code/modules/boh/ascent2/projectiles.dm
+++ b/code/modules/boh/ascent2/projectiles.dm
@@ -23,7 +23,7 @@
 	name = "particle charge"
 	icon_state = "particle"
 	fire_sound = 'sound/weapons/gauss.ogg'
-	damage = 65
+	damage = 60
 	armor_penetration = 85
 	muzzle_type = /obj/effect/projectile/laser_particle/muzzle
 	tracer_type = /obj/effect/projectile/laser_particle/tracer
@@ -33,7 +33,7 @@
 
 /obj/item/projectile/beam/particleadv/small
 	name = "particle charge"
-	damage = 55
-	armor_penetration = 65
+	damage = 30
+	armor_penetration = 40
 	shrapnel_chance_multiplier = 0.3
 	arterial_bleed_chance_multiplier = 0.3

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -99,7 +99,7 @@
 	scoped_accuracy = 9
 	recharge_time = 20
 	fire_delay = 30
-	slowdown_held = 2
+	slowdown_held = 1
 	slowdown_worn = 1
 	screen_shake = 0 //screenshake breaks the scope.
 	scope_zoom = 2

--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -174,7 +174,7 @@
 	item_state = "skrell_rifle"
 	one_hand_penalty = 3
 	fire_delay = 10
-	slowdown_held = 2
+	slowdown_held = 1
 	slowdown_worn = 1
 	screen_shake = 0 //screenshake breaks the scope.
 	scoped_accuracy = 4

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -106,12 +106,12 @@
 	armor_penetration = 20
 
 /obj/item/projectile/beam/pulse/skrell/single
-	damage = 60
+	damage = 50
 	armor_penetration = 20
 
 /obj/item/projectile/beam/pulse/skrell/single/lance
 	distance_falloff = 0.50
-	damage = 80
+	damage = 60
 	armor_penetration = 40
 
 /obj/item/projectile/beam/emitter
@@ -283,8 +283,8 @@
 /obj/item/projectile/beam/particle
 	name = "particle lance"
 	icon_state = "particle"
-	damage = 35
-	armor_penetration = 50
+	damage = 40
+	armor_penetration = 60
 	muzzle_type = /obj/effect/projectile/laser_particle/muzzle
 	tracer_type = /obj/effect/projectile/laser_particle/tracer
 	impact_type = /obj/effect/projectile/laser_particle/impact
@@ -294,7 +294,7 @@
 /obj/item/projectile/beam/particle/small
 	name = "particle beam"
 	damage = 30
-	armor_penetration = 40
+	armor_penetration = 20
 	shrapnel_chance_multiplier = 0.4
 	arterial_bleed_chance_multiplier = 0.4
 

--- a/code/modules/projectiles/projectile/magnetic.dm
+++ b/code/modules/projectiles/projectile/magnetic.dm
@@ -14,8 +14,8 @@
 	name = "slug"
 	icon_state = "gauss_silenced"
 	stun = 1
-	damage = 75
-	armor_penetration = 90
+	damage = 50
+	armor_penetration = 75
 
 /obj/item/projectile/bullet/magnetic/flechette
 	name = "flechette"

--- a/maps/torch/items/clothing/boh_clothing.dm
+++ b/maps/torch/items/clothing/boh_clothing.dm
@@ -91,7 +91,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
 		bullet = ARMOR_BALLISTIC_RIFLE,
-		laser = ARMOR_LASER_SMALL,
+		laser = ARMOR_LASER_HANDGUNS,
 		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_SHIELDED,


### PR DESCRIPTION
Ascent and Skrell are still stronger than the Dagon, but this will ensure engagements are slower and limbs aren't vaporized instantly.

Also nerfs the ZT-8's slugs a bit.