### PR TITLE
Lets the rawl fake-dock with the d4 docking port

### DIFF
--- a/maps/away/rawl/rawl_shuttles.dm
+++ b/maps/away/rawl/rawl_shuttles.dm
@@ -44,8 +44,13 @@
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 
 /obj/effect/shuttle_landmark/rawl/torch
-	name = "SEV Torch IPV Rawl Fore Dock"
+	name = "SEV Torch IPV Rawl Fore Airlock"
 	landmark_tag = "nav_hangar_rawlship_torch"
+	movable_flags = MOVABLE_FLAG_EFFECTMOVE
+
+/obj/effect/shuttle_landmark/rawl/torchdock
+	name = "SEV Torch IPV Rawl Lower Fore Dock"
+	landmark_tag = "nav_hangar_rawlship_torchdock"
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 
 /obj/effect/shuttle_landmark/transit/rawl

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -14862,6 +14862,10 @@
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
+"NF" = (
+/obj/effect/shuttle_landmark/rawl/torchdock,
+/turf/space,
+/area/space)
 "NG" = (
 /obj/machinery/computer/modular/preset/civilian,
 /obj/machinery/alarm{
@@ -26618,7 +26622,7 @@ aa
 aa
 aa
 aa
-aa
+NF
 aa
 aa
 aa

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -60,6 +60,7 @@
 		"nav_deck1_calypso",
 		"nav_deck1_guppy",
 		"nav_deck1_aquila",
+		"nav_hangar_rawlship_torchdock",
 
 		//start Hanger Deck
 		"nav_merc_hanger",


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
I sort of forgot that airlock exists. I've spent a looong time trying to get docking ports to work before, and what little I know suggest to me that it won't be able to *actually* dock unless the ship *starts* docked somewhere, but at least having it be able to kiss the d4 airlock means it'll be less beans to use.