### PR TITLE
Re-implements the removal of Bodyshielding.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -262,11 +262,13 @@
 		var/mob/M = A
 		if(istype(A, /mob/living))
 			//if they have a neck grab on someone, that person gets hit instead
+		/*
 			var/obj/item/grab/G = locate() in M
 			if(G && G.shield_assailant())
 				visible_message("<span class='danger'>\The [M] uses [G.affecting] as a shield!</span>")
 				if(Bump(G.affecting, forced=1))
 					return //If Bump() returns 0 (keep going) then we continue on to attack M.
+*/
 
 			passthrough = !attack_mob(M, distance)
 		else


### PR DESCRIPTION
Re-Implements Yawet's commenting-out of the body-shielding feature. 

Carl, I **know you're fond of Vox,** but this:

https://github.com/BoHBranch/BoH-Bay/pull/1277

Was really, **really** uncool. Vox Armalis have high hitpoints, high innate armour, 50 unarmed damage, higher regen, access to a broken as hell weapon that's being taken care of in a different PR and an **instant, inescapable max-strength grab,** as well as now apparently coming in fuckin' two packs with extra ablative chod in the form of regular vox, all also wearing combat suits.

It is **not right** that **atop all of that**, they can click on someone once and become **completely impervious to any amount of ranged damage from any direction.**

Antagonists exist to make the round interesting, not be ready, willing and able to chop through absolutely every armsman on the entire Dagon after **provoking a fight with them** and then cleave through an SDTF recon team **as well.**

People can "Skill Issue" it as much as they want, that shouldn't be **mechanically possible,** sheer attrition should have some kind of impact, it's **inarguable** that they're overtuned and this is a large part of why.

Yes, this will effect everyone else who tries to use a bodyshield. No, it's not right that ANYONE can become absolutely impervious to ranged attack of any type caliber or description from any direction indefinitely for as long as they have a redgrab, let alone something that's already a goddamn murder machine and can attain this by **clicking on someone once.**

I'm not even going to **start** on how an Armalis can eat **Eight Hundred and Fourty** damage to the tits and appear to be **absolutely fine** in this, that's gonna have to come later.