### PR TITLE
Turns Away Site's CI green

### DIFF
--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -344,6 +344,9 @@
 /obj/item/weapon/storage/backpack/dufflebag/syndie,
 /obj/item/weapon/storage/box/ammo/shotgunshells,
 /obj/item/weapon/handcuffs,
+/obj/item/device/radio/intercom{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood,
 /area/ship/scrap/command/captain)
 "aL" = (
@@ -522,15 +525,11 @@
 /turf/simulated/floor/tiled/dark/usedup,
 /area/ship/scrap/command/hallway)
 "ba" = (
-/obj/item/device/radio/intercom{
-	pixel_x = -32
-	},
 /obj/item/weapon/gun/projectile/shotgun/pump/combat{
 	desc = "When words don't strike hard enough.";
 	name = "Solid Argument"
 	},
-/obj/structure/window/reinforced/full,
-/obj/structure/table/marble,
+/obj/structure/displaycase,
 /turf/simulated/floor/wood,
 /area/ship/scrap/command/captain)
 "bb" = (
@@ -1451,11 +1450,6 @@
 /obj/machinery/computer/cryopod,
 /turf/simulated/wall,
 /area/ship/scrap/crew/cryo)
-"cE" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/shuttle/black,
-/area/ship/scrap/bearcat_shuttle)
 "cF" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -1956,7 +1950,7 @@
 /area/ship/scrap/crew/saloon)
 "dq" = (
 /obj/machinery/shipsensors,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/usedup,
 /area/ship/scrap/bearcat_shuttle)
 "dr" = (
 /obj/machinery/disposal,
@@ -2645,7 +2639,7 @@
 "ey" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
-/turf/space,
+/turf/simulated/floor/usedup,
 /area/ship/scrap/bearcat_shuttle)
 "ez" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -6100,13 +6094,6 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
 /area/ship/scrap/bearcat_shuttle)
-"ks" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1;
-	icon_state = "nozzle"
-	},
-/turf/simulated/floor/shuttle/black,
-/area/ship/scrap/bearcat_shuttle)
 "kt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -6237,14 +6224,14 @@
 	pressure_checks_default = 1;
 	use_power = 1
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/usedup,
 /area/ship/scrap/bearcat_shuttle)
 "kH" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1;
 	icon_state = "nozzle"
 	},
-/turf/space,
+/turf/simulated/floor/usedup,
 /area/ship/scrap/bearcat_shuttle)
 "kI" = (
 /obj/structure/disposalpipe/segment{
@@ -11773,8 +11760,8 @@ kR
 kR
 kR
 kR
-cE
-cE
+ey
+ey
 kf
 kp
 kf
@@ -11895,7 +11882,7 @@ kR
 kR
 kR
 kR
-cE
+ey
 hQ
 kl
 kB
@@ -12017,13 +12004,13 @@ kR
 kR
 kR
 kR
-cE
+ey
 kc
 kz
 dI
 iR
 ko
-ks
+kH
 kR
 kR
 kR
@@ -12139,13 +12126,13 @@ kR
 kR
 kR
 kR
-cE
+ey
 kd
 ki
 kk
 iR
 ko
-ks
+kH
 kR
 kR
 kR
@@ -12261,13 +12248,13 @@ kR
 kR
 kR
 kR
-cE
+ey
 ke
 ky
 dJ
 kj
 kD
-ks
+kH
 kR
 kR
 xU

--- a/maps/away/rawl/rawl.dmm
+++ b/maps/away/rawl/rawl.dmm
@@ -1216,8 +1216,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/rawl/cargo)
 "cD" = (
-/obj/item/ammo_magazine/shotholder/net,
-/obj/item/ammo_magazine/shotholder/net,
 /obj/structure/table/rack{
 	dir = 4
 	},

--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -3653,7 +3653,6 @@
 /turf/simulated/floor/reinforced/vox,
 /area/voxship/ofd)
 "EO" = (
-/obj/effect/decal/warning_stripes,
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1"

--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -1488,7 +1488,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/power/smes/buildable/preset/torch/engine_main,
+/obj/machinery/power/smes/buildable/preset/voxship/ship,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"

--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -4088,7 +4088,9 @@
 "IG" = (
 /obj/machinery/door/airlock/ascent{
 	autoset_access = 0;
-	color = "#6CDA1B"
+	color = "#6CDA1B";
+	name = "Armory";
+	req_access = list("ACCESS_VOXSHIP")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -4219,14 +4221,16 @@
 /turf/simulated/floor/reinforced/vox,
 /area/voxship/shuttle)
 "JV" = (
-/obj/machinery/door/airlock/ascent{
-	autoset_access = 0;
-	color = "#6CDA1B"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/ascent{
+	autoset_access = 0;
+	color = "#6CDA1B";
+	name = "Armory";
+	req_access = list("ACCESS_VOXSHIP")
 	},
 /turf/simulated/floor/reinforced/vox,
 /area/voxship/dock)
@@ -4703,11 +4707,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating/vox,
 /area/voxship/ship_fore)
-"Oh" = (
-/obj/effect/wallframe_spawn/alien,
-/obj/effect/wallframe_spawn/alien,
-/turf/simulated/floor/airless,
-/area/space)
 "Oj" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -12522,7 +12521,7 @@ Xw
 Jk
 cZ
 cZ
-Oh
+Jk
 Xw
 Jk
 cZ

--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -1488,7 +1488,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/power/smes/buildable/preset/voxship/ship,
+/obj/machinery/power/smes/buildable/preset/voxship/engine,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -1915,7 +1915,7 @@
 /area/voxship/shuttle)
 "pq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/power/smes/buildable/preset/voxship/ship,
+/obj/machinery/power/smes/buildable/preset/voxship/engine,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -4088,7 +4088,6 @@
 /obj/machinery/door/airlock/ascent{
 	autoset_access = 0;
 	color = "#6CDA1B";
-	name = "Armory";
 	req_access = list("ACCESS_VOXSHIP")
 	},
 /obj/structure/cable{
@@ -4228,7 +4227,6 @@
 /obj/machinery/door/airlock/ascent{
 	autoset_access = 0;
 	color = "#6CDA1B";
-	name = "Armory";
 	req_access = list("ACCESS_VOXSHIP")
 	},
 /turf/simulated/floor/reinforced/vox,

--- a/maps/away/voxship/voxship-2.dmm
+++ b/maps/away/voxship/voxship-2.dmm
@@ -441,7 +441,8 @@
 /obj/machinery/door/airlock/ascent{
 	autoset_access = 0;
 	color = "#6CDA1B";
-	dir = 4
+	dir = 4;
+	req_access = list("ACCESS_VOXSHIP")
 	},
 /obj/machinery/door/firedoor{
 	dir = 4;
@@ -947,7 +948,8 @@
 "nY" = (
 /obj/machinery/door/airlock/ascent{
 	autoset_access = 0;
-	color = "#6CDA1B"
+	color = "#6CDA1B";
+	req_access = list("ACCESS_VOXSHIP")
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1008,7 +1010,8 @@
 /obj/machinery/door/airlock/ascent{
 	autoset_access = 0;
 	color = "#6CDA1B";
-	dir = 4
+	dir = 4;
+	req_access = list("ACCESS_VOXSHIP")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1306,7 +1309,8 @@
 "tn" = (
 /obj/machinery/door/airlock/ascent{
 	autoset_access = 0;
-	color = "#6CDA1B"
+	color = "#6CDA1B";
+	req_access = list("ACCESS_VOXSHIP")
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1393,7 +1397,7 @@
 /obj/machinery/door/airlock/ascent{
 	autoset_access = 0;
 	color = "#6CDA1B";
-	name = "Washroom"
+	req_access = list("ACCESS_VOXSHIP")
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2582,7 +2586,7 @@
 /obj/machinery/door/airlock/ascent{
 	autoset_access = 0;
 	color = "#6CDA1B";
-	req_access = list("ACCESS_VOXSHIP_CAPTAIN")
+	req_access = list("ACCESS_VOXSHIP")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/firedoor,
@@ -3696,12 +3700,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/machinery/door/airlock/ascent{
-	autoset_access = 0;
-	color = "#6CDA1B";
-	dir = 4;
-	req_access = list("ACCESS_VOXSHIP")
 	},
 /obj/machinery/door/firedoor{
 	dir = 4;

--- a/maps/away/voxship/voxship-2.dmm
+++ b/maps/away/voxship/voxship-2.dmm
@@ -441,8 +441,7 @@
 /obj/machinery/door/airlock/ascent{
 	autoset_access = 0;
 	color = "#6CDA1B";
-	dir = 4;
-	req_access = list("ACCESS_VOXSHIP")
+	dir = 4
 	},
 /obj/machinery/door/firedoor{
 	dir = 4;
@@ -948,8 +947,7 @@
 "nY" = (
 /obj/machinery/door/airlock/ascent{
 	autoset_access = 0;
-	color = "#6CDA1B";
-	req_access = list("ACCESS_VOXSHIP")
+	color = "#6CDA1B"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1309,8 +1307,7 @@
 "tn" = (
 /obj/machinery/door/airlock/ascent{
 	autoset_access = 0;
-	color = "#6CDA1B";
-	req_access = list("ACCESS_VOXSHIP")
+	color = "#6CDA1B"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1396,8 +1393,7 @@
 "ub" = (
 /obj/machinery/door/airlock/ascent{
 	autoset_access = 0;
-	color = "#6CDA1B";
-	req_access = list("ACCESS_VOXSHIP")
+	color = "#6CDA1B"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3694,6 +3690,7 @@
 /area/voxship/dorms)
 "XK" = (
 /obj/machinery/door/airlock/ascent{
+	autoset_access = 0;
 	color = "#6CDA1B";
 	dir = 4;
 	req_access = list("ACCESS_VOXSHIP")

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -127,4 +127,14 @@
 	_output_on = TRUE
 	_fully_charged = TRUE
 
+/obj/machinery/power/smes/buildable/preset/voxship/engine
+	uncreated_component_parts = list(
+		/obj/item/weapon/stock_parts/smes_coil/advanced = 2
+	)
+	_input_maxed = TRUE
+	_output_maxed = TRUE
+	_input_on = TRUE
+	_output_on = TRUE
+	_fully_charged = TRUE
+
 #undef WEBHOOK_SUBMAP_LOADED_VOX


### PR DESCRIPTION
Gives bearcat a display case for the Solid Argument instead of a glass window.

makes our repo have pretty, cute green CI checks