### PR TITLE
Lets Skrell, Unathi, and Ascent dock properly with the Dagon, as well as making their landing zones exclusive!

### DIFF
--- a/maps/away/ascent/ascent-2.dmm
+++ b/maps/away/ascent/ascent-2.dmm
@@ -52,7 +52,7 @@
 	},
 /obj/machinery/door/airlock/external/bolted/ascent{
 	airlock_type = "Internal";
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_inner"
 	},
 /turf/simulated/floor/ascent,
@@ -512,7 +512,7 @@
 "bq" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
 	airlock_type = "Internal";
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_dock_starboard_internal"
 	},
 /obj/structure/cable/cyan{
@@ -805,7 +805,7 @@
 	dir = 1
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_dock_sensor";
 	pixel_x = -8;
 	pixel_y = 24
@@ -883,7 +883,7 @@
 /area/ship/ascent/fore_starboard_prow)
 "bW" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_dock_inner"
 	},
 /obj/structure/cable/cyan{
@@ -948,7 +948,7 @@
 "ce" = (
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_dock_inner"
 	},
 /turf/simulated/floor/ascent,
@@ -1847,7 +1847,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_dock_pump"
 	},
 /turf/simulated/floor/ascent,
@@ -1872,7 +1872,7 @@
 /obj/machinery/light/ascent,
 /obj/machinery/access_button{
 	command = "cycle_interior";
-	frequency = 1333;
+	frequency = 1380;
 	master_tag = "ascent_starboard";
 	pixel_y = -24
 	},
@@ -2017,12 +2017,12 @@
 "eo" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_pump_out_internal"
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	cycle_to_external_air = 1;
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard";
 	pixel_x = -24;
 	pixel_y = 0;
@@ -2139,7 +2139,7 @@
 "ey" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_dock_pump"
 	},
 /turf/simulated/floor/ascent,
@@ -2261,7 +2261,7 @@
 /area/ship/ascent/engineering)
 "eF" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_dock";
 	pixel_x = -24;
 	pixel_y = 0;
@@ -2322,7 +2322,7 @@
 "eO" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
 	airlock_type = "Internal";
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_inner"
 	},
 /obj/effect/catwalk_plated/ascent,
@@ -2341,7 +2341,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/machinery/door/airlock/external/bolted/ascent{
 	airlock_type = "Internal";
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_inner"
 	},
 /turf/simulated/floor/ascent,
@@ -2459,14 +2459,14 @@
 /area/ship/ascent/habitation)
 "fa" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_sensor";
 	pixel_x = -24;
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_pump"
 	},
 /turf/simulated/floor/ascent,
@@ -2474,7 +2474,7 @@
 "fb" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_pump"
 	},
 /obj/structure/cable/cyan{
@@ -2492,7 +2492,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_pump_out_internal"
 	},
 /turf/simulated/floor/ascent,
@@ -2517,7 +2517,7 @@
 /area/ship/ascent/habitation)
 "fe" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_outer"
 	},
 /obj/structure/cable/cyan{
@@ -2541,7 +2541,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_shuttle_starboard_vent_inner"
 	},
 /turf/simulated/floor/ascent,
@@ -2552,20 +2552,20 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/shuttle_landmark/ascent_seedship/start,
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_dock_outer"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/wing_starboard)
 "fi" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_dock_outer"
 	},
 /obj/effect/catwalk_plated/ascent,
+/obj/effect/shuttle_landmark/ascent_seedship/start,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/wing_starboard)
 "fj" = (
@@ -2604,8 +2604,8 @@
 	dir = 9
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1332;
-	id_tag = "ascent_port_shuttle_dock";
+	frequency = 1380;
+	id_tag = "ascent_port";
 	pixel_x = 24;
 	tag_airpump = "ascent_port_pump";
 	tag_chamber_sensor = "ascent_port_sensor";
@@ -2613,7 +2613,7 @@
 	tag_interior_door = "ascent_port_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_sensor";
 	pixel_x = 24;
 	pixel_y = -12
@@ -2690,7 +2690,7 @@
 /area/ship/ascent/shuttle_starboard)
 "fv" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_shuttle_starboard_vent_inner"
 	},
 /turf/simulated/floor/ascent,
@@ -2714,7 +2714,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_pump"
 	},
 /turf/simulated/floor/ascent,
@@ -3114,7 +3114,7 @@
 /area/ship/ascent/fore_hallway)
 "gs" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_inner"
 	},
 /obj/effect/catwalk_plated/ascent,
@@ -3146,7 +3146,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_pump"
 	},
 /turf/simulated/floor/ascent,
@@ -3712,14 +3712,14 @@
 /area/ship/ascent/shuttle_starboard)
 "ie" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_outer"
 	},
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
-	frequency = 1333;
+	frequency = 1380;
 	master_tag = "ascent_starboard";
 	pixel_x = -24;
 	pixel_y = 0
@@ -3824,7 +3824,7 @@
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_outer"
 	},
 /turf/simulated/floor/ascent,
@@ -3840,8 +3840,8 @@
 	dir = 4
 	},
 /obj/machinery/access_button/airlock_interior{
-	frequency = 1332;
-	master_tag = "ascent_port_shuttle_dock";
+	frequency = 1380;
+	master_tag = "ascent_port";
 	pixel_x = 4;
 	pixel_y = 24
 	},
@@ -3894,7 +3894,7 @@
 /area/ship/ascent/shuttle_port)
 "iE" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_dock_starboard_external"
 	},
 /obj/effect/catwalk_plated/ascent,
@@ -3909,7 +3909,7 @@
 /obj/effect/catwalk_plated/ascent,
 /obj/effect/shuttle_landmark/ascent_seedship/start/two,
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_dock_starboard_external"
 	},
 /turf/simulated/floor/ascent,
@@ -3927,7 +3927,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_pump"
 	},
 /turf/simulated/floor/ascent,
@@ -3978,7 +3978,7 @@
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/door/airlock/external/bolted/ascent{
 	airlock_type = "Internal";
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_dock_starboard_internal"
 	},
 /turf/simulated/floor/ascent,
@@ -4169,7 +4169,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/machinery/airlock_sensor{
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_shuttle_starboard_interior_sensor";
 	pixel_x = -8;
 	pixel_y = -24
@@ -4256,7 +4256,7 @@
 	},
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_outer"
 	},
 /turf/simulated/floor/ascent,
@@ -4294,11 +4294,11 @@
 "kH" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_pump_out_external"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_sensor_external";
 	pixel_x = -24;
 	pixel_y = 0
@@ -4413,7 +4413,7 @@
 /area/ship/ascent/aft_starboard_jut)
 "nV" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_dock";
 	pixel_x = -24;
 	pixel_y = 0;
@@ -4465,7 +4465,7 @@
 "pE" = (
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1332;
+	frequency = 1380;
 	id_tag = "ascent_port_inner"
 	},
 /turf/simulated/floor/ascent,
@@ -4582,7 +4582,7 @@
 "wO" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_pump_out_internal"
 	},
 /turf/simulated/floor/ascent,
@@ -4765,7 +4765,7 @@
 "Fg" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_pump_out_external"
 	},
 /turf/simulated/floor/ascent,
@@ -5169,7 +5169,7 @@
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1333;
+	frequency = 1380;
 	id_tag = "ascent_starboard_outer"
 	},
 /turf/simulated/floor/ascent,

--- a/maps/away/ascent/ascent_shuttles.dm
+++ b/maps/away/ascent/ascent_shuttles.dm
@@ -42,12 +42,27 @@
 	docking_controller = "ascent_starboard_dock"
 	base_area = /area/ship/ascent/wing_starboard
 
+/obj/effect/shuttle_landmark/ascent_seedship/dock
+	name = "Invalid Aft Docking Port"
+	landmark_tag = "nav_ascentshipone_dock"
+	docking_controller = "rescue_shuttle_dock_airlock"
+
+/obj/effect/shuttle_landmark/ascent_seedship/dock/two
+	name = "Valid Fore Docking Port"
+	landmark_tag = "nav_ascentshipone_altdock"
+	docking_controller = "skipjack_shuttle_dock_airlock"
+
+/obj/effect/shuttle_landmark/ascent_seedship/dock/three
+	name = "Valid Aft Docking Port"
+	landmark_tag = "nav_ascentshiptwo_dock"
+	docking_controller = "admin_shuttle_dock_airlock"
+
 /datum/shuttle/autodock/overmap/ascent
 	name = "Trichoptera"
 	warmup_time = 5
 	current_location = "nav_hangar_ascent_one"
 	range = 2
-	dock_target = "ascent_port_shuttle_dock"
+	dock_target = "ascent_port"
 	shuttle_area = /area/ship/ascent/shuttle_port
 	defer_initialisation = TRUE
 	flags = SHUTTLE_FLAGS_PROCESS

--- a/maps/away/rawl/rawl.dm
+++ b/maps/away/rawl/rawl.dm
@@ -22,6 +22,9 @@
 		"nav_rawl_1",
 		"nav_rawl_2"
 	)
+	initial_restricted_waypoints = list(
+		"IPV Rawl" = list("nav_hangar_rawlship")
+	)
 
 /obj/effect/shuttle_landmark/rawl/one
 	name = "East of asteroid"

--- a/maps/away/rawl/rawl_shuttles.dm
+++ b/maps/away/rawl/rawl_shuttles.dm
@@ -43,11 +43,11 @@
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 
 /obj/effect/shuttle_landmark/rawl/torch
-	name = "SEV Torch IPV Rawl Fore Airlock"
+	name = "Invalid Central Fore Airlock"
 	landmark_tag = "nav_hangar_rawlship_torch"
 
 /obj/effect/shuttle_landmark/rawl/torchdock
-	name = "SEV Torch IPV Rawl Lower Fore Dock"
+	name = "Valid Lower Fore Dock"
 	landmark_tag = "nav_hangar_rawlship_torchdock"
 	docking_controller = "nuke_shuttle_dock_airlock"
 

--- a/maps/away/rawl/rawl_shuttles.dm
+++ b/maps/away/rawl/rawl_shuttles.dm
@@ -10,10 +10,6 @@
 	vessel_size = SHIP_SIZE_SMALL
 	fore_dir = WEST
 	hide_from_reports = TRUE
-	initial_restricted_waypoints = list(
-		"IPV Rawl" = list("nav_hangar_rawlship")
-	)
-
 
 /datum/shuttle/autodock/overmap/rawl_ship
 	name = "IPV Rawl"

--- a/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
@@ -100,7 +100,7 @@
 /area/ship/skrellskoutship/observatory)
 "bf" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "xil_dock_pump"
 	},
 /obj/structure/handrai{
@@ -131,7 +131,7 @@
 /area/ship/skrellskoutship/observatory)
 "bu" = (
 /obj/machinery/door/airlock/external/glass{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "xil_dock_inner";
 	locked = 1
 	},
@@ -1505,7 +1505,7 @@
 /area/ship/skrellskoutship/observatory)
 "rh" = (
 /obj/machinery/door/airlock/external/glass{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "observatory_dock_inner";
 	locked = 1
 	},
@@ -1580,7 +1580,7 @@
 /area/ship/skrellscoutship/maintenance/atmos)
 "rJ" = (
 /obj/machinery/door/airlock/external/glass{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "observatory_dock_inner";
 	locked = 1
 	},
@@ -1705,7 +1705,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "observatory_dock_pump"
 	},
 /turf/simulated/floor/tiled/skrell,
@@ -1833,7 +1833,7 @@
 /area/ship/skrellscoutship/command/brig)
 "uH" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "observatory_dock";
 	pixel_x = 23;
 	pixel_y = 5;
@@ -1842,7 +1842,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "observatory_dock_pump"
 	},
 /turf/simulated/floor/tiled/skrell,
@@ -1936,11 +1936,11 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "observatory_dock_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "observatory_dock_sensor";
 	pixel_x = 24
 	},
@@ -2027,7 +2027,7 @@
 /area/ship/skrellskoutship/observatory)
 "xd" = (
 /obj/machinery/door/airlock/external/glass{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "observatory_dock_outer";
 	locked = 1
 	},
@@ -2035,7 +2035,7 @@
 /area/ship/skrellskoutship/observatory)
 "xi" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "xil_dock_pump_out_external"
 	},
 /obj/structure/handrai{
@@ -2065,13 +2065,13 @@
 	name = "Blast Doors"
 	},
 /obj/machinery/door/airlock/external/glass{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "xil_dock_outer";
 	locked = 1
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
-	frequency = 1289;
+	frequency = 1331;
 	master_tag = "xil_dock";
 	pixel_x = -32;
 	pixel_y = 6;
@@ -2084,12 +2084,12 @@
 /area/ship/skrellscoutship/dock)
 "xw" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1292;
+	frequency = 1331;
 	id_tag = "xil_dock_ext";
 	pixel_y = -23
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "xil_dock_pump_out_external"
 	},
 /obj/structure/handrai{
@@ -2100,7 +2100,7 @@
 "xz" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "xil_dock_pump_out_internal"
 	},
 /obj/machinery/light/skrell{
@@ -2128,11 +2128,11 @@
 "xM" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "xil_dock_pump_out_internal"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "xil_dock_sensor";
 	pixel_x = 24
 	},
@@ -2279,12 +2279,12 @@
 /area/ship/skrellscoutship/command/armory)
 "zq" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "xil_dock_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	cycle_to_external_air = 1;
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "xil_dock";
 	pixel_x = 23;
 	pixel_y = 5;
@@ -2747,7 +2747,7 @@
 "Eu" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "observatory_dock_pump"
 	},
 /turf/simulated/floor/tiled/skrell,
@@ -2913,7 +2913,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "observatory_dock_pump"
 	},
 /turf/simulated/floor/tiled/skrell,
@@ -3365,7 +3365,7 @@
 "JO" = (
 /obj/effect/shuttle_landmark/skrellscoutship/start,
 /obj/machinery/door/airlock/external/glass{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "observatory_dock_outer";
 	locked = 1
 	},
@@ -3928,13 +3928,13 @@
 /area/ship/skrellscoutship/command/bridge)
 "QA" = (
 /obj/machinery/door/airlock/external/glass{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "xil_dock_inner";
 	locked = 1
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
-	frequency = 1289;
+	frequency = 1331;
 	master_tag = "xil_dock";
 	pixel_x = 22;
 	pixel_y = -22
@@ -4255,7 +4255,7 @@
 	name = "Blast Doors"
 	},
 /obj/machinery/door/airlock/external/glass{
-	frequency = 1289;
+	frequency = 1331;
 	id_tag = "xil_dock_outer";
 	locked = 1
 	},

--- a/maps/away/skrellscoutship/skrellscoutship_shuttles.dm
+++ b/maps/away/skrellscoutship/skrellscoutship_shuttles.dm
@@ -48,12 +48,14 @@
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 
 /obj/effect/shuttle_landmark/skrellscoutship/dock
-	name = "SSV Secondary Docking Port"
-	landmark_tag = "nav_skrellscout_dock"
+	name = "Invalid Fore Docking Port"
+	landmark_tag = "nav_skrellscoutsh_dock"
+	docking_controller = "skipjack_shuttle_dock_airlock"
 
 /obj/effect/shuttle_landmark/skrellscoutship/altdock
-	name = "SSV Docking Port"
+	name = "Valid Aft Docking Port"
 	landmark_tag = "nav_skrellscoutsh_altdock"
+	docking_controller = "rescue_shuttle_dock_airlock"
 
 /turf/simulated/floor/shuttle_ceiling/skrell
 	color = COLOR_HULL

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -2467,6 +2467,18 @@
 	dir = 8;
 	icon_state = "pipe-j2"
 	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	display_name = "Starboard Dock C";
+	frequency = 1380;
+	id_tag = "admin_shuttle_dock_airlock";
+	pixel_x = 25;
+	pixel_y = 18;
+	req_access = list(list("ACCESS_EXTERNAL","ACCESS_TORCH_CREW"));
+	tag_airpump = "admin_shuttle_dock_pump";
+	tag_chamber_sensor = "admin_shuttle_dock_sensor";
+	tag_exterior_door = "admin_shuttle_dock_outer";
+	tag_interior_door = "admin_shuttle_dock_inner"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "eS" = (
@@ -8274,6 +8286,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
+"rI" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white{
+	dir = 1;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/hallway/primary/fourthdeck/fore)
 "rM" = (
 /obj/effect/floor_decal/techfloor,
 /obj/effect/landmark/start{
@@ -12908,6 +12930,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/sorting)
+"HA" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "skipjack_shuttle_dock_outer";
+	locked = 1;
+	name = "Docking Port Airlock"
+	},
+/obj/machinery/shield_diffuser,
+/obj/effect/shuttle_landmark/ascent_seedship/dock/two,
+/obj/effect/shuttle_landmark/skrellscoutship/dock,
+/turf/simulated/floor/plating,
+/area/hallway/primary/fourthdeck/fore)
 "HB" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Lounge Maintenance"
@@ -13150,15 +13185,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "Io" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "skipjack_shuttle_dock_outer";
-	locked = 1;
-	name = "Docking Port Airlock"
-	},
-/obj/machinery/shield_diffuser,
-/obj/effect/shuttle_landmark/skrellscoutship/dock,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
 "Ir" = (
@@ -17123,6 +17151,7 @@
 	},
 /obj/machinery/shield_diffuser,
 /obj/effect/shuttle_landmark/skrellscoutship/altdock,
+/obj/effect/shuttle_landmark/ascent_seedship/dock,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
 "TO" = (
@@ -17207,6 +17236,7 @@
 	name = "Docking Port Airlock"
 	},
 /obj/machinery/shield_diffuser,
+/obj/effect/shuttle_landmark/ascent_seedship/dock/three,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
 "TY" = (
@@ -30876,7 +30906,7 @@ FY
 BK
 BK
 BK
-aa
+BK
 aa
 aa
 aa
@@ -31078,8 +31108,8 @@ AG
 BK
 BK
 BK
-aa
-aa
+BK
+BK
 aa
 aa
 aa
@@ -31275,16 +31305,16 @@ BR
 on
 on
 EH
+rI
+rI
 Fn
 FZ
 ek
+WZ
+WZ
 YK
 WZ
 Nv
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -31474,20 +31504,20 @@ xY
 zu
 AK
 BS
+EI
 CT
+EI
 DO
 EI
 Fo
 fk
+Io
+Io
 GB
 Ho
 HR
-Io
+HA
 Kn
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -31684,11 +31714,11 @@ bj
 bj
 VV
 WZ
+WZ
+WZ
+WZ
+WZ
 cv
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -31886,8 +31916,8 @@ cS
 de
 VV
 DT
-aa
-aa
+DT
+DT
 aa
 aa
 aa
@@ -32088,7 +32118,7 @@ cX
 df
 VV
 DT
-aa
+DT
 aa
 aa
 aa

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -1431,11 +1431,6 @@
 	dir = 8;
 	pixel_x = 21
 	},
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	dir = 4;
-	id_tag = "admin_shuttle_dock_airlock";
-	pixel_x = -24
-	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
 "di" = (

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -11,7 +11,13 @@
 	initial_restricted_waypoints = list(
 		"SGEV Gaunt" = list("nav_hangar_calypso"), 	//can't have random shuttles popping inside the ship
 		"SGRP Garuda" = list("nav_hangar_guppy"),
-		"SGGS Byakhee" = list("nav_hangar_aquila")
+		"SGGS Byakhee" = list("nav_hangar_aquila"),
+
+		"Skrellian Scout" = list("nav_skrellscoutsh_dock", "nav_skrellscoutsh_altdock"),
+		"Rescue" = list("nav_ert_dock"),
+		"IPV Rawl" = list("nav_hangar_rawlship_torch","nav_hangar_rawlship_torchdock"),
+		"Trichoptera" = list("nav_ascentshipone_dock", "nav_ascentshipone_altdock"),
+		"Lepidoptera" = list("nav_ascentshiptwo_dock")
 	)
 
 	initial_generic_waypoints = list(
@@ -50,7 +56,6 @@
 		"nav_deck2_calypso",
 		"nav_deck2_guppy",
 		"nav_deck2_aquila",
-		"nav_hangar_rawlship_torch",
 
 		//start Forth Deck
 		"nav_merc_deck4",
@@ -60,17 +65,12 @@
 		"nav_deck1_calypso",
 		"nav_deck1_guppy",
 		"nav_deck1_aquila",
-		"nav_hangar_rawlship_torchdock",
 
 		//start Hanger Deck
 		"nav_merc_hanger",
 		"nav_ninja_hanger",
 		"nav_skipjack_hanger",
-		"nav_ert_hanger",
-
-		"nav_skrellscoutsh_altdock",
-		"nav_skrellscout_dock",
-		"nav_ert_dock"
+		"nav_ert_hanger"
 	)
 
 /decl/ship_contact_class/dagon


### PR DESCRIPTION
Fixes:
Skipjack can now use its intended docking port, thanks to the shipen- I mean, uh, comically large docking port. This also allows the Skrell to use this port, which they were intended to be able to use.
The Rawl no longer has a "ghost landing site" show up. It was dragging around the original landing zone but unable to go back to it, this is fixed now.
Whoever  designed the airlocks of the lower ascent shuttle screwed up hard. It's way less spaghetti now. If it has any other problems,
Features:
Functional docking for the skrell and ascent shuttles! The Ascent shuttles previously didn't have docking ports, but now they do- might give the upper ascent shuttle the ninja docking port later, but right now it has one port, and the lower ascent ship has two ports, the same ones the skrell ship has. They each only have *automatic* docking at one of the ports, and it needs to be manually done for the other port (fore for ascent is automatic, aft for skrell). Fortunately they'll be able to see this because
-Docking ports for these 3 shuttles are now less confusing to use, slightly! For these 3 ships the docking information says if the docking port is valid for docking or if you can just rub up against it. And these docking locations are now _restricted_ for the ships, meaning you won't accidentally go to "docking port" when you wanted to go to SSV docking port, because "docking port" is properly restricted to the ERT shuttle.

I didn't give the ascent accesss to the merchant ship docking port because that's the only place the merchant ship can go (and having it done this way increases the chances of a skrell-ascent war being done in one singular torch alleyway.
