### PR TITLE
Exploration rank change

### DIFF
--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -195,6 +195,8 @@
 	allowed_branches = list(/datum/mil_branch/fleet)
 
 	allowed_ranks = list(
+		/datum/mil_rank/fleet/e2,
+		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/fleet/e6


### PR DESCRIPTION
Simply adds Crewman Apprentice and Crewman ranks to basic Explorer... was kinda weird that they were all JNCOs.

