### PR TITLE
Purchasable KOSMAG Slugs

### DIFF
--- a/code/datums/supplypacks/munitions.dm
+++ b/code/datums/supplypacks/munitions.dm
@@ -1,12 +1,12 @@
 
-//The weapons that fire this charge aren't functional and they don't have any other use, so there's no reason for them to be accessible until that changes. - ITR//
 
 
-///decl/hierarchy/supply_pack/munition
-//	name = "Ship Munitions"
-//	containertype = /obj/structure/largecrate
-//	containername = "mass driver munition crate"
+/decl/hierarchy/supply_pack/munition
+	name = "Ship Munitions"
+	containertype = /obj/structure/largecrate
+	containername = "mass driver munition crate"
 
+//
 ///decl/hierarchy/supply_pack/munition/md_slug
 //	name = "Ammo - Mass Driver Slug"
 //	contains = list(/obj/structure/ship_munition/md_slug)
@@ -16,8 +16,6 @@
 //	name = "Ammo - Armor Piercing Mass Driver Slug"
 //	contains = list(/obj/structure/ship_munition/ap_slug)
 //	cost = 60
-
-//Back to business!
 
 /decl/hierarchy/supply_pack/munition/fire
 	name = "OFD Charge - FR1-ENFER (Incendiary)"

--- a/code/datums/supplypacks/munitions.dm
+++ b/code/datums/supplypacks/munitions.dm
@@ -1,39 +1,50 @@
-/decl/hierarchy/supply_pack/munition
-	name = "Ship Munitions"
-	containertype = /obj/structure/largecrate
-	containername = "mass driver munition crate"
 
-/decl/hierarchy/supply_pack/munition/md_slug
-	name = "Ammo - Mass Driver Slug"
-	contains = list(/obj/structure/ship_munition/md_slug)
-	cost = 50
+//The weapons that fire this charge aren't functional and they don't have any other use, so there's no reason for them to be accessible until that changes. - ITR//
 
-/decl/hierarchy/supply_pack/munition/ap_slug
-	name = "Ammo - Armor Piercing Mass Driver Slug"
-	contains = list(/obj/structure/ship_munition/ap_slug)
-	cost = 60
+
+///decl/hierarchy/supply_pack/munition
+//	name = "Ship Munitions"
+//	containertype = /obj/structure/largecrate
+//	containername = "mass driver munition crate"
+
+///decl/hierarchy/supply_pack/munition/md_slug
+//	name = "Ammo - Mass Driver Slug"
+//	contains = list(/obj/structure/ship_munition/md_slug)
+//	cost = 50
+
+///decl/hierarchy/supply_pack/munition/ap_slug
+//	name = "Ammo - Armor Piercing Mass Driver Slug"
+//	contains = list(/obj/structure/ship_munition/ap_slug)
+//	cost = 60
+
+//Back to business!
 
 /decl/hierarchy/supply_pack/munition/fire
-	name = "Ammo - disperser-FR1-ENFER charge"
+	name = "OFD Charge - FR1-ENFER (Incendiary)"
 	contains = list(/obj/structure/ship_munition/disperser_charge/fire)
 	cost = 40
 
 /decl/hierarchy/supply_pack/munition/emp
-	name = "Ammo - disperser-EM2-QUASAR charge"
+	name = "OFD Charge - EM2-QUASAR (Electromagnetic)"
 	contains = list(/obj/structure/ship_munition/disperser_charge/emp)
 	cost = 40
 
 /decl/hierarchy/supply_pack/munition/mining
-	name = "Ammo - disperser-MN3-BERGBAU charge"
+	name = "OFD Charge MN3-BERGBAU (Mining)"
 	contains = list(/obj/structure/ship_munition/disperser_charge/mining)
 	cost = 40
 
 /decl/hierarchy/supply_pack/munition/explosive
-	name = "Ammo - disperser-XP4-INDARRA charge"
+	name = "OFD Charge XP4-INDARRA (Explosive)"
 	contains = list(/obj/structure/ship_munition/disperser_charge/explosive)
 	cost = 40
 
+/decl/hierarchy/supply_pack/munition/shiptoship
+	name = "OFD Charge - N8-KOSMAG slug (Anti-Ship Warhead)"
+	contains = list(/obj/structure/ship_munition/disperser_charge/s2s)
+	cost = 40
+
 /decl/hierarchy/supply_pack/munition/odst
-	name = "Ammo - Droppod"
+	name = "OFD-Launched Drop Pod"
 	contains = list(/obj/structure/closet/odst)
 	cost = 30


### PR DESCRIPTION
Hallo,

Spotted someone mention as a ghost that you can't purchase KOSMAG slugs, and I'm fairly sure that's just because they weren't added to the supply menu when they were implemented. This change makes them purchasable at the same cost as any other slug, as well as makes the name of the supply packs they come in a little nicer to read and comments out (NOT deletes) the ability to order ammunition for ship weapons that physically exist on the Dagon but can't be fired due to true Ship to Ship combat not being implemented.

Should be an inoffensive enough change! :)

