### PR TITLE
fix veteris suits

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -124,7 +124,7 @@
 	//Set species_restricted list
 	switch(target_species)
 		if(SPECIES_HUMAN,SPECIES_SKRELL)	//humanoid bodytypes
-			species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_IPC) //skrell/humans/machines can wear each other's suits
+			species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_IPC,SPECIES_OLDUNATHI) //skrell/humans/machines can wear each other's suits
 		else
 			species_restricted = list(target_species)
 
@@ -143,6 +143,8 @@
 			species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_IPC) //skrell helmets fit humans too
 		if(SPECIES_HUMAN)
 			species_restricted = list(SPECIES_HUMAN,SPECIES_IPC) //human helmets fit IPCs too
+		if(SPECIES_UNATHI)
+			species_restricted = list(SPECIES_UNATHI,SPECIES_OLDUNATHI)
 		else
 			species_restricted = list(target_species)
 

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -53,7 +53,7 @@
 	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	siemens_coefficient = 0.4
 
-	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_IPC)
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_IPC,SPECIES_OLDUNATHI)
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_suit_unathi.dmi',
 		SPECIES_SKRELL = 'icons/mob/species/skrell/onmob_suit_skrell.dmi',


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Veteris were supposed to be able to wear voidsuits with a human body and unathi helmet, but the guy who tried to do that was a silly man. This fixes it. Yes I tested it.