### PR TITLE
fixes sauna shutters being sorta-open

### DIFF
--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -3954,7 +3954,8 @@
 	density = 0;
 	icon_state = "shutter0";
 	id_tag = "saunashutters";
-	name = "privacy shutters"
+	name = "privacy shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/head/sauna)
@@ -4360,7 +4361,8 @@
 	density = 0;
 	icon_state = "shutter0";
 	id_tag = "saunashutters";
-	name = "privacy shutters"
+	name = "privacy shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/head/sauna)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Previously sauna shutters started open, but obscuring view. This was pretty confusing, Sauna has like 3 seperate ways to obscure vision with the windows and that did not help. a bug in any case.