### PR TITLE
Adds Tasers to Security's Kit Options

### DIFF
--- a/code/modules/boh_misc/boxes.dm
+++ b/code/modules/boh_misc/boxes.dm
@@ -62,6 +62,7 @@
 	options["Ballistic - Military Revolver"] = list(/obj/item/weapon/gun/projectile/revolver/medium/sec/pepper,/obj/item/ammo_magazine/speedloader/rubber)
 //	options["Energy - Smartgun"] = list(/obj/item/weapon/gun/energy/gun/secure)
 //	options["Energy - Stun Revolver"] = list(/obj/item/weapon/gun/energy/stunrevolver/secure)
+	options["Stun - Non-Lethal Taser"] = list(/obj/item/weapon/gun/energy/taser)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)
 		var/list/things_to_spawn = options[choice]

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -83,6 +83,7 @@
 		/obj/item/device/megaphone,
 		/obj/item/weapon/melee/baton/loaded,
 		/obj/item/weapon/gun/projectile/pistol/magnum_pistol/solar/loaded,
+		/obj/item/weapon/gun/energy/taser,
 		/obj/item/weapon/melee/telebaton,
 		/obj/item/weapon/reagent_containers/spray/pepper,
 		/obj/item/clothing/accessory/storage/black_vest,


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
A simple addition after asking over on the Discord's suggestions page. This PR aims to add non-lethal, low capacity tasers as an option for security's equipment kits and provides the COS one with their 15mm magnum.

The reason I think this is necessary is that at the moment, security has painfully bad non-lethal options at a range. Weapons like rubbers and beanbag shotguns still land people in the medbay more often than not. Infantry of all departments has tasers and are more effective at taking people down non-lethally than security because of that.

To avoid complaints about security having lasers, these tasers are strictly non-lethal. They only have stun and shock settings with no way to be set to lethal. Smartguns aren't going to be made irrelevant because of this.

:cl:
tweak: Security's equipment kits now have a non-lethal taser as an option. The Chief of Security's locker also spawns with one due to them not having kits.
/:cl: