### PR TITLE
Pulls Skrell skills more into line.

### DIFF
--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -88,7 +88,7 @@
 	allowed_ranks = list(/datum/mil_rank/skrell_fleet/zuumqix)
 	outfit_type = /decl/hierarchy/outfit/job/skrellscoutship
 	info = "Your vessel is scouting through unknown space, working to map out any potential dangers, as well as potential allies."
-	skill_points = 46 //Skrell get the same buffs the ascent do. Strange why we gave them less
+	skill_points = 40 //Skrell get the same buffs the ascent do. Strange why we gave them less
 	is_semi_antagonist = TRUE
 	min_skill = list(SKILL_EVA = SKILL_ADEPT,
 					SKILL_HAULING = SKILL_ADEPT,

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -88,7 +88,7 @@
 	allowed_ranks = list(/datum/mil_rank/skrell_fleet/zuumqix)
 	outfit_type = /decl/hierarchy/outfit/job/skrellscoutship
 	info = "Your vessel is scouting through unknown space, working to map out any potential dangers, as well as potential allies."
-	skill_points = 30
+	skill_points = 46 //Skrell get the same buffs the ascent do. Strange why we gave them less
 	is_semi_antagonist = TRUE
 	min_skill = list(SKILL_EVA = SKILL_ADEPT,
 					SKILL_HAULING = SKILL_ADEPT,


### PR DESCRIPTION
Read https://github.com/BoHBranch/BoH-Bay/pull/1288.


Essentially; Skrell and Ascent were having issues involving skill points and specialisation due to the fact they got (10 or so) less points than everyone else. 18 less in the case of the Vox in some instances.

No clue why this was the case. Carlman bad.