### PR TITLE
Revert "makes D100 have 100 sides"

### DIFF
--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -45,7 +45,7 @@
 	name = "d100"
 	desc = "A dice with ten sides. This one is for the tens digit."
 	icon_state = "d10010"
-	sides = 100
+	sides = 10
 
 /obj/item/weapon/dice/proc/roll_die()
 	var/result = rand(1, sides)


### PR DESCRIPTION
Reverts BoHBranch/BoH-Bay#498

This breaks the D100. The code for the d100 cycles the icon state based off of the result. The d100 only has icon states for 1-10. So if the result is greater than 10, the dice switches to an icon state that does not currently exist. To fix this the d100 would need 100 icon states.