### PR TITLE
makes yeosa names 3 words long when you use random name gen

### DIFF
--- a/code/modules/mob/language/alien/unathi.dm
+++ b/code/modules/mob/language/alien/unathi.dm
@@ -25,6 +25,7 @@
 		LANGUAGE_UNATHI_YEOSA = 50
 	)
 
+
 /datum/language/yeosa
 	name = LANGUAGE_UNATHI_YEOSA
 	desc = "A language of Moghes consisting of a combination of spoken word and gesticulation. While it is uncommonly spoken in the drier regions, it enjoys popular usage as the official tongue of the Yeosa clans."
@@ -52,3 +53,5 @@
 		LANGUAGE_SPACER = 2,
 		LANGUAGE_UNATHI_SINTA = 50
 	)
+/datum/language/yeosa/get_random_name()
+	return ..(FEMALE,3)

--- a/code/modules/species/station/lizard_subspecies.dm
+++ b/code/modules/species/station/lizard_subspecies.dm
@@ -31,7 +31,7 @@
 			RELIGION_UNATHI_AGA_EAKHE
 		)
 	)
-
+	default_cultural_info = list(TAG_CULTURE = CULTURE_UNATHI_YEOSA_LITTORAL)
 
 
 	override_organ_types = list(


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Yeosa names are supposed to be 3 words, and as much as I'd like to enact martial law on naming policy as even fucking tgstation does, I can't do that in good faith unless randomname gives you an accurate yeosa name so people aren't confused.
Also this sets their default culture which is just a plus.