### PR TITLE
Tempoary bioreactor fix

### DIFF
--- a/code/modules/boh_misc/machinery.dm
+++ b/code/modules/boh_misc/machinery.dm
@@ -87,7 +87,7 @@
 	icon = 'icons/obj/machines/power/fusion_core.dmi'
 	icon_state = "core1"
 	color = COLOR_DARK_GREEN_GRAY
-	output_power = 15 KILOWATTS //Temp number to make up for the fact that I'm too out of it to actually add a proper bio reactor rn. -Carl
+	output_power = 5 MEGAWATTS //Temp number to make up for the fact that I'm too out of it to actually add a proper bio reactor rn. -Carl
 
 /obj/machinery/power/ascent_reactor/attack_hand(mob/user)
 	. = ..()


### PR DESCRIPTION
This is a fix for the problems that voxes usually face since they do not have any way to get any power outside the bioreactor, which can only power up the medical room with its current capacity.
The only reason that the vox ship has power half of the time, is because they get two full SMEs units.
![Skærmbillede 2022-02-21 013903](https://user-images.githubusercontent.com/63320341/154872024-2d1a7107-ad0a-400b-97f5-ddfa236430e5.png)


<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->