### PR TITLE
Exoplanet Drop

### DIFF
--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -34,7 +34,7 @@
 
 	default_law_type = /datum/ai_laws/solgov
 	use_overmap = 1
-	num_exoplanets = 3
+	num_exoplanets = 1
 
 	away_site_budget = 12
 	//id_hud_icons = 'maps/torch/icons/assignment_hud.dmi'


### PR DESCRIPTION
Returns exoplanets to one, from three, after the short period we've had them active.
Site budget remains at twelve.