### PR TITLE
Balance Adjustments, Boogaloo

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -327,7 +327,7 @@ proc/blood_splatter(var/target,var/datum/reagent/blood/source,var/large,var/spra
 	if(chem_effects[CE_OXYGENATED] == 1) // Dexalin.
 		oxygenated_mult = 0.5
 	else if(chem_effects[CE_OXYGENATED] >= 2) // Dexplus.
-		oxygenated_mult = 0.7
+		oxygenated_mult = 0.8
 	blood_volume_mod = blood_volume_mod + oxygenated_mult - (blood_volume_mod * oxygenated_mult)
 	blood_volume = blood_volume * blood_volume_mod
 	return min(blood_volume, 100)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -138,12 +138,11 @@
 
 /datum/reagent/dexalinp
 	name = "Dexalin Plus"
-	description = "Dexalin Plus is used in the treatment of oxygen deprivation in extremely short bursts. It is highly effective."
+	description = "Dexalin Plus is used in the treatment of oxygen deprivation. It is highly effective."
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#0040ff"
 	overdose = REAGENTS_OVERDOSE * 0.5
-	metabolism = REM * 3
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
 	value = 3.7
@@ -153,7 +152,6 @@
 		M.adjustToxLoss(removed * 9)
 	else if(alien != IS_DIONA)
 		M.add_chemical_effect(CE_OXYGENATED, 2)
-		M.adjustOxyLoss(-5)
 	holder.remove_reagent(/datum/reagent/lexorin, 3 * removed)
 
 /datum/reagent/tricordrazine

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -215,6 +215,7 @@
 	name = "Tricordrazine"
 	result = /datum/reagent/tricordrazine
 	required_reagents = list(/datum/reagent/inaprovaline = 1, /datum/reagent/dylovene = 1)
+	catalysts = list(/datum/reagent/toxin/phoron = 5)
 	result_amount = 2
 
 /datum/chemical_reaction/alkysine
@@ -242,6 +243,7 @@
 	name = "Dexalin Plus"
 	result = /datum/reagent/dexalinp
 	required_reagents = list(/datum/reagent/dexalin = 1, /datum/reagent/carbon = 1, /datum/reagent/iron = 1)
+	catalysts = list(/datum/reagent/toxin/phoron = 5)
 	result_amount = 3
 
 /datum/chemical_reaction/bicaridine

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -3197,6 +3197,12 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/exploration_shuttle/power)
+"fv" = (
+/obj/machinery/door/window/eastleft,
+/obj/structure/window/reinforced,
+/obj/machinery/artifact,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/isolation)
 "fw" = (
 /obj/structure/catwalk,
 /obj/structure/cable/cyan{
@@ -3770,6 +3776,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"gB" = (
+/obj/machinery/door/window/eastright,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/machinery/artifact,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/isolation)
 "gC" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -49452,8 +49467,8 @@ Wl
 Wl
 sD
 Wl
-sy
-cX
+fv
+gB
 fF
 fF
 aa

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -3594,6 +3594,7 @@
 	},
 /obj/prefab/hand_teleporter,
 /obj/item/integrated_circuit/manipulation/bluespace_rift,
+/obj/item/weapon/card/id/captains_spare,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "fW" = (


### PR DESCRIPTION
- - -
Balance:
 - DexPlus returned to its previous state. As it was post-change, the medicine became borderline broken for obvious reasons. It was fun at first, but it's wacky otherwise.
 - DexPlus given a requirement of a five unit phoron catalyst.
 - Tricord given the requirement of a five unit phoron catalyst. Most people sleep on this chem, but it's genuinely deserving of this.
 - Captain's spare returned to the office.
 - Roundstart artefacts returned to the Polyp.
- - -