### PR TITLE
Cargo order additions

### DIFF
--- a/code/datums/supplypacks/galley.dm
+++ b/code/datums/supplypacks/galley.dm
@@ -91,6 +91,28 @@
 	containername = "emergency rations"
 	supply_method = /decl/supply_method/randomized
 
+/decl/hierarchy/supply_pack/galley/rations/vegan
+	name = "Emergency - Vegetarian MREs"
+	contains = list(/obj/item/weapon/storage/mre/menu9 = 6)
+	cost = 30
+	containertype = /obj/structure/closet/crate/freezer
+	containername = "emergency rations"
+
+/decl/hierarchy/supply_pack/galley/rations/protein
+	name = "Emergency - Protein MREs"
+	contains = list(/obj/item/weapon/storage/mre/menu10 = 6)
+	cost = 30
+	containertype = /obj/structure/closet/crate/freezer
+	containername = "emergency rations"
+
+/decl/hierarchy/supply_pack/galley/rations/crayon
+	name = "Emergency - Marine MREs"
+	contains = list(/obj/item/weapon/storage/mre/menu11 = 6)
+	cost = 30
+	containertype = /obj/structure/closet/crate/freezer
+	containername = "emergency rations"
+	contraband = 1
+
 /decl/hierarchy/supply_pack/galley/party
 	name = "Bar - Party equipment"
 	contains = list(

--- a/code/datums/supplypacks/materials.dm
+++ b/code/datums/supplypacks/materials.dm
@@ -114,6 +114,12 @@
 	cost = 20
 	containername = "diamond sheets crate"
 
+/decl/hierarchy/supply_pack/materials/platinum10
+	name = "10 platinum sheets"
+	contains = list(/obj/item/stack/material/platinum/ten)
+	cost = 20
+	containername = "platinum sheets crate"
+
 //wood zone
 /decl/hierarchy/supply_pack/materials/wood50
 	name = "50 wooden planks"


### PR DESCRIPTION
Adds Vegan MRE's, Protein MRE's and a shipment of 10 platinum sheets to the Supply ordering program.
Also adds the ability to order crayon MRE's if the console is hacked.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->