### PR TITLE
Changes the revolver to make it more distinct from the pistol / less ass (mostly a buff)

### DIFF
--- a/code/modules/boh_misc/firearms.dm
+++ b/code/modules/boh_misc/firearms.dm
@@ -51,9 +51,11 @@
 	ammo_type = /obj/item/ammo_casing/pistol
 	fire_sound = 'sound/weapons/gunshot/revolver_small.ogg'
 	desc = "The Lumoco Arms' Mk12 is a rugged revolver for people who don't keep their guns well-maintained. Unlike its cousin, the Mk59 'Jhen Bothus', it has no issues with reliability."
-	accuracy = 1
+	accuracy = 2
 	bulk = 0
-	fire_delay = 9
+	fire_delay = 14
+	penetration_mod = 10
+	falloff_mod = -0.5
 
 /obj/item/weapon/gun/projectile/revolver/medium/sec/pepper
 	ammo_type = /obj/item/ammo_casing/pistol/rubber/pepperball

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -90,8 +90,10 @@
 	var/combustion
 	//damage multiplier. Multiplies damage. 0 does nothing, by the way. Higher means more damage, lower less.
 	var/damage_mult = 1
-	// Pen multiplier. Multiplies pen. 0 means no pen, higher means more pen, lower less.
-	var/penetration_mult = 1
+	// Pen multiplier. adds/subtracts pen. 0 means no pen, higher means more pen, lower less.
+	var/penetration_mod = 0
+	// Falloff modifier. less means less distance falloff, more means more.
+	var/falloff_mod = 0
 	// Does this firemode at full auto? Effectively an autoclicker. Set to true if yes. The gun will keep firing until empty when the mouse is held down.
 	var/automatic = FALSE
 	// Our base Acc_Mod. Higher levels means the gun has a higher accuracy modifier in the acc_mod calcs.
@@ -444,8 +446,8 @@
 /obj/item/weapon/gun/proc/process_projectile(obj/projectile, mob/user, atom/target, var/target_zone, var/params=null)
 	var/obj/item/projectile/P = projectile
 	P.damage *= damage_mult // Multiplies our projectiles damage.
-	P.armor_penetration *= penetration_mult // Multiplies the penetration of our projectile.
-
+	P.armor_penetration += penetration_mod // adds/subtracts from penetration of our projectile.
+	P.distance_falloff += falloff_mod // Adds/subtracts distance falloff of our projectile.
 	if(!istype(P))
 		return 0 //default behaviour only applies to true projectiles
 


### PR DESCRIPTION
This was made with the thought in mind that having only 6 bullets as opposed to 15 in its first clip and every spare ammo thing making it far inferior to the pistol.
How it's different:
+The revolver has +1 extra accuracy and -0.5 distance falloff, meaning it does slightly more damage at range and is more accurate at range (equivalent to your target being one tile closer)
+the revolver's shots have +10 armor penetration, meaning its shots have +10 armor penetration
-the revolver is WAYYY slower. 14 delay compared to the pistol's delay of 8 means you can spam the pistol way harder. 

Also changes the unused penetration multiplier to a modifier so that it works (better overall, really) as well as adds a damage falloff modifier.