### PR TITLE
Makes GAS Insuls available to GAS Engineers.

### DIFF
--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -24,7 +24,7 @@ var/datum/robolimb/basic_robolimb
 	var/list/species_cannot_use = list()
 	var/list/restricted_to = list()
 	var/list/applies_to_part = list() //TODO.
-	var/list/allowed_bodytypes = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SKRELL,SPECIES_UNATHI)
+	var/list/allowed_bodytypes = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SKRELL,SPECIES_TAJ)
 
 /datum/robolimb/bishop
 	company = "Bishop"

--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -24,7 +24,7 @@ var/datum/robolimb/basic_robolimb
 	var/list/species_cannot_use = list()
 	var/list/restricted_to = list()
 	var/list/applies_to_part = list() //TODO.
-	var/list/allowed_bodytypes = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SKRELL,SPECIES_TAJ)
+	var/list/allowed_bodytypes = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SKRELL,SPECIES_UNATHI)
 
 /datum/robolimb/bishop
 	company = "Bishop"

--- a/maps/torch/loadout/loadout_xeno.dm
+++ b/maps/torch/loadout/loadout_xeno.dm
@@ -37,6 +37,6 @@
 	path = /obj/item/clothing/gloves/nabber
 	description = "A set of insulated gloves meant for GAS."
 	whitelisted = list(SPECIES_NABBER)
-	allowed_branches = ENGINEERING_ROLES
+	allowed_roles = ENGINEERING_ROLES
 	sort_category = "Xenowear"
 


### PR DESCRIPTION
Fixes https://github.com/BoHBranch/BoH-Bay/issues/1399. GAS Insuls were not available to GAS Engineers. This fixes the issue by correcting allowed_branches to allowed_roles as engineering_roles is a role, and not a branch.

![image](https://user-images.githubusercontent.com/100093914/156858188-23d12028-1838-4ad8-839a-f9e25857dfff.png)
