### PR TITLE
Supply/Munition update!

### DIFF
--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -41,7 +41,7 @@
 							 /datum/computer_file/program/deck_management,
 							 /datum/computer_file/program/reports)
 	
-	datum/job/qm/get_description_blurb()
+	get_description_blurb()
 	return "You are the Deck Officer, and the Supply department, hanger, and munitions are your domain. Your responsibilities include ensuring the ship is supplied, the flight records are filled, shuttles are fuelled, missiles are made, and the ship is always combat ready for ship to ship combat." 						 
 
 
@@ -84,7 +84,7 @@
 							 /datum/computer_file/program/deck_management,
 							 /datum/computer_file/program/reports)
 	
-	datum/job/cargo_tech/get_description_blurb()
+	get_description_blurb()
 	return "You are a Deck Technician, you answer directly to the Deck Officer. Your responsibilities are to ensure supplies ordered are delivered, shuttles are fuelled, munitions are made and loaded, and to man the ship's missile weaponry in the case  of ship to ship combat."
 
 /datum/job/mining

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -55,7 +55,7 @@
 	minimum_character_age = list(SPECIES_HUMAN = 18)
 	alt_titles = list(
 		"Supply Technician",
-		"Gunnery Technician")
+		"Munitions Technician")
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/tech
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -41,7 +41,7 @@
 							 /datum/computer_file/program/deck_management,
 							 /datum/computer_file/program/reports)
 	
-	get_description_blurb()
+/datum/job/qm/get_description_blurb()
 	return "You are the Deck Officer, and the Supply department, hanger, and munitions are your domain. Your responsibilities include ensuring the ship is supplied, the flight records are filled, shuttles are fuelled, missiles are made, and the ship is always combat ready for ship to ship combat." 						 
 
 
@@ -84,7 +84,7 @@
 							 /datum/computer_file/program/deck_management,
 							 /datum/computer_file/program/reports)
 	
-	get_description_blurb()
+/datum/job/cargo_tech/get_description_blurb()
 	return "You are a Deck Technician, you answer directly to the Deck Officer. Your responsibilities are to ensure supplies ordered are delivered, shuttles are fuelled, munitions are made and loaded, and to man the ship's missile weaponry in the case  of ship to ship combat."
 
 /datum/job/mining

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -1,7 +1,7 @@
 /datum/job/qm
 	title = "Deck Officer"
 	department = "Support"
-	department_flag = SPT
+	department_flag = SPT|SUP
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the Commanding Officer"

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -41,7 +41,7 @@
 							 /datum/computer_file/program/deck_management,
 							 /datum/computer_file/program/reports)
 	
-	/datum/job/qm/get_description_blurb()
+	datum/job/qm/get_description_blurb()
 	return "You are the Deck Officer, and the Supply department, hanger, and munitions are your domain. Your responsibilities include ensuring the ship is supplied, the flight records are filled, shuttles are fuelled, missiles are made, and the ship is always combat ready for ship to ship combat." 						 
 
 
@@ -84,7 +84,7 @@
 							 /datum/computer_file/program/deck_management,
 							 /datum/computer_file/program/reports)
 	
-	/datum/job/cargo_tech/get_description_blurb()
+	datum/job/cargo_tech/get_description_blurb()
 	return "You are a Deck Technician, you answer directly to the Deck Officer. Your responsibilities are to ensure supplies ordered are delivered, shuttles are fuelled, munitions are made and loaded, and to man the ship's missile weaponry in the case  of ship to ship combat."
 
 /datum/job/mining

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -40,9 +40,10 @@
 	software_on_spawn = list(/datum/computer_file/program/supply,
 							 /datum/computer_file/program/deck_management,
 							 /datum/computer_file/program/reports)
-							 
+	
 	/datum/job/qm/get_description_blurb()
-	return "You are the Deck Officer, and the Supply department, hanger, and munitions are your domain. Your responsibilities include ensuring the ship is supplied, the flight records are filled, shuttles are fuelled, missiles are made, and the ship is always combat ready for ship to ship combat." 
+	return "You are the Deck Officer, and the Supply department, hanger, and munitions are your domain. Your responsibilities include ensuring the ship is supplied, the flight records are filled, shuttles are fuelled, missiles are made, and the ship is always combat ready for ship to ship combat." 						 
+
 
 /datum/job/cargo_tech
 	title = "Deck Technician"

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -1,7 +1,7 @@
 /datum/job/qm
 	title = "Deck Officer"
-	department = "Supply"
-	department_flag = SUP
+	department = "Support"
+	department_flag = SPT
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the Commanding Officer"
@@ -9,7 +9,9 @@
 	minimal_player_age = 0
 	minimum_character_age = list(SPECIES_HUMAN = 25)
 	alt_titles = list(
-		"Deck Chief")
+		"Deck Chief",
+		"Gunnery Officer",
+		"Gunnery Chief")
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/deckofficer
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
@@ -32,12 +34,15 @@
 
 	access = list(access_maint_tunnels, access_bridge, access_emergency_storage, access_tech_storage,  access_cargo, access_guppy_helm,
 						access_cargo_bot, access_qm, access_mailsorting, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
-						access_mining, access_mining_office, access_mining_station, access_commissary)
+						access_mining, access_mining_office, access_mining_station, access_commissary, access_gunnery, access_eva)
 	minimal_access = list()
 
 	software_on_spawn = list(/datum/computer_file/program/supply,
 							 /datum/computer_file/program/deck_management,
 							 /datum/computer_file/program/reports)
+							 
+	/datum/job/qm/get_description_blurb()
+	return "You are the Deck Officer, and the Supply department, hanger, and munitions are your domain. Your responsibilities include ensuring the ship is supplied, the flight records are filled, shuttles are fuelled, missiles are made, and the ship is always combat ready for ship to ship combat." 
 
 /datum/job/cargo_tech
 	title = "Deck Technician"
@@ -47,6 +52,9 @@
 	spawn_positions = 3
 	supervisors = "the Deck Officer"
 	minimum_character_age = list(SPECIES_HUMAN = 18)
+	alt_titles = list(
+		"Supply Technician",
+		"Gunnery Technician")
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/tech
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
@@ -68,12 +76,15 @@
 	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
 
 	access = list(access_maint_tunnels, access_emergency_storage, access_cargo, access_guppy_helm,
-						access_cargo_bot, access_mailsorting, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar, access_commissary)
+						access_cargo_bot, access_mailsorting, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar, access_commissary, access_gunnery, access_eva)
 	minimal_access = list()
 
 	software_on_spawn = list(/datum/computer_file/program/supply,
 							 /datum/computer_file/program/deck_management,
 							 /datum/computer_file/program/reports)
+	
+	/datum/job/qm/get_description_blurb()
+	return "You are a Deck Technician, you answer directly to the Deck Officer. Your responsibilities are to ensure supplies ordered are delivered, shuttles are fuelled, munitions are made and loaded, and to man the ship's missile weaponry in the case  of ship to ship combat."
 
 /datum/job/mining
 	title = "Prospector"

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -83,7 +83,7 @@
 							 /datum/computer_file/program/deck_management,
 							 /datum/computer_file/program/reports)
 	
-	/datum/job/qm/get_description_blurb()
+	/datum/job/cargo_tech/get_description_blurb()
 	return "You are a Deck Technician, you answer directly to the Deck Officer. Your responsibilities are to ensure supplies ordered are delivered, shuttles are fuelled, munitions are made and loaded, and to man the ship's missile weaponry in the case  of ship to ship combat."
 
 /datum/job/mining

--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -462,6 +462,7 @@
 /datum/job/cargo_tech
 	allowed_branches = list(
 		/datum/mil_branch/fleet,
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/supply/contractor,
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/supply/tech/marine
 	)
 	allowed_ranks = list(
@@ -473,6 +474,7 @@
 		/datum/mil_rank/marine_corps/e3,
 		/datum/mil_rank/marine_corps/e4,
 		/datum/mil_rank/marine_corps/e5,
+		/datum/mil_rank/civ/contractor
 	)
 /***/
 

--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -462,7 +462,6 @@
 /datum/job/cargo_tech
 	allowed_branches = list(
 		/datum/mil_branch/fleet,
-		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/supply/contractor,
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/supply/tech/marine
 	)
 	allowed_ranks = list(
@@ -474,7 +473,6 @@
 		/datum/mil_rank/marine_corps/e3,
 		/datum/mil_rank/marine_corps/e4,
 		/datum/mil_rank/marine_corps/e5,
-		/datum/mil_rank/civ/contractor
 	)
 /***/
 


### PR DESCRIPTION
Description: This PR gives Supply (Deck Technician, Deck Officer) access to the newly added missile systems of the Dagon. The ordering, making, loading, and firing of the missiles in the case of ship to ship combat now falls to Supply. Deck Officer, and Deck Technician have also been given a few brand new alt titles to show this change, however it also includes the removal of Civilian Deck technicians...considering civilians wouldn't surely be manning a military vessel's missile weaponry.

To also nip this in the bud now before it comes up or is made a problem on the server. The Deck Officer is now in command of the missile systems, not the Bridge Officer/Tactical Officer. However, if a Deck Officer is not present, but Deck Technicians are (or aren't), the Bridge Officer/Tactical Officer has the right to command the missile systems. The Bridge Officer/Tactical Officer however remains their command over the OFD as normal. 

Another massive question also is. Why Supply, and not any other department to handle the missiles? The reason that Supply was selected for this instead any of the other departments is because in the case of a ship to ship battle, and most cases in normal rounds, Supply simply doesn't have much to do. Some may say, why wouldn't engineering handle the missiles? which whilst a good point does not take into account that when in ship to ship combat the engineers already have a lot on their plate including the engines, power, shields, dealing with breaches, etc etc.

Possible future changes: Within the future with further feedback, and more discussion with the devs, the Supply Department may also be given a different name to show off this change of responsibilities and duties. Other changes may be that Deck Technicians and Gunnery Technicians might also be made their own separate roles instead of simply the same role with alt titles.  

If you have feedback, wanna complain at me, or suggest other things to add to Supply then message or @ me on discord. "✦ Ali'nar ✦"