### PR TITLE
Fixes two unathi voice-related fuckups of my own creation.

### DIFF
--- a/code/modules/emotes/definitions/_species.dm
+++ b/code/modules/emotes/definitions/_species.dm
@@ -31,7 +31,7 @@
 		/decl/emote/audible/lizard_bellow
 		)
 
-/datum/species/unathi
+/datum/species/unathi/yeosa
 	default_emotes = list(
 		/decl/emote/human/swish,
 		/decl/emote/human/wag,

--- a/maps/away/rawl/rawl_jobs.dm
+++ b/maps/away/rawl/rawl_jobs.dm
@@ -8,6 +8,7 @@
 	for mercenary work of all sorts. You're as willing to offer labor as you are to \
 	get into trouble, but if you get caught trying to steal info or tech from Sol, keep your mouth shut."
 	whitelisted_species = list(SPECIES_UNATHI)
+	required_language = LANGUAGE_UNATHI_SINTA
 	is_semi_antagonist = TRUE
 	min_skill = list(
 		SKILL_BUREAUCRACY = SKILL_ADEPT,
@@ -54,6 +55,7 @@
 	for mercenary work of all sorts. You're as willing to offer labor as you are to \
 	get into trouble, but if you get caught trying to steal info or tech from Sol, keep your mouth shut."
 	whitelisted_species = list(SPECIES_UNATHI,SPECIES_YEOSA,SPECIES_OLDUNATHI)
+	required_language = LANGUAGE_UNATHI_SINTA
 	is_semi_antagonist = TRUE
 	min_skill = list(
 		SKILL_CONSTRUCTION = SKILL_ADEPT,
@@ -105,6 +107,7 @@
 	for mercenary work of all sorts. You're as willing to offer labor as you are to \
 	get into trouble, but if you get caught trying to steal info or tech from Sol, keep your mouth shut."
 	whitelisted_species = list(SPECIES_UNATHI,SPECIES_YEOSA,SPECIES_OLDUNATHI)
+	required_language = LANGUAGE_UNATHI_SINTA
 	is_semi_antagonist = TRUE
 	min_skill = list(
 		SKILL_HAULING = SKILL_BASIC,


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
1. being able to speak unathi was supposed to be mandatory for people on the Rawl, for obvious reasons. now it is.
2. Squealing is for yeosa. code error meant it was for all unathi. Now it's for yeosa.