### PR TITLE
Adds stealth module to traitor uplink, removes them from everything else.

### DIFF
--- a/code/datums/uplink/hardsuit_modules.dm
+++ b/code/datums/uplink/hardsuit_modules.dm
@@ -51,3 +51,4 @@
 	desc = "A module that drains your power reserves while cloaking you from all visual scanners"
 	item_cost = 130
 	path = /obj/item/rig_module/stealth_field
+	antag_roles = list(MODE_TRAITOR)

--- a/code/datums/uplink/hardsuit_modules.dm
+++ b/code/datums/uplink/hardsuit_modules.dm
@@ -45,3 +45,9 @@
 	desc = "A module capable of draining your suit's power reserves in order to fire a shoulder mounted laser cannon."
 	item_cost = 64
 	path = /obj/item/rig_module/mounted/lcannon
+
+/datum/uplink_item/item/hardsuit_modules/stealth_module
+	name = "\improper Stealth Module
+	desc = "A module that drains your power reserves while cloaking you from all visual scanners"
+	item_cost = 130
+	path = /obj/item/rig_module/stealth_field

--- a/code/datums/uplink/hardsuit_modules.dm
+++ b/code/datums/uplink/hardsuit_modules.dm
@@ -47,7 +47,7 @@
 	path = /obj/item/rig_module/mounted/lcannon
 
 /datum/uplink_item/item/hardsuit_modules/stealth_module
-	name = "\improper Stealth Module
+	name = "\improper Stealth Module"
 	desc = "A module that drains your power reserves while cloaking you from all visual scanners"
 	item_cost = 130
 	path = /obj/item/rig_module/stealth_field

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1121,7 +1121,6 @@ something, make sure it's not in one of the other lists.*/
 	return list(/obj/item/weapon/rig/industrial,
 				/obj/item/weapon/rig/eva,
 				/obj/item/weapon/rig/light/hacker,
-				/obj/item/weapon/rig/light/stealth,
 				/obj/item/weapon/rig/light,
 				/obj/item/weapon/rig/unathi)
 

--- a/code/modules/research/designs/designs_rig_modules.dm
+++ b/code/modules/research/designs/designs_rig_modules.dm
@@ -166,15 +166,6 @@
 	build_path = /obj/item/rig_module/fabricator/energy_net
 	sort_string = "WCKAC"
 
-/datum/design/item/rig/stealth
-	name = "Active Camouflage"
-	desc = "An integrated active camouflage system, mountable on a RIG."
-	id = "rig_stealth"
-	req_tech = list(TECH_MATERIAL = 5, TECH_POWER = 6, TECH_MAGNET = 6, TECH_ESOTERIC = 6, TECH_ENGINEERING = 7)
-	materials = list(MATERIAL_STEEL = 6000, MATERIAL_GLASS = 3000, MATERIAL_DIAMOND = 2000, MATERIAL_SILVER = 2000, MATERIAL_URANIUM = 2000, MATERIAL_GOLD = 2000, MATERIAL_PLASTIC = 2000)
-	build_path = /obj/item/rig_module/stealth_field
-	sort_string = "WCLAA"
-
 /datum/design/item/rig/cooling_unit
 	name = "Cooling Unit"
 	desc = "A suit cooling unit, mountable on a RIG."


### PR DESCRIPTION
Stealth modules are extremely powerful, yet can currently be found for free in maintenance, bought from merchants, or worst of all unlocked in the R&D lathe by simply deconstructing the 10 TC chameleon kit. 

This will remove stealth RIGs from maintenance/merchant drop tables and remove the stealth module from R&D. Cloaking can now only be acquired from a traitor uplink/Ninja.

Stealth modules will cost 130 TC, leaving 50 to spend on whatever else with a default uplink. Mercenaries will not be able to buy these because an entire squad of literal stealth ops would be amusing exactly zero times.