### PR TITLE
swaps  bonus point of eva skill for fleet with sci skill

### DIFF
--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -180,7 +180,8 @@
 	assistant_job = /datum/job/crew
 	min_skill = list(	SKILL_HAULING = SKILL_BASIC,
 						SKILL_WEAPONS = SKILL_BASIC,
-						SKILL_EVA     = SKILL_ADEPT)
+						SKILL_SCIENCE = SKILL_BASIC,
+						SKILL_EVA     = SKILL_BASIC)
 
 /datum/mil_branch/army
 	name = "Army"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

I didn't want to do this, but there's a bug I'm not sure how would be best to fix (maybe some other time) where because these skills are applied first, a job that gives you a lower level of eva (e.g. most jobs) overrides the higher level eva, meaning the trained isn't applied to a lot of jobs. and even with that they had 1 point less worth of skills than marines. sci skill costs 2, so it evens it out, and it's a thing? can fix it later but here's an alternative to the fucky wucky behaviour for now.