### PR TITLE
buffs breacher suits

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -3,17 +3,9 @@
 	desc = "A makeshift Unathi battle-rig. Looks like a fish, moves like a fish, steers like a cow."
 	suit_type = "\improper makeshift breacher rig"
 	icon_state = "breacher_rig_cheap"
-	armor = list(
-		melee = ARMOR_MELEE_MAJOR,
-		bullet = ARMOR_BALLISTIC_RIFLE,
-		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_RESISTANT,
-		bomb = ARMOR_BOMB_RESISTANT,
-		bio = ARMOR_BIO_SHIELDED,
-		rad = ARMOR_RAD_MINOR
-		)
+	armor = 0
 	emp_protection = -20
-	online_slowdown = 6
+	online_slowdown = 3
 	offline_slowdown = 10
 	offline_vision_restriction = TINT_BLIND
 	allowed = list(/obj/item/weapon/storage/)
@@ -28,25 +20,96 @@
 	desc = "An (outwardly) authentic Unathi breacher chassis. Huge, bulky and absurdly heavy. It must be like wearing a tank."
 	suit_type = "breacher chassis"
 	icon_state = "breacher_rig"
-	armor = list(
-		melee = ARMOR_MELEE_VERY_HIGH,
-		bullet = ARMOR_BALLISTIC_AP,
-		laser = ARMOR_LASER_MAJOR,
-		energy = ARMOR_ENERGY_STRONG,
-		bomb = ARMOR_BOMB_RESISTANT,
-		bio = ARMOR_BIO_SHIELDED,
-		rad = ARMOR_RAD_SMALL)
+	chest_type = /obj/item/clothing/suit/space/rig/unathi/fancy
+	helm_type = /obj/item/clothing/head/helmet/space/rig/unathi/fancy
+	boot_type = /obj/item/clothing/shoes/magboots/rig/unathi/fancy
+	glove_type = /obj/item/clothing/gloves/rig/unathi/fancy
 
 /obj/item/clothing/head/helmet/space/rig/unathi
 	species_restricted = list(SPECIES_UNATHI, SPECIES_OLDUNATHI)
 	force = 5
 	sharp = 1 //poking people with the horn
-
+	armor = list(
+		melee = ARMOR_MELEE_VERY_HIGH,
+		bullet = ARMOR_BALLISTIC_AP,
+		laser = ARMOR_LASER_RIFLES,
+		energy = ARMOR_ENERGY_RESISTANT,
+		bomb = ARMOR_BOMB_RESISTANT,
+		bio = ARMOR_BIO_SHIELDED,
+		rad = ARMOR_RAD_SHIELDED
+		)
 /obj/item/clothing/suit/space/rig/unathi
 	species_restricted = list(SPECIES_UNATHI, SPECIES_OLDUNATHI)
-
+	armor = list(
+		melee = ARMOR_MELEE_MAJOR,
+		bullet = ARMOR_BALLISTIC_RIFLE,
+		laser = ARMOR_LASER_MAJOR,
+		energy = ARMOR_ENERGY_RESISTANT,
+		bomb = ARMOR_BOMB_RESISTANT,
+		bio = ARMOR_BIO_SHIELDED,
+		rad = ARMOR_RAD_SHIELDED
+		)
 /obj/item/clothing/shoes/magboots/rig/unathi
 	species_restricted = list(SPECIES_UNATHI, SPECIES_OLDUNATHI)
-
+	armor = list(
+		melee = ARMOR_MELEE_RESISTANT,
+		bullet = ARMOR_BALLISTIC_RESISTANT,
+		laser = ARMOR_LASER_HANDGUNS,
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_PADDED,
+		bio = ARMOR_BIO_SHIELDED,
+		rad = ARMOR_RAD_SHIELDED
+		)
 /obj/item/clothing/gloves/rig/unathi
 	species_restricted = list(SPECIES_UNATHI, SPECIES_OLDUNATHI)
+	armor = list(
+		melee = ARMOR_MELEE_RESISTANT,
+		bullet = ARMOR_BALLISTIC_RESISTANT,
+		laser = ARMOR_LASER_HANDGUNS,
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_PADDED,
+		bio = ARMOR_BIO_SHIELDED,
+		rad = ARMOR_RAD_SHIELDED
+		)
+/obj/item/clothing/head/helmet/space/rig/unathi/fancy
+	armor = list(
+		melee = ARMOR_MELEE_SHIELDED,
+		bullet = ARMOR_BALLISTIC_HEAVY,
+		laser = ARMOR_LASER_HEAVY,
+		energy = ARMOR_ENERGY_SHIELDED,
+		bomb = ARMOR_BOMB_SHIELDED,
+		bio = ARMOR_BIO_SHIELDED,
+		rad = ARMOR_RAD_SHIELDED
+		)
+/obj/item/clothing/suit/space/rig/unathi/fancy
+	armor = list(
+		melee = ARMOR_MELEE_VERY_HIGH,
+		bullet = ARMOR_BALLISTIC_AP,
+		laser = ARMOR_LASER_RIFLES,
+		energy = ARMOR_ENERGY_STRONG,
+		bomb = ARMOR_BOMB_SHIELDED,
+		bio = ARMOR_BIO_SHIELDED,
+		rad = ARMOR_RAD_SHIELDED
+		)
+
+/obj/item/clothing/shoes/magboots/rig/unathi/fancy
+	armor = list(
+		melee = ARMOR_MELEE_MAJOR,
+		bullet = ARMOR_BALLISTIC_RIFLE,
+		laser = ARMOR_LASER_MAJOR,
+		energy = ARMOR_ENERGY_RESISTANT,
+		bomb = ARMOR_BOMB_SHIELDED,
+		bio = ARMOR_BIO_SHIELDED,
+		rad = ARMOR_RAD_SHIELDED
+		)
+
+/obj/item/clothing/gloves/rig/unathi/fancy
+	armor = list(
+		melee = ARMOR_MELEE_MAJOR,
+		bullet = ARMOR_BALLISTIC_RIFLE,
+		laser = ARMOR_LASER_MAJOR,
+		energy = ARMOR_ENERGY_RESISTANT,
+		bomb = ARMOR_BOMB_SHIELDED,
+		bio = ARMOR_BIO_SHIELDED,
+		rad = ARMOR_RAD_SHIELDED
+		)


### PR DESCRIPTION
## About The Pull Request
First, breacher suits have half the slowdown. 3's still a lot. Next, the default breacher's torso has been buffed in laser armor and rad armor to be in line with the infantry suit. Lastly, its armor values are now higher on the helmet, and lower on the arms and legs.
## Why It's Good For The Game
First off, the breachers fucking suck. The makeshift one is supposed to be a worse version of the good one, yeah, but even the good one fucking sucks. The breacher should be cool, and maybe there's simple ways to make it cooler without making it op. It doesn't need to be as good as an infantry suit, but it should be competitive with other found rigs, so the slowdown is reduced. As for the helmet and limb guards, it's a little bit because it'd be neat for balance (It's frustrating to get instantly melted by a headshot so buffing armor there would be good, but being able to cronch their legs would mean breacher guys don't feel invincible) and a little because it'd make sense for Unathi, because they can regrow limbs but not brains. Also the head of the breacher suit was already special because it has a horn for making headbutting better but it's still a bad idea, more armor there makes it a less stupid idea.

Big breacher's admin only right now, so not sure what to do with it really, but I changed it in line with the other so it's still better.
## Did You Test It?
Yes
## Authorship
Rock
## Changelog

:cl:
tweak:breacher suit slows you down less and has a tougher helmet but weaker limbs.
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->