### PR TITLE
Makes the merchant blast doors less CBT

### DIFF
--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -9890,7 +9890,7 @@
 /area/shuttle/merchant/home)
 "aSK" = (
 /obj/machinery/button/blast_door{
-	id_tag = "merchant_rear";
+	id_tag = "merchant_station_hatchr";
 	name = "Rear Hatch Control";
 	pixel_y = -24;
 	req_access = list("ACCESS_MERCHANT")
@@ -12211,9 +12211,10 @@
 /obj/effect/paint/silver,
 /obj/machinery/door/blast/regular{
 	dir = 4;
-	id_tag = "merchant_rear";
+	id_tag = "merchant_station_hatch";
 	name = "Rear Hatch"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/shuttle/merchant/home)
 "oiM" = (


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
This makes the merchant blast doors less annoying to use by letting you open both sides of the blast doors at once, and gives the merchant side an emergency shutter (station side already has one) so mishaps aren't terrible.