### PR TITLE
Ascent Ship Turrets

### DIFF
--- a/maps/away/ascent/ascent-1.dmm
+++ b/maps/away/ascent/ascent-1.dmm
@@ -2990,6 +2990,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/subdeck_center)
+"qA" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/subdeck_north)
 "sH" = (
 /obj/machinery/door/airlock/ascent,
 /turf/simulated/floor/tiled/ascent,
@@ -3033,6 +3037,10 @@
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/tiroarea)
+"vr" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/subdeck_south)
 "wL" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -3112,6 +3120,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/tiroarea)
+"zU" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/subdeck_center)
 "BA" = (
 /obj/effect/catwalk_plated/ascent,
 /obj/structure/cable/cyan{
@@ -3377,6 +3389,10 @@
 /obj/effect/floor_decal/corner/paleblue,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/subdeck_hospital)
+"RP" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/subdeck_atmos)
 "SL" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -3412,6 +3428,10 @@
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/tiroarea)
+"UU" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/subdeck_south_spike)
 "Vh" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -6288,6 +6308,7 @@ aa
 aa
 aa
 aa
+UU
 aa
 aa
 aa
@@ -6299,8 +6320,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UU
 aa
 aa
 aa
@@ -8236,7 +8256,7 @@ aa
 aa
 aa
 aa
-aa
+qA
 ax
 ax
 ax
@@ -8256,7 +8276,7 @@ dw
 bO
 bO
 bO
-aa
+vr
 aa
 aa
 aa
@@ -9086,7 +9106,7 @@ aa
 aa
 aa
 aa
-aa
+RP
 aa
 aa
 aR
@@ -9235,7 +9255,7 @@ af
 aa
 aa
 aa
-aa
+zU
 aa
 aa
 aa
@@ -9935,7 +9955,7 @@ aa
 aa
 aa
 aa
-aa
+RP
 aR
 aR
 aR

--- a/maps/away/ascent/ascent-2.dmm
+++ b/maps/away/ascent/ascent-2.dmm
@@ -4355,9 +4355,6 @@
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/aft_starboard_jut)
-"mg" = (
-/turf/space,
-/area/ship/ascent/fore_starboard_jut)
 "mn" = (
 /obj/effect/catwalk_plated/ascent,
 /obj/structure/cable/cyan{
@@ -4440,6 +4437,7 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
 "oF" = (
+/obj/machinery/porta_turret/mantid,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
 "oL" = (
@@ -10738,7 +10736,7 @@ aa
 aa
 aa
 aa
-mg
+aa
 cL
 CA
 as

--- a/maps/away/ascent/ascent-2.dmm
+++ b/maps/away/ascent/ascent-2.dmm
@@ -4309,6 +4309,10 @@
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
+"kI" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/fore_starboard_jut)
 "lb" = (
 /obj/effect/catwalk_plated/ascent,
 /obj/structure/cable/cyan{
@@ -4435,6 +4439,9 @@
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
+"oF" = (
+/turf/simulated/floor/ascent,
+/area/ship/ascent/fore_starboard_prow)
 "oL" = (
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/hydroponics_starboard)
@@ -4497,6 +4504,10 @@
 /obj/item/weapon/reagent_containers/dropper,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
+"qZ" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/fore_port_spike)
 "rb" = (
 /turf/simulated/floor/ascent,
 /area/ship/ascent/aft_starboard_jut)
@@ -4574,6 +4585,10 @@
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/aft_starboard_jut)
+"wJ" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/fore_port_prow)
 "wM" = (
 /obj/effect/catwalk_plated/ascent,
 /obj/structure/cable/cyan{
@@ -4614,6 +4629,12 @@
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
+"yv" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent{
+	initial_gas = newlist()
+	},
+/area/ship/ascent/fore_port_prow)
 "yx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4630,6 +4651,10 @@
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_jut)
+"yS" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/aft_starboard_jut)
 "yU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -4774,6 +4799,12 @@
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
+"FE" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent{
+	initial_gas = newlist()
+	},
+/area/ship/ascent/fore_hallway)
 "FO" = (
 /obj/structure/bed/chair/padded/purple/ascent{
 	dir = 1
@@ -4785,6 +4816,7 @@
 /obj/structure/window/phoronreinforced{
 	dir = 4
 	},
+/obj/machinery/porta_turret/mantid,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
 "Gl" = (
@@ -4816,6 +4848,7 @@
 	dir = 8
 	},
 /obj/structure/window/phoronreinforced,
+/obj/machinery/porta_turret/mantid,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
 "If" = (
@@ -4973,6 +5006,12 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_jut)
+"OV" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent{
+	initial_gas = newlist()
+	},
+/area/ship/ascent/wing_starboard)
 "OZ" = (
 /obj/machinery/mineral/unloading_machine{
 	color = "PURPLE";
@@ -5064,6 +5103,12 @@
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/shuttle_starboard)
+"Su" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent{
+	initial_gas = newlist()
+	},
+/area/ship/ascent/fore_starboard_jut)
 "TL" = (
 /obj/effect/catwalk_plated/ascent,
 /obj/structure/cable/cyan{
@@ -5075,6 +5120,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_jut)
+"TM" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent{
+	initial_gas = newlist()
+	},
+/area/ship/ascent/aft_starboard_jut)
 "TN" = (
 /obj/structure/window/phoronreinforced{
 	dir = 1
@@ -5135,6 +5186,12 @@
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
+"Vw" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent{
+	initial_gas = newlist()
+	},
+/area/ship/ascent/shuttle_port)
 "Vx" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -5213,6 +5270,10 @@
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
+"YB" = (
+/obj/machinery/porta_turret/mantid,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/shuttle_port)
 "Zh" = (
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_starboard_jut)
@@ -7998,6 +8059,7 @@ aa
 aa
 aa
 aa
+qZ
 aa
 aa
 aa
@@ -8009,8 +8071,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+qZ
 aa
 aa
 aa
@@ -9587,13 +9648,13 @@ aA
 cu
 av
 aa
+FE
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+FE
 aa
 bz
 hr
@@ -9946,7 +10007,7 @@ aa
 aa
 aa
 aa
-aa
+oF
 ah
 ah
 ah
@@ -9966,7 +10027,7 @@ hG
 cy
 cy
 cy
-aa
+wJ
 aa
 aa
 aa
@@ -10798,7 +10859,7 @@ aa
 aa
 aa
 aa
-mg
+kI
 ac
 ac
 ah
@@ -10820,7 +10881,7 @@ cv
 cv
 cv
 cy
-aa
+wJ
 aa
 aa
 aa
@@ -11552,7 +11613,7 @@ cv
 hc
 ic
 dT
-aa
+yv
 cN
 je
 cQ
@@ -11645,7 +11706,7 @@ aa
 aa
 aa
 aa
-aa
+Su
 ac
 ac
 ac
@@ -12049,7 +12110,7 @@ iS
 gT
 cN
 cN
-XM
+Vw
 aa
 aa
 aa
@@ -12264,7 +12325,7 @@ MY
 ab
 ab
 Qz
-qG
+kI
 ah
 as
 as
@@ -12419,7 +12480,7 @@ cN
 XM
 iX
 cN
-aa
+YB
 aa
 aa
 aa
@@ -13029,7 +13090,7 @@ cN
 XM
 XM
 cN
-aa
+YB
 aa
 aa
 aa
@@ -13240,7 +13301,7 @@ Nv
 ab
 ab
 Qz
-na
+yS
 ag
 an
 fW
@@ -13391,7 +13452,7 @@ jc
 jl
 cN
 cN
-XM
+Vw
 aa
 aa
 aa
@@ -13841,7 +13902,7 @@ aa
 aa
 aa
 aa
-aa
+TM
 aj
 aj
 aj
@@ -13870,7 +13931,7 @@ ek
 bI
 da
 ag
-aa
+OV
 cN
 jb
 cQ
@@ -14822,7 +14883,7 @@ aa
 aa
 aa
 aa
-aa
+TM
 aj
 aj
 aj


### PR DESCRIPTION
*Adds a variety of Ascent Anti-Boarding turrets to the Seedship and its shuttles. nothing overly excessive.

*The Ascent Ship lacked Anti-Boarding turrets to prevent lazy boarding, also makes boarding shuttles a tiny bit harder.

#Worksonmymachine

