### PR TITLE
fixes 2 more maint doors

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -7064,8 +7064,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	autoset_access = 0;
+	req_access = list("ACCESS_MAINT")
+	},
 /turf/simulated/floor/plating,
 /area/rnd/anom_storage/gas)
 "alW" = (
@@ -8570,8 +8573,11 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	autoset_access = 0;
+	req_access = list("ACCESS_MAINT")
+	},
 /turf/simulated/floor/plating,
 /area/rnd/anom_storage/gas)
 "aoz" = (


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
These silly maint doors required the wrong access, blocking off half of d1 maint. this fixes it.
![image](https://user-images.githubusercontent.com/18406892/156013548-c019a04d-3b0c-4e54-8b06-4d15acc4ce33.png)
