### PR TITLE
Vox nerfs the big umpf

### DIFF
--- a/code/modules/projectiles/guns/energy/vox.dm
+++ b/code/modules/projectiles/guns/energy/vox.dm
@@ -29,6 +29,7 @@
 	projectile_type = /obj/item/projectile/beam/stun/darkmatter
 	one_hand_penalty = 2 //a little bulky
 	self_recharge = 1
+	recharge_time = 12
 	firemodes = list(
 		list(mode_name="stunning", burst=1, fire_delay=null, move_delay=null, burst_accuracy=list(30), dispersion=null, projectile_type=/obj/item/projectile/beam/stun/darkmatter, charge_cost = 15),
 		list(mode_name="focused", burst=1, fire_delay=null, move_delay=null, burst_accuracy=list(30), dispersion=null, projectile_type=/obj/item/projectile/beam/darkmatter, charge_cost = 25),

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -191,6 +191,18 @@
 	tracer_type = /obj/effect/projectile/laser/xray/tracer
 	impact_type = /obj/effect/projectile/laser/xray/impact
 
+/obj/item/projectile/beam/snipervox
+	name = "sniper beam"
+	icon_state = "xray"
+	fire_sound = 'sound/weapons/marauder.ogg'
+	distance_falloff = 0.50
+	damage = 50
+	armor_penetration = 50
+
+	muzzle_type = /obj/effect/projectile/laser/xray/muzzle
+	tracer_type = /obj/effect/projectile/laser/xray/tracer
+	impact_type = /obj/effect/projectile/laser/xray/impact
+
 /obj/item/projectile/beam/stun
 	name = "stun beam"
 	icon_state = "stun"

--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -1715,19 +1715,19 @@
 	dir = 6
 	},
 /obj/item/weapon/storage/bible/kojiki{
-	name = "The teaching of Chakala";
-	desc = "It contains a collection of knowledge passed down through generation. It has a symbol of a golden trinity of eyes on it.";
+	name = "Codex of Chakala";
+	desc = "The collection of knowledge from a long dead civilization, from science to culture. Three golden eyes are engraved on the cover of the tome.";
 	deity_name = "Chakala"
 	},
 /obj/item/weapon/storage/bible/tanakh{
 	deity_name = "Kihikihi";
-	name = "The wisdom of Kihikihi";
-	desc = "It tells tales about how Kihikihi protect their children from either this plane of reality or another. It is a symbol of a lone feather, glowing bright blue on it."
+	name = "Cloak of Kihikihi";
+	desc = "A collection of fables and helpful tips on stealth and survival, centered around a neither living-nor-dead Auralis. A single feather decorates the cover, a brilliant shimmering blue."
 	},
 /obj/item/weapon/storage/bible/aqdas{
 	deity_name = "Kritika";
-	name = "Kritika book of conquest";
-	desc = "It contains the wisdom on how to both be mightful in diplomatic as well as in military strength. It has a symbol of an outstretched claw, talons embossed over an open flame on it."
+	name = "Blade of Kritika";
+	desc = "The cover is decorated with an outstretched claw, talons embossed over an open flame. Inside, it contains the wisdom of how to employ both diplomatic and military strength, along with numerous tales of conquest and statecraft from a long dead Auralis."
 	},
 /turf/simulated/floor/carpet/purple,
 /area/voxship/hoard)

--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -751,7 +751,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/voxship/engineering)
 "bR" = (
-/obj/structure/ship_munition/disperser_charge/s2s,
+/obj/structure/ship_munition/disperser_charge/fire,
 /turf/simulated/floor/plating/vox,
 /area/voxship/ship_fore)
 "bS" = (
@@ -8717,7 +8717,7 @@
 /turf/simulated/floor/tiled/skrell/red,
 /area/voxship/med)
 "xo" = (
-/obj/structure/ship_munition/disperser_charge/s2s,
+/obj/structure/ship_munition/disperser_charge/emp,
 /turf/simulated/floor/plating/vox,
 /area/voxship/med)
 "yv" = (
@@ -8899,7 +8899,7 @@
 /area/voxship/engineering)
 "NO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/ship_munition/disperser_charge/s2s,
+/obj/structure/ship_munition/disperser_charge/fire,
 /turf/simulated/floor/plating/vox,
 /area/voxship/ship_fore)
 "NZ" = (
@@ -8995,12 +8995,12 @@
 /turf/simulated/floor/plating/vox,
 /area/voxship/engineering)
 "VC" = (
-/obj/structure/ship_munition/disperser_charge/s2s,
-/obj/structure/ship_munition/disperser_charge/s2s,
+/obj/structure/ship_munition/disperser_charge/fire,
 /turf/simulated/floor/plating/vox,
-/area/voxship/ship_fore)
+/area/voxship/med)
 "VX" = (
 /obj/machinery/light/small/red,
+/obj/structure/ship_munition/disperser_charge/fire,
 /turf/simulated/floor/plating/vox,
 /area/voxship/med)
 "Wd" = (
@@ -9008,10 +9008,10 @@
 /turf/simulated/floor/plating/vox,
 /area/voxship/med)
 "WE" = (
-/obj/structure/ship_munition/disperser_charge/s2s,
 /obj/machinery/light/small/red{
 	dir = 1
 	},
+/obj/structure/ship_munition/disperser_charge/emp,
 /turf/simulated/floor/plating/vox,
 /area/voxship/med)
 "Xb" = (
@@ -24694,8 +24694,8 @@ rv
 qT
 fC
 xo
-xo
 rg
+VC
 tS
 sT
 tS
@@ -24896,7 +24896,7 @@ rp
 oH
 fC
 WE
-Wd
+rg
 VX
 tS
 aS
@@ -25681,7 +25681,7 @@ ae
 an
 ak
 uz
-aN
+av
 av
 as
 aW
@@ -25883,7 +25883,7 @@ ae
 an
 ak
 av
-aN
+av
 av
 as
 cS
@@ -26085,7 +26085,7 @@ ae
 an
 ak
 av
-dT
+bR
 dT
 as
 dR
@@ -26286,8 +26286,8 @@ ae
 ae
 an
 ak
-av
-dT
+bR
+bR
 dT
 cf
 dT
@@ -26489,7 +26489,7 @@ ae
 an
 ak
 bR
-dT
+bR
 dT
 hI
 cm
@@ -26690,9 +26690,9 @@ ae
 ae
 an
 ak
-LO
-dT
 NO
+bR
+ii
 cf
 cz
 bv
@@ -26893,8 +26893,8 @@ ae
 an
 ak
 LO
-dT
-NO
+aN
+ii
 nj
 ax
 bs
@@ -27095,8 +27095,8 @@ ae
 an
 ak
 RS
-bR
-bR
+aN
+aN
 as
 ck
 bs
@@ -27297,8 +27297,8 @@ ae
 an
 ak
 ak
-VC
-bR
+aN
+aN
 ba
 by
 bs

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -210,7 +210,7 @@
 /obj/item/weapon/gun/energy/sniperrifle/vox
 	desc = "This is a modified Hephaestus Industries Baleful, the cell have been replaced by a vox variant, making it able to self charge. It's a designated marksman rifle capable of shooting powerful ionized beams, this is a weapon to kill from a distance."
 	self_recharge = 1
-	recharge_time = 60
+	recharge_time = 80
 	max_shots = 2
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -208,10 +208,10 @@
 	recharge_time = 20
 
 /obj/item/weapon/gun/energy/sniperrifle/vox
-	desc = "This is a modified Hephaestus Industries Baleful, the cell have been replaced by a vox variant, making it able to self charge. It's a designated marksman rifle capable of shooting powerful ionized beams, this is a weapon to kill from a distance."
+	desc = "This is a modified Hephaestus Industries Baleful, the cell have been replaced by a vox variant, making it able to self charge. Sadly, this makes it loose it's function to knock people out. It's a designated marksman rifle capable of shooting powerful ionized beams, this is a weapon to kill from a distance."
 	self_recharge = 1
-	recharge_time = 80
-	max_shots = 2
+	recharge_time = 60
+	projectile_type = /obj/item/projectile/beam/snipervox
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew
 	name = "Shard Acolyte"

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -208,7 +208,7 @@
 	recharge_time = 20
 
 /obj/item/weapon/gun/energy/sniperrifle/vox
-	desc = "This is a modified Hephaestus Industries Baleful, the cell have been replaced by a vox variant, making it able to self charge. It's a designated marksman rifle capable of shooting powerful ionized beams, this is a weapon to kill from a distance."
+	desc = "This is a modified Hephaestus Industries Baleful. The cell has been replaced by a vox variant, allowing it to self-charge. Sadly, this makes it lose its function to knock people out. It's a designated marksman rifle capable of shooting powerful ionized beams, this is a weapon to kill from a distance."
 	self_recharge = 1
 	recharge_time = 60
 	max_shots = 2

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -208,10 +208,10 @@
 	recharge_time = 20
 
 /obj/item/weapon/gun/energy/sniperrifle/vox
-	desc = "This is a modified Hephaestus Industries Baleful, the cell have been replaced by a vox variant, making it able to self charge. It's a designated marksman rifle capable of shooting powerful ionized beams, this is a weapon to kill from a distance."
+	desc = "This is a modified Hephaestus Industries Baleful, the cell have been replaced by a vox variant, making it able to self charge. Sadly, this makes it loose it's function to knock people out. It's a designated marksman rifle capable of shooting powerful ionized beams, this is a weapon to kill from a distance."
 	self_recharge = 1
 	recharge_time = 60
-	max_shots = 2
+	projectile_type = /obj/item/projectile/beam/snipervox
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew
 	name = "Shard Acolyte"

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -210,7 +210,7 @@
 /obj/item/weapon/gun/energy/sniperrifle/vox
 	desc = "This is a modified Hephaestus Industries Baleful, the cell have been replaced by a vox variant, making it able to self charge. It's a designated marksman rifle capable of shooting powerful ionized beams, this is a weapon to kill from a distance."
 	self_recharge = 1
-	recharge_time = 80
+	recharge_time = 60
 	max_shots = 2
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -211,7 +211,7 @@
 	desc = "This is a modified Hephaestus Industries Baleful, the cell have been replaced by a vox variant, making it able to self charge. It's a designated marksman rifle capable of shooting powerful ionized beams, this is a weapon to kill from a distance."
 	self_recharge = 1
 	recharge_time = 60
-	max_shots = 3
+	max_shots = 2
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew
 	name = "Shard Acolyte"

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -208,7 +208,7 @@
 	recharge_time = 20
 
 /obj/item/weapon/gun/energy/sniperrifle/vox
-	desc = "This is a modified Hephaestus Industries Baleful, the cell have been replaced by a vox variant, making it able to self charge. Sadly, this makes it loose it's function to knock people out. It's a designated marksman rifle capable of shooting powerful ionized beams, this is a weapon to kill from a distance."
+	desc = "This is a modified Hephaestus Industries Baleful. The cell has been replaced by a vox variant, allowing it to self-charge. Sadly, this makes it lose its function to knock people out. It's a designated marksman rifle capable of shooting powerful ionized beams, this is a weapon to kill from a distance."
 	self_recharge = 1
 	recharge_time = 60
 	projectile_type = /obj/item/projectile/beam/snipervox

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -208,7 +208,7 @@
 	recharge_time = 20
 
 /obj/item/weapon/gun/energy/sniperrifle/vox
-	desc = "This is a modified Hephaestus Industries Baleful. The cell has been replaced by a vox variant, allowing it to self-charge. Sadly, this makes it lose its function to knock people out. It's a designated marksman rifle capable of shooting powerful ionized beams, this is a weapon to kill from a distance."
+	desc = "This is a modified Hephaestus Industries Baleful. The cell has been replaced by a vox variant, allowing it to self-charge. Sadly, this makes it lose its function to knock people out. It's a designated marksman rifle capable of shooting powerful ionized beams."
 	self_recharge = 1
 	recharge_time = 60
 	projectile_type = /obj/item/projectile/beam/snipervox

--- a/maps/away/voxship/voxship_jobs_boh.dm
+++ b/maps/away/voxship/voxship_jobs_boh.dm
@@ -1,6 +1,6 @@
 /datum/job/submap/voxship_vox/armalis
 	title = "Shard Martinet"
-	total_positions = 2
+	total_positions = 1
 	outfit_type = /decl/hierarchy/outfit/job/voxship/crew
 	supervisors = "apex and the arkship"
 	info = "Loyal to your Quill-Captain, you enforce the will of the ark admirals; while you may be away from the main fleets, the crew must not forget they are subservient to the will of the Archon. \


### PR DESCRIPTION
Vox nerfs: Kosmag removed, Armalis changed to one, and the sniper rifle nerfed so that it **cannot** stun anymore while giving it back its original ammo.
Nerfed the dark matter gun, to charge a focused shot, every 12 seconds.
These changes were talked about with AntonKR before they were made.
Final confirmation from Carl would be good.
Let's see how this goes.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->