### PR TITLE
Removes Thermals from most offships

### DIFF
--- a/code/modules/ascent/ascent_rigs.dm
+++ b/code/modules/ascent/ascent_rigs.dm
@@ -34,7 +34,7 @@
 		SPECIES_MONARCH_QUEEN =  'icons/mob/species/nabber/msq/onmob_back_msq.dmi'
 		)
 	initial_modules = list(
-		/obj/item/rig_module/vision/thermal,
+		/obj/item/rig_module/vision/nvg,
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/electrowarfare_suite,
 		/obj/item/rig_module/chem_dispenser/mantid,
@@ -253,7 +253,7 @@
 	icon_override = 'icons/mob/species/mantid/onmob_back_gyne.dmi'
 	mantid_caste = SPECIES_MANTID_GYNE
 	initial_modules = list(
-		/obj/item/rig_module/vision/thermal,
+		/obj/item/rig_module/vision/nvg,
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/electrowarfare_suite,
 		/obj/item/rig_module/chem_dispenser/mantid,
@@ -277,7 +277,7 @@
 	chest_type = /obj/item/clothing/suit/space/rig/mantid/serpentid
 	boot_type =  null
 	initial_modules = list(
-		/obj/item/rig_module/vision/thermal,
+		/obj/item/rig_module/vision/nvg,
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/electrowarfare_suite,
 		/obj/item/rig_module/chem_dispenser/nabber,
@@ -308,7 +308,7 @@
 	icon_override = 'icons/mob/species/nabber/msq/onmob_back_msq.dmi'
 	mantid_caste = SPECIES_MONARCH_QUEEN
 	initial_modules = list(
-		/obj/item/rig_module/vision/thermal,
+		/obj/item/rig_module/vision/nvg,
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/electrowarfare_suite,
 		/obj/item/rig_module/chem_dispenser/nabber,

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -61,7 +61,7 @@
 		/obj/item/rig_module/datajack,
 		/obj/item/rig_module/electrowarfare_suite,
 		/obj/item/rig_module/voice,
-		/obj/item/rig_module/vision,
+		/obj/item/rig_module/vision/nvg,
 		/obj/item/rig_module/cooling_unit
 		)
 
@@ -169,6 +169,6 @@
 	req_access = list(access_syndicate)
 
 	initial_modules = list(
-		/obj/item/rig_module/vision,
+		/obj/item/rig_module/vision/nvg,
 		/obj/item/rig_module/cooling_unit
 		) //removed the stealth module because it lacks counterplay and shouldn't be readily available.

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -26,7 +26,7 @@
 
 	initial_modules = list(
 		/obj/item/rig_module/mounted/lcannon,
-		/obj/item/rig_module/vision/thermal,
+		/obj/item/rig_module/vision/nvg,
 		/obj/item/rig_module/grenade_launcher,
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/power_sink,

--- a/code/modules/clothing/spacesuits/rig/suits/vox.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vox.dm
@@ -52,7 +52,7 @@
 	cell_type =  /obj/item/weapon/cell/hyper
 
 	initial_modules = list(
-		/obj/item/rig_module/vision,
+		/obj/item/rig_module/vision/nvg,
 		/obj/item/rig_module/mounted/plasmacutter,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/power_sink,

--- a/code/modules/skrell/skrell_rigs.dm
+++ b/code/modules/skrell/skrell_rigs.dm
@@ -78,7 +78,7 @@
 		SPECIES_SKRELL = 'icons/boh/mob/species/skrell/onmob_back_rig_skrell.dmi'
 	)
 	initial_modules = list(
-		/obj/item/rig_module/vision,
+		/obj/item/rig_module/vision/nvg,
 		/obj/item/rig_module/chem_dispenser/skrell,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/clustertool/skrell,
@@ -101,7 +101,7 @@
 		rad = ARMOR_RAD_SHIELDED
 	)
 	initial_modules = list(
-		/obj/item/rig_module/vision,
+		/obj/item/rig_module/vision/nvg,
 		/obj/item/rig_module/chem_dispenser/skrell/combat,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/clustertool/skrell,
@@ -118,7 +118,7 @@
 	desc = "A highly sophisticated, cutting-edge medical hardsuit with an integrated power supply and atmosphere. It's impressive design is resistant yet extremely lightweight, perfectly tailoring itself to the user's body"
 	icon_state = "skrell_med_rig"
 	initial_modules = list(
-		/obj/item/rig_module/vision,
+		/obj/item/rig_module/vision/nvg,
 		/obj/item/rig_module/chem_dispenser/injector/skrell,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/clustertool/skrell,
@@ -142,7 +142,7 @@
 		rad = ARMOR_RAD_SHIELDED
 	)
 	initial_modules = list(
-		/obj/item/rig_module/vision,
+		/obj/item/rig_module/vision/nvg,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/clustertool/skrell,
 		/obj/item/rig_module/chem_dispenser/skrell/combat,
@@ -165,7 +165,7 @@
 		rad = ARMOR_RAD_SHIELDED
 	)
 	initial_modules = list(
-		/obj/item/rig_module/vision,
+		/obj/item/rig_module/vision/nvg,
 		/obj/item/rig_module/chem_dispenser/injector/skrell,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/clustertool/skrell,


### PR DESCRIPTION
DOES NOT AFFECT MERC, TRAITORS OR OTHER ANTAG-RELATED ROLES.

This PR removes thermals and replaces them to NVGS for:
- Skrell
- Vox
- Ascent

MERCs and TRAITORS can STILL BUY THERMALS from their uplink.