### PR TITLE
[SPEEDMERGE] I HATE JOB CODE I HATE JOB CODE

### DIFF
--- a/maps/away/ascent/ascent_jobs.dm
+++ b/maps/away/ascent/ascent_jobs.dm
@@ -16,7 +16,7 @@
 		//datum/job/submap/ascent/control_mind,
 		/datum/job/submap/ascent/msq,
 		/datum/job/submap/ascent/msw,
-		/datum/job/submap/tiro
+		/datum/job/submap/ascent/tiro
 	)
 	call_webhook = WEBHOOK_SUBMAP_LOADED_ASCENT
 
@@ -247,7 +247,7 @@
 					SKILL_MEDICAL = SKILL_BASIC)
 	requires_supervisor = "Ascent Gyne"
 
-/datum/job/submap/tiro //We do this snowflake style because otherwise the species throws a fit. DO NOT SUBTYPE THIS TO ASCENT!!!!
+/datum/job/submap/ascent/tiro //We do this snowflake style because otherwise the species throws a fit. DO NOT SUBTYPE THIS TO ASCENT!!!!
 	title = "Ascent Tiro"
 	supervisors = "the Khaarmani."
 	total_positions = 2
@@ -260,20 +260,10 @@
 	loadout_allowed = TRUE
 	skill_points = 50 //Just *about* the # for a Roboticst at default, counting their preset skills. We have no min-skill level for this role since anyone could be deemed "interesting".
 	min_skill = list()
-	var/requires_supervisor = "Ascent Gyne"
+	requires_supervisor = "Ascent Gyne"
+	set_species_on_join = null
 
-/*/datum/job/submap/tiro/is_position_available() //Doesn't work. If you can fix it, uncomment this.
-	..()
-	if(. && requires_supervisor)
-		for(var/mob/M in GLOB.player_list)
-			if(!M.client || !M.mind || !M.mind.assigned_job || M.mind.assigned_job.title != requires_supervisor)
-				continue
-			var/datum/job/submap/ascent/ascent_job = M.mind.assigned_job
-			if(istype(ascent_job) && ascent_job.owner == owner)
-				return TRUE
-		return FALSE*/
-
-/datum/job/submap/tiro/equip(var/mob/living/carbon/human/H) //You have no FFFFUCKING idea how happy I am that this works now FUCK
+/datum/job/submap/ascent/tiro/equip(var/mob/living/carbon/human/H) //You have no FFFFUCKING idea how happy I am that this works now FUCK
 	..()
 	qdel(H.internal_organs_by_name[BP_LUNGS]) //Delete the old lungs
 	H.internal_organs_by_name[BP_LUNGS] = new /obj/item/organ/internal/lungs/tirolungs //Install new ones

--- a/maps/away/ascent/ascent_jobs.dm
+++ b/maps/away/ascent/ascent_jobs.dm
@@ -262,7 +262,7 @@
 	min_skill = list()
 	var/requires_supervisor = "Ascent Gyne"
 
-/datum/job/submap/tiro/is_position_available()
+/*/datum/job/submap/tiro/is_position_available() //Doesn't work. If you can fix it, uncomment this.
 	..()
 	if(. && requires_supervisor)
 		for(var/mob/M in GLOB.player_list)
@@ -271,7 +271,7 @@
 			var/datum/job/submap/ascent/ascent_job = M.mind.assigned_job
 			if(istype(ascent_job) && ascent_job.owner == owner)
 				return TRUE
-		return FALSE
+		return FALSE*/
 
 /datum/job/submap/tiro/equip(var/mob/living/carbon/human/H) //You have no FFFFUCKING idea how happy I am that this works now FUCK
 	..()


### PR DESCRIPTION
## About The Pull Request
Removes the Gyne requirement for Tiros because _something_ about it just broke the role entirely.
## Why It's Good For The Game

## Did You Test It?

## Authorship

## Changelog

:cl:
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->