### PR TITLE
Re-adds robolimbs mistakenely removed.

### DIFF
--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -24,7 +24,7 @@ var/datum/robolimb/basic_robolimb
 	var/list/species_cannot_use = list()
 	var/list/restricted_to = list()
 	var/list/applies_to_part = list() //TODO.
-	var/list/allowed_bodytypes = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SKRELL,SPECIES_TAJ)
+	var/list/allowed_bodytypes = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SKRELL,SPECIES_TAJ,SPECIES_UNATHI)
 
 /datum/robolimb/bishop
 	company = "Bishop"


### PR DESCRIPTION
So apparently when lizards are exposed to pollution, they can't regen, and might need robolimbs. Making https://github.com/BoHBranch/BoH-Bay/pull/1418 erroneous. This adds Unathi back to the list of races that can accept robolimbs.