### PR TITLE
Combat medic tweaks

### DIFF
--- a/maps/torch/infantry/outfits.dm
+++ b/maps/torch/infantry/outfits.dm
@@ -13,12 +13,6 @@
 	icon_state = "cap_cypherkey"
 	channels = list("Infantry" = 1, "Engineering" = 1, "Supply" = 1, "Exploration" = 1)
 
-/obj/item/device/encryptionkey/infantry/med
-	name = "infantry medic encryption key"
-	desc = "An Encryption key."
-	icon_state = "cap_cypherkey"
-	channels = list("Infantry" = 1, "Medical" = 1, "Exploration" = 1)
-
 /obj/item/device/encryptionkey/infantry
 	name = "infantry technician encryption key"
 	desc = "An Encryption key."
@@ -44,13 +38,6 @@
 	icon_state = "exp_headset"
 	item_state = "headset"
 	ks1type = /obj/item/device/encryptionkey/infantry/tech
-
-/obj/item/device/radio/headset/infmed
-	name = "infantry medic headset"
-	desc = "A headset with an inbuilt subspace antenna for better reception."
-	icon_state = "exp_headset"
-	item_state = "headset"
-	ks1type = /obj/item/device/encryptionkey/infantry/med
 
 /obj/item/device/radio/headset/inftech/alt
 	name = "infantry technician bowman headset"

--- a/maps/torch/job/hestia_jobs.dm
+++ b/maps/torch/job/hestia_jobs.dm
@@ -140,16 +140,16 @@
 	skill_points = 24
 	minimum_character_age = list(SPECIES_HUMAN = 20)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/infantry/combat_medic
-	min_skill = list(   SKILL_EVA     = SKILL_BASIC,
-	                    SKILL_MEDICAL = SKILL_BASIC,
-						SKILL_COMBAT  = SKILL_ADEPT,
-						SKILL_WEAPONS = SKILL_ADEPT,
-	                    SKILL_ANATOMY = SKILL_BASIC)
+	min_skill = list(SKILL_EVA    = SKILL_BASIC,
+					SKILL_MEDICAL = SKILL_BASIC,
+					SKILL_COMBAT  = SKILL_ADEPT,
+					SKILL_WEAPONS = SKILL_ADEPT,
+					SKILL_ANATOMY = SKILL_BASIC)
 
-	max_skill = list(   SKILL_MEDICAL      = SKILL_MAX,
-						SKILL_COMBAT       = SKILL_MAX,
-						SKILL_WEAPONS      = SKILL_MAX,
-	                    SKILL_CHEMISTRY    = SKILL_MAX)
+	max_skill = list(SKILL_MEDICAL     = SKILL_MAX,
+					SKILL_COMBAT       = SKILL_MAX,
+					SKILL_WEAPONS      = SKILL_MAX,
+					SKILL_CHEMISTRY    = SKILL_MAX)
 
 	allowed_branches = list(/datum/mil_branch/fleet)
 	allowed_ranks = list(

--- a/maps/torch/job/hestia_jobs.dm
+++ b/maps/torch/job/hestia_jobs.dm
@@ -140,16 +140,16 @@
 	skill_points = 24
 	minimum_character_age = list(SPECIES_HUMAN = 20)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/infantry/combat_medic
-	min_skill = list(SKILL_ANATOMY         = SKILL_ADEPT,
-						SKILL_MEDICAL      = SKILL_ADEPT,
-						SKILL_COMBAT       = SKILL_ADEPT,
-						SKILL_WEAPONS      = SKILL_ADEPT)
+	min_skill = list(   SKILL_EVA     = SKILL_BASIC,
+	                    SKILL_MEDICAL = SKILL_BASIC,
+						SKILL_COMBAT  = SKILL_ADEPT,
+						SKILL_WEAPONS = SKILL_ADEPT,
+	                    SKILL_ANATOMY = SKILL_BASIC)
 
-	max_skill = list(	SKILL_COMBAT       = SKILL_MAX,
+	max_skill = list(   SKILL_MEDICAL      = SKILL_MAX,
+						SKILL_COMBAT       = SKILL_MAX,
 						SKILL_WEAPONS      = SKILL_MAX,
-						SKILL_EVA		   = SKILL_MAX,
-						SKILL_MEDICAL      = SKILL_MAX,
-						SKILL_ANATOMY      = SKILL_MAX)
+	                    SKILL_CHEMISTRY    = SKILL_MAX)
 
 	allowed_branches = list(/datum/mil_branch/fleet)
 	allowed_ranks = list(

--- a/maps/torch/job/outfits/hestia_outfits.dm
+++ b/maps/torch/job/outfits/hestia_outfits.dm
@@ -23,4 +23,4 @@
 	uniform = /obj/item/clothing/under/solgov/utility/army/medical
 	id_type = /obj/item/weapon/card/id/torch/crew/infantry/infmed
 	pda_type = /obj/item/modular_computer/pda/medical
-	l_ear = /obj/item/device/radio/headset/infmed
+	l_ear = /obj/item/device/radio/headset/infantry

--- a/maps/torch/structures/closets.dm
+++ b/maps/torch/structures/closets.dm
@@ -155,14 +155,21 @@
 /obj/structure/closet/secure_closet/infmed/WillContain()
 	return list(
 		/obj/item/weapon/storage/belt/holster/security/tactical,
+		/obj/item/weapon/reagent_containers/syringe,
+		/obj/item/weapon/storage/firstaid/combat,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/weapon/material/knife/combat,
+		/obj/item/bodybag/rescue,
+		/obj/item/bodybag/rescue,
 		/obj/item/clothing/glasses/tacgoggles,
 		/obj/item/weapon/storage/belt/utility,
 		/obj/item/weapon/weldpack/bigwelder,
 		/obj/item/weapon/storage/box/flares,
 		/obj/item/clothing/suit/armor/pcarrier/light/sol,
 		/obj/item/gunbox/infmed,
+		/obj/item/weapon/defibrillator/compact,
+		/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
+		/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
 		/obj/item/gunbox/sidearm/infantry
 		)
 


### PR DESCRIPTION
Going to defer this one to Carl.

This PR gives combat medics a combat medkit, two syringes and bottles of dyloevene and inaprovaline, along with a few rescue bags and a defib.

This PR removes their medical radio access and their ability to acquire surgery skills, while nerfing their point-pool somewhat, though it is still perfectly viable to take athletics, EVA, medical and combat skills all at once.