### PR TITLE
Adds robolimbs to Taj, removes from Unathi.

### DIFF
--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -24,7 +24,7 @@ var/datum/robolimb/basic_robolimb
 	var/list/species_cannot_use = list()
 	var/list/restricted_to = list()
 	var/list/applies_to_part = list() //TODO.
-	var/list/allowed_bodytypes = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SKRELL,SPECIES_UNATHI)
+	var/list/allowed_bodytypes = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SKRELL,SPECIES_TAJ)
 
 /datum/robolimb/bishop
 	company = "Bishop"


### PR DESCRIPTION
Corrects https://github.com/BoHBranch/BoH-Bay/issues/902 Removes the ability for Unathi to spawn with robolimbs, as they can regrow limbs. Adds the ability for Tajarans to spawn with robolimbs, as they cannot regrow limbs.

![image](https://user-images.githubusercontent.com/100093914/156862704-75b58565-8d60-4015-b55b-fc8db4aff1b2.png)