### PR TITLE
fixes up fucky rawl stuff and mining stuff

### DIFF
--- a/code/modules/mining/machinery/mineral_processor.dm
+++ b/code/modules/mining/machinery/mineral_processor.dm
@@ -34,7 +34,7 @@
 				for(var/o_material in I.matter)
 					if(!isnull(ores_stored[o_material]))
 						ores_stored[o_material] += I.matter[o_material]
-			qdel(I)
+						qdel(I)
 
 	if(!active)
 		return

--- a/code/modules/mining/machinery/mineral_unloader.dm
+++ b/code/modules/mining/machinery/mineral_unloader.dm
@@ -5,7 +5,9 @@
 	output_turf = EAST
 
 /obj/machinery/mineral/unloading_machine/Process()
-	if(input_turf && output_turf)
+	if(input_turf)
+		if(isnull(output_turf))
+			output_turf = get_turf(src)
 		if(length(output_turf.contents) < 15)
 			var/ore_this_tick = 10
 			for(var/obj/structure/ore_box/unloading in input_turf)

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -100,6 +100,12 @@
 	matter = list(MATERIAL_STEEL = 1700, MATERIAL_GLASS = 2900)
 	marking_color = COLOR_MUZZLE_FLASH
 
+/obj/item/ammo_magazine/shotholder/net
+	name = "net shell holder"
+	ammo_type = /obj/item/ammo_casing/shotgun/net
+	matter = list(MATERIAL_STEEL = 720)
+	marking_color = COLOR_PALE_PURPLE_GRAY
+
 /obj/item/ammo_magazine/shotholder/empty
 	name = "shotgun ammunition holder"
 	matter = list(MATERIAL_STEEL = 250)

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -126,6 +126,13 @@
 	leaves_residue = 0
 	matter = list(MATERIAL_STEEL = 360, MATERIAL_GLASS = 720)
 
+/obj/item/ammo_casing/shotgun/net
+	name = "net shell"
+	desc = "A net shell."
+	icon_state = "netshell"
+	projectile_type = /obj/item/projectile/bullet/shotgun/beanbag/net
+	matter = list(MATERIAL_STEEL = 180)
+
 /obj/item/ammo_casing/shotgun/stunshell/emp_act(severity)
 	if(prob(100/severity)) BB = null
 	update_icon()

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -187,6 +187,16 @@
 	armor_penetration = 10
 	embed = 0
 
+/obj/item/projectile/bullet/shotgun/beanbag/net
+	name = "netshell"
+	damage = 5
+	agony = 10
+
+/obj/item/projectile/bullet/shotgun/beanbag/net/on_hit(var/atom/target, var/blocked = 0, var/def_zone = null)
+	var/obj/item/weapon/energy_net/safari/net = new(loc)
+	net.throw_impact(target)
+	return TRUE
+
 //Spreads damage across more body parts than slugs, but is more effective up close and against unarmored opponents
 //High number of pellets with low velocity lends itself to more embeds
 /obj/item/projectile/bullet/pellet/shotgun

--- a/maps/away/rawl/rawl.dm
+++ b/maps/away/rawl/rawl.dm
@@ -134,3 +134,27 @@
 		/obj/item/rig_module/device/orescanner,
 		/obj/item/rig_module/vision/meson,
 		)
+
+//If you think this code is shit? We wouldn't need it if torch files weren't seperately loaded.
+/obj/item/ammo_magazine/shotholder/rawlnet
+	name = "net shell holder"
+	ammo_type = /obj/item/ammo_casing/shotgun/net
+	matter = list(MATERIAL_STEEL = 720)
+	marking_color = COLOR_PALE_PURPLE_GRAY
+
+/obj/item/ammo_casing/shotgun/rawlnet
+	name = "net shell"
+	desc = "A net shell."
+	icon_state = "netshell"
+	projectile_type = /obj/item/projectile/bullet/shotgun/beanbag/net
+	matter = list(MATERIAL_STEEL = 180)
+
+/obj/item/projectile/bullet/shotgun/beanbag/rawlnet
+	name = "netshell"
+	damage = 5
+	agony = 10
+
+/obj/item/projectile/bullet/shotgun/beanbag/rawlnet/on_hit(var/atom/target, var/blocked = 0, var/def_zone = null)
+	var/obj/item/weapon/energy_net/safari/net = new(loc)
+	net.throw_impact(target)
+	return TRUE

--- a/maps/away/rawl/rawl.dm
+++ b/maps/away/rawl/rawl.dm
@@ -134,27 +134,3 @@
 		/obj/item/rig_module/device/orescanner,
 		/obj/item/rig_module/vision/meson,
 		)
-
-//If you think this code is shit? We wouldn't need it if torch files weren't seperately loaded.
-/obj/item/ammo_magazine/shotholder/rawlnet
-	name = "net shell holder"
-	ammo_type = /obj/item/ammo_casing/shotgun/rawlnet
-	matter = list(MATERIAL_STEEL = 720)
-	marking_color = COLOR_PALE_PURPLE_GRAY
-
-/obj/item/ammo_casing/shotgun/rawlnet
-	name = "net shell"
-	desc = "A net shell."
-	icon_state = "netshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun/beanbag/rawlnet
-	matter = list(MATERIAL_STEEL = 180)
-
-/obj/item/projectile/bullet/shotgun/beanbag/rawlnet
-	name = "netshell"
-	damage = 5
-	agony = 10
-
-/obj/item/projectile/bullet/shotgun/beanbag/rawlnet/on_hit(var/atom/target, var/blocked = 0, var/def_zone = null)
-	var/obj/item/weapon/energy_net/safari/net = new(loc)
-	net.throw_impact(target)
-	return TRUE

--- a/maps/away/rawl/rawl.dm
+++ b/maps/away/rawl/rawl.dm
@@ -138,7 +138,7 @@
 //If you think this code is shit? We wouldn't need it if torch files weren't seperately loaded.
 /obj/item/ammo_magazine/shotholder/rawlnet
 	name = "net shell holder"
-	ammo_type = /obj/item/ammo_casing/shotgun/net
+	ammo_type = /obj/item/ammo_casing/shotgun/rawlnet
 	matter = list(MATERIAL_STEEL = 720)
 	marking_color = COLOR_PALE_PURPLE_GRAY
 
@@ -146,7 +146,7 @@
 	name = "net shell"
 	desc = "A net shell."
 	icon_state = "netshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun/beanbag/net
+	projectile_type = /obj/item/projectile/bullet/shotgun/beanbag/rawlnet
 	matter = list(MATERIAL_STEEL = 180)
 
 /obj/item/projectile/bullet/shotgun/beanbag/rawlnet

--- a/maps/away/rawl/rawl.dmm
+++ b/maps/away/rawl/rawl.dmm
@@ -613,12 +613,12 @@
 /obj/item/ammo_magazine/shotholder,
 /obj/item/ammo_magazine/shotholder,
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel{
-	ammo_type = /obj/item/ammo_casing/shotgun/rawlnet
+	ammo_type = /obj/item/ammo_casing/shotgun/net
 	},
 /obj/item/weapon/pickaxe/silver,
 /obj/item/weapon/storage/ore,
-/obj/item/ammo_magazine/shotholder/rawlnet,
-/obj/item/ammo_magazine/shotholder/rawlnet,
+/obj/item/ammo_magazine/shotholder/net,
+/obj/item/ammo_magazine/shotholder/net,
 /turf/simulated/floor/tiled/dark,
 /area/ship/rawl/cargo)
 "bc" = (

--- a/maps/away/rawl/rawl.dmm
+++ b/maps/away/rawl/rawl.dmm
@@ -22,7 +22,7 @@
 	frequency = 1331;
 	id_tag = "jimmysfuel_dock_outer";
 	locked = 1;
-	name = "Jimmy's Fuel
+	name = "Jimmy's Fuel"
 	},
 /turf/simulated/floor/plating,
 /area/ship/rawl/wreck)
@@ -106,12 +106,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/submap_landmark/spawnpoint/rawl_tech,
-/obj/structure/handrai,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/computer/mining{
 	density = 0;
 	pixel_y = 30
+	},
+/obj/machinery/mineral/unloading_machine{
+	output_turf = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/rawl/cargo)
@@ -312,6 +312,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/rawl/crew)
+"aD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/mineral/processing_unit{
+	input_turf = 8;
+	output_turf = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/rawl/cargo)
 "aE" = (
 /turf/simulated/floor/asteroid,
 /area/space)
@@ -400,6 +413,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/rawl/fore)
+"aM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/rawl/cargo)
 "aN" = (
 /obj/machinery/power/terminal{
 	dir = 1;
@@ -552,6 +574,10 @@
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/white,
 /area/ship/rawl/crew)
+"aZ" = (
+/obj/effect/submap_landmark/spawnpoint/rawl_tech,
+/turf/simulated/floor/tiled/dark,
+/area/ship/rawl/cargo)
 "ba" = (
 /obj/machinery/door/airlock{
 	name = "Atmospherics"
@@ -570,6 +596,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/rawl/fore)
+"bb" = (
+/obj/structure/table/rack{
+	dir = 4
+	},
+/obj/item/weapon/material/harpoon,
+/obj/item/weapon/material/harpoon,
+/obj/item/weapon/material/harpoon,
+/obj/item/device/dociler,
+/obj/item/device/dociler,
+/obj/item/device/dociler,
+/obj/machinery/power/apc/high/rawl{
+	pixel_y = -28
+	},
+/obj/structure/cable,
+/obj/item/ammo_magazine/shotholder,
+/obj/item/ammo_magazine/shotholder,
+/obj/item/weapon/gun/projectile/shotgun/doublebarrel{
+	ammo_type = /obj/item/ammo_casing/shotgun/rawlnet
+	},
+/obj/item/weapon/pickaxe/silver,
+/obj/item/weapon/storage/ore,
+/obj/item/ammo_magazine/shotholder/rawlnet,
+/obj/item/ammo_magazine/shotholder/rawlnet,
+/turf/simulated/floor/tiled/dark,
+/area/ship/rawl/cargo)
 "bc" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1331;
@@ -976,19 +1027,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/rawl/fore)
-"ca" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/mineral/processing_unit{
-	input_turf = 4;
-	output_turf = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/rawl/cargo)
 "cb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -1069,19 +1107,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/rawl/fore)
-"ck" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/loading{
-	dir = 8;
-	icon_state = "loadingarea"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/rawl/cargo)
 "cl" = (
 /obj/structure/table/standard,
 /obj/machinery/button/windowtint{
@@ -1223,29 +1248,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/rawl/cargo)
-"cD" = (
-/obj/structure/table/rack{
-	dir = 4
-	},
-/obj/item/weapon/material/harpoon,
-/obj/item/weapon/material/harpoon,
-/obj/item/weapon/material/harpoon,
-/obj/item/device/dociler,
-/obj/item/device/dociler,
-/obj/item/device/dociler,
-/obj/machinery/power/apc/high/rawl{
-	pixel_y = -28
-	},
-/obj/structure/cable,
-/obj/item/ammo_magazine/shotholder,
-/obj/item/ammo_magazine/shotholder,
-/obj/item/weapon/gun/projectile/shotgun/doublebarrel{
-	ammo_type = /obj/item/ammo_casing/shotgun/net
-	},
-/obj/item/weapon/pickaxe/silver,
-/obj/item/weapon/storage/ore,
 /turf/simulated/floor/tiled/dark,
 /area/ship/rawl/cargo)
 "cE" = (
@@ -23343,7 +23345,7 @@ cz
 aj
 bN
 cu
-cD
+bb
 iD
 aa
 aa
@@ -23745,7 +23747,7 @@ bf
 aJ
 bg
 iD
-ca
+aD
 MR
 wQ
 iD
@@ -23947,8 +23949,8 @@ bc
 Ua
 xz
 PB
-ck
-MR
+aM
+aZ
 xd
 iD
 aa

--- a/maps/torch/items/explo_shotgun.dm
+++ b/maps/torch/items/explo_shotgun.dm
@@ -82,29 +82,6 @@
 			return FALSE
 	return ..()
 
-/obj/item/ammo_magazine/shotholder/net
-	name = "net shell holder"
-	ammo_type = /obj/item/ammo_casing/shotgun/net
-	matter = list(MATERIAL_STEEL = 720)
-	marking_color = COLOR_PALE_PURPLE_GRAY
-
-/obj/item/ammo_casing/shotgun/net
-	name = "net shell"
-	desc = "A net shell."
-	icon_state = "netshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun/beanbag/net
-	matter = list(MATERIAL_STEEL = 180)
-
-/obj/item/projectile/bullet/shotgun/beanbag/net
-	name = "netshell"
-	damage = 5
-	agony = 10
-
-/obj/item/projectile/bullet/shotgun/beanbag/net/on_hit(var/atom/target, var/blocked = 0, var/def_zone = null)
-	var/obj/item/weapon/energy_net/safari/net = new(loc)
-	net.throw_impact(target)
-	return TRUE
-
 /obj/item/weapon/storage/box/ammo/explo_shells
 	name = "box of utility shells"
 	startswith = list(/obj/item/ammo_magazine/shotholder/beanbag = 1,


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
the mining smelter was eating people's organs because somebody didn't press tab enough times. It'll still eat metal that passes by it, though, so the Rawl one now has an ore loader for added safety. Now if an ore loader doesn't have an output set it'll still take the input to its current tile. Also fixes net shells being against the CI.
Yeah I map merged this pretty good, if it doesn't  seem map merged to you, I think the fuckup was previous, but lmk if there's something i need to do to fix this. 