### PR TITLE
Reverts Yawet's Stealth Buffs to Monarch Serpentids

### DIFF
--- a/maps/away/ascent/ascent_jobs.dm
+++ b/maps/away/ascent/ascent_jobs.dm
@@ -174,7 +174,6 @@
 	title = "Serpentid Adjunct"
 	supervisors = "your Queen"
 	total_positions = 2
-	skill_points = 46 //Monarchs live longer and take longer to grow compared to Gynes and Alates.
 	info = "You are a Monarch Serpentid Worker serving as an attendant to your Queen on this vessel. Serve her however she requires."
 	set_species_on_join = SPECIES_MONARCH_WORKER
 	outfit_type = /decl/hierarchy/outfit/job/monarch
@@ -189,7 +188,6 @@
 	title = "Serpentid Queen"
 	supervisors = "the Gyne"
 	total_positions = 1
-	skill_points = 46 //Ditto
 	info = "You are a Monarch Serpentid Queen living on an independant Ascent vessel. Assist the Gyne in her duties and tend to your Workers."
 	set_species_on_join = SPECIES_MONARCH_QUEEN
 	outfit_type = /decl/hierarchy/outfit/job/monarch


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

About five hours ago, according to the ascent_maps.dm, Yawet committed a 12 point increase to all monarch serpent job points directly to the dev branch without a PR. Because I'm not a fan of developers going behind everyone's back and buffing their choice of species, I'm making that change public and putting a pull request to revert it.

A 12 point increase for no particular reason is frankly insane. There's no reason that the monarchs should have more points than a gyne on top of the already strong pre-set job skills for Ascent. I don't care what your 'lore accuracy' is. This is terrible from a balance perspective and an extremely shitty thing to do by committing this without telling anyone.

![image](https://user-images.githubusercontent.com/67706292/155061180-69e29467-9e6b-4f70-b461-70fbc5952e1f.png)

No pull request, no prior alert to this, absolutely debased.