### PR TITLE
Tricord Tweak

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -166,7 +166,7 @@
 
 /datum/reagent/tricordrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(3 * removed, 3 * removed)
+		M.heal_organ_damage(1.5 * removed, 1.5 * removed)
 
 /datum/reagent/cryoxadone
 	name = "Cryoxadone"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -217,6 +217,7 @@
 	required_reagents = list(/datum/reagent/inaprovaline = 1, /datum/reagent/dylovene = 1)
 	minimum_temperature = 50 CELSIUS
 	maximum_temperature = 100 CELSIUS
+	mix_message = "The solution bubbles and swirls, giving off a distinctive purple vapour."
 	result_amount = 2
 
 /datum/chemical_reaction/alkysine

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -215,6 +215,8 @@
 	name = "Tricordrazine"
 	result = /datum/reagent/tricordrazine
 	required_reagents = list(/datum/reagent/inaprovaline = 1, /datum/reagent/dylovene = 1)
+	minimum_temperature = 50 CELSIUS
+	maximum_temperature = 100 CELSIUS
 	result_amount = 2
 
 /datum/chemical_reaction/alkysine

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -215,7 +215,6 @@
 	name = "Tricordrazine"
 	result = /datum/reagent/tricordrazine
 	required_reagents = list(/datum/reagent/inaprovaline = 1, /datum/reagent/dylovene = 1)
-	catalysts = list(/datum/reagent/toxin/phoron = 5)
 	result_amount = 2
 
 /datum/chemical_reaction/alkysine


### PR DESCRIPTION
Hi hi,

As discussed in VC, this change removes the requirement for a phoron catalyst when mixing tricord, halves its effectiveness in overall healing and prevents it from mixing inside a body by requiring a temperature between 50 and 100 Celsius. 

I didn't see an easy way to just prevent Inaprov and Dylo from combining if and only if they're in a body, but the temperature requirement does the same thing!
