### PR TITLE
Raises Exoplanet Count | Raises Off-Site Budget

### DIFF
--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -34,8 +34,8 @@
 
 	default_law_type = /datum/ai_laws/solgov
 	use_overmap = 1
-	num_exoplanets = 1
+	num_exoplanets = 3
 
-	away_site_budget = 8
+	away_site_budget = 12
 	//id_hud_icons = 'maps/torch/icons/assignment_hud.dmi'
 	id_hud_icons = 'maps/torch/icons/assignment_hud_boh.dmi'


### PR DESCRIPTION
- - -
Balance:
 - Exoplanet count raised by two, bringing it up to three. Previously, it sat at one, not leaving room for variety in our semi-lengthy rounds. This is likely to heavily impact performance; as such, we'll test merge it first.
 - Away site budget raised from eight to twelve. If you don't know what this does? Don't worry about it.
- - -