### PR TITLE
Taser Carbines Tweak

### DIFF
--- a/code/modules/boh_misc/boxes.dm
+++ b/code/modules/boh_misc/boxes.dm
@@ -87,7 +87,7 @@
 	var/list/options = list()
 	options["Ballistic - SMG"] = list(/obj/item/weapon/gun/projectile/automatic/sec_smg/less_lethal,/obj/item/weapon/storage/box/ammo/smg_frang)
 	options["Ballistic - Beanbag Shotgun"] = list(/obj/item/weapon/gun/projectile/shotgun/pump/beanbag,/obj/item/weapon/storage/box/ammo/shotgunammo/birdshot/full)
-	options["Stun - Taser Carbine"] = list(/obj/item/weapon/gun/energy/taser/carbine/ext)
+	options["Stun - Stun Rifle"] = list(/obj/item/weapon/gun/energy/stunrevolver/rifle)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
 	if(src && choice)
 		var/list/things_to_spawn = options[choice]

--- a/code/modules/boh_misc/firearms.dm
+++ b/code/modules/boh_misc/firearms.dm
@@ -200,15 +200,6 @@
 	return ..()
 
 /////////
-// Extended Taser Carbine
-/////////
-/obj/item/weapon/gun/energy/taser/carbine/ext
-	name = "modified electrolaser carbine"
-	desc = "The NT Mk44 NL is a high capacity gun used for non-lethal takedowns. It can switch between high and low intensity stun shots. \
-	This one has a larger capacity."
-	max_shots = 24
-
-/////////
 // EPP
 /////////
 /obj/item/weapon/gun/energy/pulse_rifle/pistol/epp

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -346,6 +346,7 @@
 	},
 /obj/structure/table/rack,
 /obj/item/weapon/gun/energy/ionrifle/small,
+/obj/item/weapon/gun/energy/ionrifle,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "aaB" = (
@@ -2335,6 +2336,7 @@
 	health = 1e+006
 	},
 /obj/item/weapon/storage/box/frags,
+/obj/item/weapon/storage/box/stinger,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "aee" = (
@@ -9759,7 +9761,8 @@
 /obj/machinery/light,
 /obj/structure/window/reinforced,
 /obj/structure/table/rack,
-/obj/item/weapon/storage/box/stinger,
+/obj/item/weapon/gun/energy/taser/carbine,
+/obj/item/weapon/gun/energy/taser/carbine,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "aqJ" = (


### PR DESCRIPTION
Following some comments on the Discord, I decided to look into the issue of Taser Carbines being overpowered.

Taser carbines are well-documented as being very powerful in a game ruled by stun combat (Groin shots are instant floorings and the agony damage they deal is no joke). This PR removes them from the SEC primary gunbox and adds the Electrode Rifle in their place. Two taser carbines were added into SECarm aswell.

Furthermore, the BOH variant of the Taser Carbine was removed. 24 Shots felt uneeded and a bit in the big side. I would suggest a rifle-sized smartgun or an energy SMG if we are going with laser primaries for security, and potentially re-enabling smartguns as a secondary alternative, though I think this should be deferred to Carl's judgement.

Also adds one ion rifle to the SEC's armory because those are heavily lacking in the Dagon.