### PR TITLE
Support Lance Bugfix

### DIFF
--- a/code/modules/ascent/ascent_rigs.dm
+++ b/code/modules/ascent/ascent_rigs.dm
@@ -293,6 +293,7 @@
 	allowed = list(
 		/obj/item/clustertool,
 		/obj/item/weapon/gun/energy/particle/small,
+		/obj/item/weapon/gun/energy/particle/support,
 		/obj/item/weapon/weldingtool/electric/mantid,
 		/obj/item/device/multitool/mantid,
 		/obj/item/stack/medical/resin,
@@ -326,6 +327,7 @@
 	allowed = list(
 		/obj/item/clustertool,
 		/obj/item/weapon/gun/energy/particle/small,
+		/obj/item/weapon/gun/energy/particle/support,
 		/obj/item/weapon/weldingtool/electric/mantid,
 		/obj/item/device/multitool/mantid,
 		/obj/item/stack/medical/resin,
@@ -363,6 +365,7 @@
 	allowed = list(
 		/obj/item/clustertool,
 		/obj/item/weapon/gun/energy/particle/small,
+		/obj/item/weapon/gun/energy/particle/support,
 		/obj/item/weapon/weldingtool/electric/mantid,
 		/obj/item/device/multitool/mantid,
 		/obj/item/stack/medical/resin,


### PR DESCRIPTION
- - -
Bugfix:
 - Previously, up until this PR, the support lance could only be lugged around by hand. Now, just like the small lance, you can place it into your suit storage. The previous behavior was unintended.
- - -