### PR TITLE
Monarch proper buffs (now that its not 5:06 AM)

### DIFF
--- a/maps/away/ascent/ascent_jobs.dm
+++ b/maps/away/ascent/ascent_jobs.dm
@@ -174,6 +174,7 @@
 	title = "Serpentid Adjunct"
 	supervisors = "your Queen"
 	total_positions = 2
+	skill_points = 46 //Monarchs live longer and take longer to grow compared to Gynes and Alates.
 	info = "You are a Monarch Serpentid Worker serving as an attendant to your Queen on this vessel. Serve her however she requires."
 	set_species_on_join = SPECIES_MONARCH_WORKER
 	outfit_type = /decl/hierarchy/outfit/job/monarch
@@ -188,6 +189,7 @@
 	title = "Serpentid Queen"
 	supervisors = "the Gyne"
 	total_positions = 1
+	skill_points = 46 //Ditto
 	info = "You are a Monarch Serpentid Queen living on an independant Ascent vessel. Assist the Gyne in her duties and tend to your Workers."
 	set_species_on_join = SPECIES_MONARCH_QUEEN
 	outfit_type = /decl/hierarchy/outfit/job/monarch


### PR DESCRIPTION
Failures to note MSW's and MSQ's inherit the GAS debuff.


Also they have forced combat skills that eat 12 points anyway, please see how we handle forced skills.

Meant to PR it anyway, did a funny and hit push to master due to 5 am, unfucked

(also, as a later edit, I figured out why I did this in the first place.

Every other off-ship except skrell gets 44-48)