### PR TITLE
Quill's personal rigsuit.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/vox.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vox.dm
@@ -45,3 +45,20 @@
 /obj/item/clothing/gloves/rig/vox_rig
 	species_restricted = list(SPECIES_VOX)
 	siemens_coefficient = 0
+
+/obj/item/weapon/rig/vox/quill
+	name = "Quill's rig control module"
+	desc = "The quill's rig suit. It looks exactly like the standard rig suit, but fancier. Parts of it writhe and squirm as if alive. The visor looks more like a thick membrane."
+	cell_type =  /obj/item/weapon/cell/hyper
+	req_access = list(access_voxship_captain)
+
+	initial_modules = list(
+		/obj/item/rig_module/vision,
+		/obj/item/rig_module/mounted/plasmacutter,
+		/obj/item/rig_module/maneuvering_jets,
+		/obj/item/rig_module/power_sink,
+		/obj/item/rig_module/cooling_unit,
+		/obj/item/rig_module/mounted/egun,
+		/obj/item/rig_module/chem_dispenser/combat,
+		/obj/item/rig_module/device/healthscanner,
+		)

--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -6685,6 +6685,7 @@
 /obj/item/weapon/disk/tech_disk,
 /obj/item/weapon/disk/tech_disk,
 /obj/item/weapon/disk/tech_disk,
+/obj/item/weapon/rig/vox/quill,
 /turf/simulated/floor/plating/vox,
 /area/voxship/bridge)
 "oK" = (


### PR DESCRIPTION
It adds a rigsuit that is specifically for the quill.
It uses the quills ID to protect it, from any grabby voxes that want to use it.

That's about it.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->