### PR TITLE
Re-allows Vox Merchants.

### DIFF
--- a/maps/torch/job/misc_jobs.dm
+++ b/maps/torch/job/misc_jobs.dm
@@ -63,8 +63,12 @@ Civilian
 	outfit_type = /decl/hierarchy/outfit/job/torch/merchant
 	allowed_branches = list(
 		/datum/mil_branch/civilian
+		/datum/mil_branch/alien
+		/datum/mil_branch/civilian
 	)
 	allowed_ranks = list(
+		/datum/mil_rank/civ/civ
+		/datum/mil_rank/alien
 		/datum/mil_rank/civ/civ
 	)
 	latejoin_at_spawnpoints = 1

--- a/maps/torch/job/misc_jobs.dm
+++ b/maps/torch/job/misc_jobs.dm
@@ -64,12 +64,10 @@ Civilian
 	allowed_branches = list(
 		/datum/mil_branch/civilian,
 		/datum/mil_branch/alien
-		/datum/mil_branch/civilian
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/civ,
 		/datum/mil_rank/alien
-		/datum/mil_rank/civ/civ
 	)
 	latejoin_at_spawnpoints = 1
 	access = list(access_merchant)

--- a/maps/torch/job/misc_jobs.dm
+++ b/maps/torch/job/misc_jobs.dm
@@ -62,12 +62,12 @@ Civilian
 	create_record = 0
 	outfit_type = /decl/hierarchy/outfit/job/torch/merchant
 	allowed_branches = list(
-		/datum/mil_branch/civilian
+		/datum/mil_branch/civilian,
 		/datum/mil_branch/alien
 		/datum/mil_branch/civilian
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/civ/civ
+		/datum/mil_rank/civ/civ,
 		/datum/mil_rank/alien
 		/datum/mil_rank/civ/civ
 	)


### PR DESCRIPTION
Someone requested a PR that reallows Vox Merchants, this undoes the changes in https://github.com/BoHBranch/BoH-Bay/pull/1056 that removed Vox from being merchants.

I make no comments on whether or not this is a good idea. I also did not test it.