### PR TITLE
Makes FBP Charge relevant

### DIFF
--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -9,7 +9,7 @@
 	var/open
 	var/obj/item/weapon/cell/cell = /obj/item/weapon/cell/hyper
 	//at 0.8 completely depleted after 60ish minutes of constant walking or 130 minutes of standing still
-	var/servo_cost = 0.8
+	var/servo_cost = 1.2 //Buffed up. At 1.2 it's ~30 minutes without a charger.
 
 	min_broken_damage = 35//up from 15. Buffed because for some reason the damage used isn't consistent?
 	max_damage = 45//Simply 45 now.

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -56,7 +56,7 @@
 		return
 	var/cost = get_power_drain()
 	if(world.time - owner.l_move_time < 15)
-		cost *= 2
+		cost *= (2 + (damage / 10))
 	if(!checked_use(cost) && owner.isSynthetic())
 		if(!owner.lying && !owner.buckled)
 			to_chat(owner, "<span class='warning'>You don't have enough energy to function!</span>")

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -11,8 +11,8 @@
 	//at 0.8 completely depleted after 60ish minutes of constant walking or 130 minutes of standing still
 	var/servo_cost = 0.8
 
-	min_broken_damage = 15//up from 5
-	max_damage = 65//up from 45. Easily destroyed still.
+	min_broken_damage = 45//up from 15. Buffed because for some reason the damage used isn't consistent?
+	max_damage = 45//Simply 45 now.
 
 	relative_size = 70
 

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -11,7 +11,7 @@
 	//at 0.8 completely depleted after 60ish minutes of constant walking or 130 minutes of standing still
 	var/servo_cost = 0.8
 
-	min_broken_damage = 45//up from 15. Buffed because for some reason the damage used isn't consistent?
+	min_broken_damage = 35//up from 15. Buffed because for some reason the damage used isn't consistent?
 	max_damage = 45//Simply 45 now.
 
 	relative_size = 70

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -54,7 +54,7 @@
 		return
 	if(owner.stat == DEAD)	//not a drain anymore
 		return
-	var/cost = get_power_drain()
+	var/cost = (get_power_drain() + (damage / 10))
 	if(world.time - owner.l_move_time < 15)
 		cost *= (2 + (damage / 10))
 	if(!checked_use(cost) && owner.isSynthetic())


### PR DESCRIPTION
FBP/IPC charge crit is now based off of their actual charge, versus organ damage

For some reason, it was using the damage to determine if the organ was dead, which stopped it from discharging entirely.

Now, this was an issue, as the organ_broken for IPCs was 15, resulting in them getting the incorrect message + causing a balance hell.

This simply moves it to be based on their charge, so you don't get situations where they have 2000+ charge but are still in crit because they have had exactly 1 more damage to their micro than 15

This now also makes microbattery damage increase power usage (shorting mechanic), encouraging repairs lest ye collapse.

Open to suggestion.