### PR TITLE
fixes all the runtimes I can find

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -117,7 +117,8 @@
 /obj/machinery/door/window/brigdoor/southright{
 	dir = 8;
 	name = "Supply Desk";
-	req_access = list("ACCESS_CARGO")
+	req_access = list("ACCESS_CARGO");
+	autoset_access = 0
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/shutters{

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -3337,7 +3337,8 @@
 	},
 /obj/machinery/door/window/brigdoor/eastleft{
 	name = "Bar";
-	req_access = list("ACCESS_BAR")
+	req_access = list("ACCESS_BAR");
+	autoset_access = 0
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
@@ -14979,7 +14980,8 @@
 /area/maintenance/thirddeck/port)
 "BT" = (
 /obj/machinery/door/window/brigdoor/westleft{
-	req_access = list("ACCESS_ENGINE_EQUIP")
+	req_access = list("ACCESS_ENGINE_EQUIP");
+	autoset_access = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -241,7 +241,8 @@
 	},
 /obj/machinery/door/window/brigdoor/northleft{
 	name = "emergency core eject";
-	req_access = list("ACCESS_ENGINEERING")
+	req_access = list("ACCESS_ENGINEERING");
+	autoset_access = 0
 	},
 /obj/machinery/button/blast_door{
 	desc = "A remote switch to open the engine core vent to space.";
@@ -9029,7 +9030,8 @@
 /obj/machinery/door/window/brigdoor/southleft{
 	dir = 4;
 	name = "Monitoring Desk";
-	req_access = list("ACCESS_ENGINE_EQUIP")
+	req_access = list("ACCESS_ENGINE_EQUIP");
+	autoset_access = 0
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engineering_monitoring)

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -12361,7 +12361,8 @@
 /obj/machinery/door/window/brigdoor/westright{
 	dir = 8;
 	name = "CE's Equipment Storage";
-	req_access = list("ACCESS_CHIEF_ENGINEER")
+	req_access = list("ACCESS_CHIEF_ENGINEER");
+	autoset_access = 0
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/window/reinforced{

--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -34,14 +34,16 @@
 	dir = 1
 	},
 /obj/machinery/door/window/brigdoor/eastright{
-	req_access = list("ACCESS_MERCHANT")
+	req_access = list("ACCESS_MERCHANT");
+	autoset_access = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/merchant/home)
 "aah" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/eastright{
-	req_access = list("ACCESS_MERCHANT")
+	req_access = list("ACCESS_MERCHANT");
+	autoset_access = 0
 	},
 /obj/machinery/light,
 /obj/structure/closet/walllocker/emerglocker/south,
@@ -49,21 +51,24 @@
 /area/shuttle/merchant/home)
 "aai" = (
 /obj/machinery/door/window/brigdoor/northleft{
-	req_access = list("ACCESS_MERCHANT")
+	req_access = list("ACCESS_MERCHANT");
+	autoset_access = 0
 	},
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled,
 /area/shuttle/merchant/home)
 "aaj" = (
 /obj/machinery/door/window/brigdoor/northright{
-	req_access = list("ACCESS_MERCHANT")
+	req_access = list("ACCESS_MERCHANT");
+	autoset_access = 0
 	},
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled,
 /area/shuttle/merchant/home)
 "aak" = (
 /obj/machinery/door/window/brigdoor/northright{
-	req_access = list("ACCESS_MERCHANT")
+	req_access = list("ACCESS_MERCHANT");
+	autoset_access = 0
 	},
 /obj/structure/table/rack,
 /obj/machinery/light{


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
they're all caused by bloody windoors. I might've missed one, and if I did, I think it's on centcomm z, but that's all I really know.