### PR TITLE
Slightly Lowers Engineering Age Minimum

### DIFF
--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -55,7 +55,7 @@
 	supervisors = "the Chief Engineer"
 	economic_power = 5
 	minimal_player_age = 0
-	minimum_character_age = list(SPECIES_HUMAN = 20)
+	minimum_character_age = list(SPECIES_HUMAN = 19)
 	alt_titles = list(
 		"Engine Technician",
 		"Damage Control Technician",

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -55,7 +55,7 @@
 	supervisors = "the Chief Engineer"
 	economic_power = 5
 	minimal_player_age = 0
-	minimum_character_age = list(SPECIES_HUMAN = 24)
+	minimum_character_age = list(SPECIES_HUMAN = 20)
 	alt_titles = list(
 		"Engine Technician",
 		"Damage Control Technician",
@@ -168,7 +168,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	minimal_player_age = 0
-	minimum_character_age = list(SPECIES_HUMAN = 25)
+	minimum_character_age = list(SPECIES_HUMAN = 22)
 	supervisors = "the Chief Engineer and the Corporate Liaison."
 	selection_color = "#5b4d20"
 	economic_power = 6


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
While looking through the jobs, I found it extremely strange that out of every department, for some reason Engineers must all be 25 or older. For a military this is extremely strange because it means we have E-3s at 25 which would be the age of something more like a staff sergeant or PO1. The age minimum has been lowered to 19, the average age of an E-3 in the US Military.

I also slightly lowered the robotics age to 22, the average age of an E-5 in the US military. This should more accurately represent our ranks in game to ages.

The engineer trainee job on the other hand still has its age limit at 18, as they are an E-2 or new E-3 learning the ropes.