### PR TITLE
Fixes a Skill Issue

### DIFF
--- a/code/modules/client/preference_setup/occupation/skill_selection.dm
+++ b/code/modules/client/preference_setup/occupation/skill_selection.dm
@@ -21,10 +21,14 @@
 		return allocated[req_skill] + get_min_skill(job, req_skill)
 
 /datum/preferences/proc/get_min_skill(datum/job/job, decl/hierarchy/skill/S)
-	if(job && job.min_skill)
-		. = job.min_skill[S.type]
+	var/datum/mil_branch/branch = mil_branches.get_branch(branches[job.title])
+	if(job && job.min_skill && branch && branch.min_skill) //hacky check, makes sure whatever skill is higher is applied. Sorry guys.
+		if(job.min_skill[S.type] < branch.min_skill[S.type])
+			. = branch.min_skill[S.type]
 	if(!.)
-		var/datum/mil_branch/branch = mil_branches.get_branch(branches[job.title])
+		if(job && job.min_skill)
+			. = job.min_skill[S.type]
+	if(!.)
 		if(branch && branch.min_skill)
 			. = branch.min_skill[S.type]
 	if(!.)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Previously if your job skills were lower than your branch skills but existed (e.g. paramedics got basic eva) you would get the lower job value instead of the higher branch value. On account of this being fucking stupid, this is changed. Now you get whatever skill value is higher.

![image](https://user-images.githubusercontent.com/18406892/155893226-9463a639-df66-48d9-8cbf-0e85e351fff4.png)
