### PR TITLE
Tricord | Dex Revert

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -138,7 +138,7 @@
 
 /datum/reagent/dexalinp
 	name = "Dexalin Plus"
-	description = "Dexalin Plus is used in the treatment of oxygen deprivation. It is highly effective."
+	description = "Dexalin Plus is used in the treatment of extreme oxygen deprivation."
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#0040ff"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -215,7 +215,6 @@
 	name = "Tricordrazine"
 	result = /datum/reagent/tricordrazine
 	required_reagents = list(/datum/reagent/inaprovaline = 1, /datum/reagent/dylovene = 1)
-	catalysts = list(/datum/reagent/toxin/phoron = 5)
 	result_amount = 2
 
 /datum/chemical_reaction/alkysine
@@ -243,7 +242,6 @@
 	name = "Dexalin Plus"
 	result = /datum/reagent/dexalinp
 	required_reagents = list(/datum/reagent/dexalin = 1, /datum/reagent/carbon = 1, /datum/reagent/iron = 1)
-	catalysts = list(/datum/reagent/toxin/phoron = 5)
 	result_amount = 3
 
 /datum/chemical_reaction/bicaridine


### PR DESCRIPTION
- - -
Balance:
 - Returns Tricord to the state it was prior, not requiring a catalyst. This means you can once again body-mix, to the detriment of a patient.
 - Returns DexPlus to the state it was prior, not requiring a catalyst.
- - -