### PR TITLE
Various changes to traders and the merchant

### DIFF
--- a/code/datums/trading/food.dm
+++ b/code/datums/trading/food.dm
@@ -1,93 +1,3 @@
-/datum/trader/ship/pizzaria
-	name = "Pizza Shop Employee"
-	name_language = TRADER_DEFAULT_NAME
-	origin = "Pizzeria"
-	possible_origins = list("Papa Joe's", "Pizza Ship", "Dominator Pizza", "Little Kaezars", "Pizza Planet", "Cheese Louise", "Little Taste o' Neo-Italy", "Pizza Gestapo")
-	trade_flags = TRADER_MONEY
-	possible_wanted_items = list() //They are a pizza shop, not a bargainer.
-	possible_trading_items = list(/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza   = TRADER_SUBTYPES_ONLY)
-
-	speech = list("hail_generic"    = "Hello! Welcome to ORIGIN, may I take your order?",
-				"hail_deny"         = "Beeeep... I'm sorry, your connection has been severed.",
-
-				"trade_complete"    = "Thank you for choosing ORIGIN!",
-				"trade_no_goods"    = "I'm sorry but we only take cash.",
-				"trade_blacklisted" = "Sir that's... highly illegal.",
-				"trade_not_enough"  = "Uhh... that's not enough money for pizza.",
-				"how_much"          = "That pizza will cost you VALUE CURRENCY.",
-
-				"compliment_deny"   = "That's a bit forward, don't you think?",
-				"compliment_accept" = "Thanks, sir! You're very nice!",
-				"insult_good"       = "Please stop that, sir.",
-				"insult_bad"        = "Sir, just because I'm contractually obligated to keep you on the line for a minute doesn't mean I have to take this.",
-
-				"bribe_refusal"     = "Uh... thanks for the cash, sir. As long as you're in the area, we'll be here...",
-				)
-
-/datum/trader/pizzaria/trade(var/list/offers, var/num, var/turf/location)
-	. = ..()
-	if(.)
-		var/atom/movable/M = .
-		var/obj/item/pizzabox/box = new(location)
-		M.forceMove(box)
-		box.pizza = M
-		box.boxtag = "A special order from [origin]"
-
-/datum/trader/ship/chinese
-	name = "Chinese Restaurant"
-	name_language = TRADER_DEFAULT_NAME
-	origin = "Captain Panda Bistro"
-	possible_origins = list("888 Shanghai Kitchen", "Mr. Lee's Greater Hong Kong", "The House of the Venerable and Inscrutable Colonel", "Lucky Dragon")
-	trade_flags = TRADER_MONEY
-	possible_wanted_items = list()
-	possible_trading_items = list(/obj/item/weapon/reagent_containers/food/snacks/meatkabob    	       = TRADER_THIS_TYPE,
-							/obj/item/weapon/reagent_containers/food/snacks/ricepudding                = TRADER_THIS_TYPE,
-							/obj/item/weapon/reagent_containers/food/snacks/slice/xenomeatbread/filled = TRADER_THIS_TYPE,
-							/obj/item/weapon/reagent_containers/food/snacks/soydope                    = TRADER_THIS_TYPE,
-							/obj/item/weapon/reagent_containers/food/snacks/stewedsoymeat              = TRADER_THIS_TYPE,
-							/obj/item/weapon/reagent_containers/food/snacks/wingfangchu                = TRADER_THIS_TYPE,
-							/obj/item/weapon/reagent_containers/food/drinks/dry_ramen                  = TRADER_THIS_TYPE
-							)
-
-	var/list/fortunes = list("Today it's up to you to create the peacefulness you long for.",
-							"If you refuse to accept anything but the best, you very often get it.",
-							"A smile is your passport into the hearts of others.",
-							"Hard work pays off in the future, laziness pays off now.",
-							"Change can hurt, but it leads a path to something better.",
-							"Hidden in a valley beside an open stream- This will be the type of place where you will find your dream.",
-							"Never give up. You're not a failure if you don't give up.",
-							"Love can last a lifetime, if you want it to.",
-							"The love of your life is stepping into your planet this summer.",
-							"Your ability for accomplishment will follow with success.",
-							"Please help me, I'm trapped in a fortune cookie factory!")
-
-	speech = list("hail_generic"     = "There are two things constant in life, death and Chinese food. How may I help you?",
-				"hail_deny"          = "We do not take orders from rude customers.",
-
-				"trade_complete"     = "Thank you, sir, for your patronage.",
-				"trade_blacklist"    = "No, that is very odd. Why would you trade that away?",
-				"trade_no_goods"     = "I only accept money transfers.",
-				"trade_not_enough"   = "No, I am sorry, that is not possible. I need to make a living.",
-				"how_much"           = "I give you ITEM, for VALUE CURRENCY. No more, no less.",
-
-				"compliment_deny"    = "That was an odd thing to say. You are very odd.",
-				"compliment_accept"  = "Good philosophy, see good in bad, I like.",
-				"insult_good"        = "As a man said long ago, \"When anger rises, think of the consequences.\" Think on that.",
-				"insult_bad"         = "I do not need to take this from you.",
-
-				"bribe_refusal"     = "Hm... I'll think about it.",
-				"bribe_accept"      = "Oh yes! I think I'll stay a few more minutes, then.",
-				)
-
-/datum/trader/ship/chinese/trade(var/list/offers, var/num, var/turf/location)
-	. = ..()
-	if(.)
-		var/obj/item/weapon/reagent_containers/food/snacks/fortunecookie/cookie = new(location)
-		var/obj/item/weapon/paper/paper = new(cookie)
-		cookie.trash = paper
-		paper.SetName("Fortune")
-		paper.info = pick(fortunes)
-
 /datum/trader/ship/grocery
 	name = "Juicer"
 	name_language = TRADER_DEFAULT_NAME
@@ -148,6 +58,7 @@
 							/obj/item/weapon/reagent_containers/food/snacks/human                      = TRADER_BLACKLIST_ALL,
 							/obj/item/weapon/reagent_containers/food/snacks/sliceable/braincake        = TRADER_BLACKLIST,
 							/obj/item/weapon/reagent_containers/food/snacks/meat/human                 = TRADER_BLACKLIST,
+							/obj/item/weapon/reagent_containers/cooking_container					   = TRADER_SUBTYPES_ONLY,
 							/obj/item/weapon/reagent_containers/food/snacks/variable                   = TRADER_BLACKLIST_ALL
 								)
-								
+

--- a/code/datums/trading/goods.dm
+++ b/code/datums/trading/goods.dm
@@ -356,7 +356,7 @@ Sells devices, odds and ends, and medical stuff
 								  /obj/item/weapon/reagent_containers/glass/bottle/antitoxin = TRADER_THIS_TYPE,
 								  /obj/item/weapon/reagent_containers/glass/bottle/inaprovaline = TRADER_THIS_TYPE,
 								  /obj/item/bodybag/cryobag = TRADER_THIS_TYPE,
-								  /obj/item/weapon/reagent_containers/chem_disp_cartridge/dexalin/small = TRADER_THIS_TYPE,
+								  /obj/item/weapon/reagent_containers/chem_disp_cartridge = TRADER_SUBTYPES_ONLY,
 								  /obj/item/sign/medipolma = TRADER_THIS_TYPE
 								)
 

--- a/code/datums/trading/misc.dm
+++ b/code/datums/trading/misc.dm
@@ -75,7 +75,7 @@
 								/obj/item/device/dociler              = TRADER_THIS_TYPE,
 								/obj/structure/dogbed                 = TRADER_THIS_TYPE)
 
-/datum/trader/ship/prank_shop
+/datum/trader/prank_shop
 	name = "Prank Shop Owner"
 	name_language = LANGUAGE_ROOTLOCAL
 	origin = "Prank Shop"

--- a/code/datums/trading/weaponry.dm
+++ b/code/datums/trading/weaponry.dm
@@ -37,34 +37,6 @@
 								/obj/item/ammo_magazine/magnum/empty           = TRADER_BLACKLIST,
 								/obj/item/clothing/accessory/storage/holster        = TRADER_ALL)
 
-/datum/trader/ship/egunshop
-	name = "Energy Gun Shop Employee"
-	name_language = TRADER_DEFAULT_NAME
-	origin = "EGun Shop"
-	possible_origins = list("The Emperor's Lasgun Shop", "Future Guns", "Solar Army", "Kiefer's Dependable Electric Arms", "Olympus Kingsport")
-	speech = list("hail_generic"    = "Welcome to the future of warfare! ORIGIN, your one-stop shop for energy weaponry!",
-				"hail_deny"         = "I'm sorry, your communication channel has been blacklisted.",
-
-				"trade_complete"    = "Thank you, your purchase has been logged and you have automatically liked our Spacebook page.",
-				"trade_blacklist"   = "I'm sorry, is that a joke?",
-				"trade_no_goods"    = "We deal in cash.",
-				"trade_not_enough"  = "State of the art weaponry costs more than that.",
-				"how_much"          = "All our quality weapons are priceless, but I'd give that to you for VALUE.",
-
-				"compliment_deny"   = "If I was dumber I probably would have believed you.",
-				"compliment_accept" = "Yes, I am very smart.",
-				"insult_good"       = "Energy weapons are TWICE the gun kinetic guns are!",
-				"insult_bad"        = "That's... very mean. I won't think twice about blacklisting your channel, so stop."
-				)
-
-	possible_trading_items = list(/obj/item/weapon/gun/energy/taser                      = TRADER_THIS_TYPE,
-								/obj/item/weapon/cell                                    = TRADER_THIS_TYPE,
-								/obj/item/weapon/cell/crap                               = TRADER_THIS_TYPE,
-								/obj/item/weapon/cell/high                               = TRADER_THIS_TYPE,
-								/obj/item/weapon/cell/super                              = TRADER_THIS_TYPE,
-								/obj/item/weapon/cell/hyper                              = TRADER_THIS_TYPE,
-								/obj/item/clothing/accessory/storage/holster                     = TRADER_ALL)
-
 /datum/trader/dogan
 	name = "Dogan"
 	origin = "Dogan's Gun Beacon"

--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -9275,6 +9275,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/reagentgrinder,
 /turf/simulated/floor/wood,
 /area/merchant_station)
 "aQa" = (
@@ -11059,7 +11060,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/mob/living/exosuit/premade/powerloader,
 /turf/simulated/floor/tiled,
 /area/merchant_station)
 "aWJ" = (


### PR DESCRIPTION
Gitusername- Spummm
Ckey- Spum
Changes:
Removed pizza trader and Chinese food trader, made redundant by other food traders
Removed energy gun seller because they sell a taser and some batteries, letting them have real energy weapons would be irresponsible at the moment and this can be fixed later
Added a reagent grinder to the merchant station
Removed a duplicate powerloader from the merchant station
Added the ability for  medical trader to sell various reagent containers (rare, only can show up at roundstart, not guaranteed to sell any specific items)
Made the prank trader only able to show up at roundstart (letting every trader buy and sell full clown outfits every round is too powerful, also was a less dynamic trader i.e. had very specific items anyways, improves variety)
Made one of the grocery traders able to sell basic cooking equipment

![eeee](https://user-images.githubusercontent.com/76866579/155860088-cf3de96c-53f7-4f46-b1e6-805965a58424.PNG)

