### PR TITLE
Darkmatter Gun Nerf

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -314,9 +314,8 @@
 /obj/item/projectile/beam/darkmatter
 	name = "dark matter bolt"
 	icon_state = "darkb"
-	damage = 50
-	armor_penetration = 65
-	damage_flags = DAM_DISPERSED
+	damage = 35
+	armor_penetration = 45
 	muzzle_type = /obj/effect/projectile/darkmatter/muzzle
 	tracer_type = /obj/effect/projectile/darkmatter/tracer
 	impact_type = /obj/effect/projectile/darkmatter/impact
@@ -326,7 +325,7 @@
 	icon_state = "darkt"
 	damage_flags = 0
 	sharp = 0 //not a laser
-	agony = 50
+	agony = 25
 	damage_type = STUN
 	muzzle_type = /obj/effect/projectile/stun/darkmatter/muzzle
 	tracer_type = /obj/effect/projectile/stun/darkmatter/tracer

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -205,6 +205,6 @@
 	name = "dark matter pellet"
 	icon_state = "dark_pellet"
 	fire_sound = 'sound/weapons/eLuger.ogg'
-	damage = 35
-	armor_penetration = 35
+	damage = 25
+	armor_penetration = 15
 	damage_flags = DAM_DISPERSED


### PR DESCRIPTION
- - -
Balance:
 - Vox darkmatter firearm was overperforming significantly, given a bug with dispersed damage flags. This flag is no longer applied.
 - The damage for the darkmatter firearm been toned way back as a result of the above. Previously 50D/65AP, now 35D/45AP.
 - Vox scatter bolts dropped in power quite a bit. From 35D/35AP, now 25D/15AP.
 - Vox stun beams toned back quite a bit, from 50AD to 25AD.
- - -