### PR TITLE
Fixes the Half-Assed MS Material | Other Stuff

### DIFF
--- a/code/__defines/culture.dm
+++ b/code/__defines/culture.dm
@@ -176,7 +176,7 @@
 
 #define FACTION_UNATHI_CLAN          "Clan Focused"
 #define FACTION_UNATHI_KRUKZUZ       "Krukzuz"
-#define FACTION_UNATHI_SOL           "Sol Central Government"
+#define FACTION_UNATHI_SOL           "Solarian Government"
 #define FACTION_UNATHI_INDEPENDENT   "Independent Faction"
 
 #define RELIGION_UNATHI_ANCESTORS	 "Ancestor Worship"
@@ -184,7 +184,7 @@
 #define RELIGION_UNATHI_PRECURSOR    "Precursor"
 #define RELIGION_UNATHI_VINE         "Hand of the Vine"
 #define RELIGION_UNATHI_LIGHTS       "The Fruitful Lights"
-#define RELIGION_UNATHI_OTHER        "Other Religion"
+#define RELIGION_UNATHI_OTHER        "Other"
 #define RELIGION_UNATHI_MARKESHELI   "Markesheli Cult"
 
 // Nabber grades.

--- a/code/modules/boh_misc/munitions.dm
+++ b/code/modules/boh_misc/munitions.dm
@@ -21,7 +21,7 @@
 	range_step = 2
 	spread_step = 10
 	agony = 15//up from 8.5
-//	embed = 0
+	embed = 1//shouldn't HAVE to be noted, but, y'know, seems like it's a problem.
 
 //holder
 /obj/item/ammo_magazine/shotholder/birdshot
@@ -86,7 +86,7 @@
 	damage_flags = DAM_EDGE | DAM_DISPERSED | DAM_EXPLODE
 
 	on_hit(var/atom/target, var/blocked = 0)
-		explosion(target, 1, 6, 12)
+		explosion(target, 0, 1, 6, 12)
 		return 1
 
 /////////

--- a/code/modules/clothing/spacesuits/rig/suits/vox.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vox.dm
@@ -50,7 +50,6 @@
 	name = "Quill's rig control module"
 	desc = "The quill's rig suit. It looks exactly like the standard rig suit, but fancier. Parts of it writhe and squirm as if alive. The visor looks more like a thick membrane."
 	cell_type =  /obj/item/weapon/cell/hyper
-	req_access = list(access_voxship_captain)
 
 	initial_modules = list(
 		/obj/item/rig_module/vision,

--- a/code/modules/culture_descriptor/faction/factions_unathi.dm
+++ b/code/modules/culture_descriptor/faction/factions_unathi.dm
@@ -2,6 +2,7 @@
 	name = FACTION_UNATHI_CLAN
 	description = "Like most Unathi, your allegiance lies in your clan. Even the most religious of Unathi think that caring for your clan \
 	is more important to life. Even when you are seperate from your brethren, one way or another, what you do, you do it for them."
+
 /decl/cultural_info/faction/unathi/krukzuz
 	name = FACTION_UNATHI_KRUKZUZ
 	description = "Krukzuz are the name Unathi give to the groups of clans given control of a sphere of influence by the SCG.\
@@ -9,12 +10,14 @@
 	simply take the support sol gives them and try fill the quotes sol demands, which usually come in the form of recruits. \
 	in any case, you associate more with your local government than you do with Sol, and for many clans that value combat, the rewards sol gives are worth the levies they take."
 	economic_power = 1.2
+
 /decl/cultural_info/faction/unathi/sol
 	name = FACTION_UNATHI_SOL
 	description = "Many Unathi took full advantage of their incorporation into the SCG. Living among humanity has been safer and easier than life on Moghes \
 	for the most part, though at times you face disdain from humans and unathi alike. Still, you are treated more fairly in human society than ever before, and now you \
 	can have a real impact."
 	economic_power = 1.1
+
 /decl/cultural_info/faction/unathi/independent
 	name = FACTION_UNATHI_INDEPENDENT
 	description = "Perhaps you were exiled, or perhaps you were one of the unlucky ones who never had a clan. Perhaps you simply value yourself more than your family. \

--- a/code/modules/culture_descriptor/religion/religions_unathi.dm
+++ b/code/modules/culture_descriptor/religion/religions_unathi.dm
@@ -37,6 +37,7 @@
 	description = "In order to ensure the normal functioning of natural and societal life, Unathi seek patronage with the powerful spirits of the \
 	past, especially with those of their own kin, whom the call the Ancestors - the ranks of which every unathi is bound to join at some point. \
 	The worship of the Ancestors is almost universal, and serves as the basis for other spiritual movements of Moghes."
+
 /decl/cultural_info/religion/unathi_others
 	name = RELIGION_UNATHI_OTHER
 	description = "It's very unusual for an Unathi not to worship the ancestors. Perhaps you're some crazed rebel who rejects all of society, \

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -10,10 +10,9 @@
 	id = "awaysite_voxship"
 	description = "Vox ship."
 	suffixes = list("voxship/voxship-1.dmm")
-	cost = 0//From 0.5
+	cost = 0.5
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_shuttle)
 	area_usage_test_exempted_root_areas = list(/area/voxship)
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 
 /obj/effect/overmap/visitable/ship/voxship

--- a/maps/torch/items/clothing/boh_clothing.dm
+++ b/maps/torch/items/clothing/boh_clothing.dm
@@ -84,15 +84,15 @@
 /obj/item/weapon/rig/military/infantry
 	name = "heavy suit control module"
 	desc = "A heavy, incredibly sleek suit of military grade armor. \
-	The minor ablative coating and composite armor makes it seem incredibly sturdy."
+	The ablative coating and composite armor makes it seem incredibly sturdy."
 	req_access = list(access_infantry)
 	suit_type = "military hardsuit"
 	icon_state = "military_rig"
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
 		bullet = ARMOR_BALLISTIC_RIFLE,
-		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_SMALL,
+		laser = ARMOR_LASER_MAJOR,
+		energy = ARMOR_ENERGY_RESISTANT,
 		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED


### PR DESCRIPTION
- - -
Originally, I had disabled MS aboard the Ascent ships due to them being unfinished and unworthy of filling a niche that didn't need to be filled.
A now departed maintainer re-enabled them without consultation in a speed merged PR.
Because players have taken a liking to them(I think?), I've gone ahead and made them actually unscuffed. Said maintainer rushed this one through, so you can imagine my frustration.

For now, the MSQ and her workers use the same naming convention and system, nearly one-to-one as a copy, from the Gyne. Someone else can fix this, because I certainly don't have the patience when it comes to this.
- - -
Balance:
 - Vox no longer guaranteed.
 - MS and MSQ require the MSQ and Gyne to spawn, respectively.
 - Removes full destruction from the Recoilless Rifle (TVP-2/3)
 - Birdshot should now reliably embed, unlike prior. Even though this shouldn't need the var, apparently it does? Wacky stuff, man.
 - Infantry hardsuits received a buff to bring it in line with contemporaries.
- - -
Bugfixes:
 - Spacing for new Unathi factions and religions fixed. Probably.
 - Hopefully fixes Unathi faction and religions sharing identical tags to other stuff?
 - Removes invalid access on Quill rig.
- - -