### PR TITLE
Reverts the Charge Boost to Vox Flux Cannon

### DIFF
--- a/code/modules/projectiles/guns/energy/vox.dm
+++ b/code/modules/projectiles/guns/energy/vox.dm
@@ -30,9 +30,9 @@
 	one_hand_penalty = 2 //a little bulky
 	self_recharge = 1
 	firemodes = list(
-		list(mode_name="stunning", burst=1, fire_delay=null, move_delay=null, burst_accuracy=list(30), dispersion=null, projectile_type=/obj/item/projectile/beam/stun/darkmatter, charge_cost = 15),
-		list(mode_name="focused", burst=1, fire_delay=null, move_delay=null, burst_accuracy=list(30), dispersion=null, projectile_type=/obj/item/projectile/beam/darkmatter, charge_cost = 25),
-		list(mode_name="scatter burst", burst=8, fire_delay=null, move_delay=null, burst_accuracy=list(0, 0, 0, 0, 0, 0, 0, 0), dispersion=list(0, 1, 2, 2, 3, 3, 3, 3, 3), projectile_type=/obj/item/projectile/energy/darkmatter, charge_cost = 7.5),
+		list(mode_name="stunning", burst=1, fire_delay=null, move_delay=null, burst_accuracy=list(30), dispersion=null, projectile_type=/obj/item/projectile/beam/stun/darkmatter, charge_cost = 50),
+		list(mode_name="focused", burst=1, fire_delay=null, move_delay=null, burst_accuracy=list(30), dispersion=null, projectile_type=/obj/item/projectile/beam/darkmatter, charge_cost = 75),
+		list(mode_name="scatter burst", burst=8, fire_delay=null, move_delay=null, burst_accuracy=list(0, 0, 0, 0, 0, 0, 0, 0), dispersion=list(0, 1, 2, 2, 3, 3, 3, 3, 3), projectile_type=/obj/item/projectile/energy/darkmatter, charge_cost = 10),
 		)
 
 /obj/item/weapon/gun/energy/darkmatter/Initialize()


### PR DESCRIPTION
After a recent round, it's clear that whoever made this change did not consider how recharging works.

The current issue with the Flux Cannon is that it's a weapon that fits in a satchel and has the power of a laser cannon in a mode that can be fired almost ever 3-5 seconds without needing to be charged. While yes, the original PR's intention was to increase how many shots it has, it also increased the rate at which it charges. It's a little less than optimal to have a gun that can be fired almost forever and instantly stop people's hearts.

Other than that, I think the Vox situation is fine. This was the only major meme.