### PR TITLE
Gives the midlaser (laser carbine laser) it's original AP value again

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -31,7 +31,7 @@
 
 /obj/item/projectile/beam/midlaser
 	damage = 40
-	armor_penetration = 15
+	armor_penetration = 20
 	distance_falloff = 1
 
 /obj/item/projectile/beam/heavylaser


### PR DESCRIPTION
When the nerf bat struck lasers the AP value of the midlaser was nerfed a bit too much by 5 AP. This PR gives the midlasers its original Hestia and Bay AP of 20. 