### PR TITLE
reduces tiro skill points

### DIFF
--- a/maps/away/ascent/ascent_jobs.dm
+++ b/maps/away/ascent/ascent_jobs.dm
@@ -258,7 +258,7 @@
 	blacklisted_species = list(SPECIES_VOXPARIAH, SPECIES_VOX, SPECIES_VOX_ARMALIS, SPECIES_ADHERENT)
 	whitelisted_species = null
 	loadout_allowed = TRUE
-	skill_points = 50 //Just *about* the # for a Roboticst at default, counting their preset skills. We have no min-skill level for this role since anyone could be deemed "interesting".
+	skill_points = 36
 	min_skill = list()
 	requires_supervisor = "Ascent Gyne"
 	set_species_on_join = null


### PR DESCRIPTION
## About The Pull Request
This reduces Tiro skill points from 50 to 36, (from 58 to 44 after the general job skill bonuses) the default for away maps like the bearcat and verne. 
## Why It's Good For The Game
58 skill points isn't just the highest skill point value in the game, it's 10 higher than the second highest. Why should they have this? Because, according to the code comment. it's equivalent to what roboticists can afford. first off, this is very misleading- roboticists have an incredibly high skill point total anyways. Second off, the difference is that the Tiro can spend those skillpoints on whatever they want, such as getting master combat, master weapons, AND master athletics, and still having 12 points left over. Even the COS can't do that. The brig chief can barely afford that, and they have the most spare skillpoints of any job on the dagon as well as combat skills.

Why should a tiro have this many points? There isn't much of a reason. A tiro could be anyone? Well, that's the theory with the bearcat and escape pod, pod survivors can be anyone, but they don't have 58 skillpoints. They have 44, and 44 is still quite a bit. 

Why SHOULDN'T they have this many points? Well, there's a few reasons, it being horribly imbalanced is one thing, but With all the free points, and the suits, and not having to deal with the complexities of being an alate, Tiro is far more appealing of a role than alate. and that isn't inherently a bad thing, but the ascent isn't just a bunch of humans in purple suits, and with a skillspread like this, they can do everything an alate can just fine.
 
If 44 points isn't enough for your tiro then that's a skill issue. as in, skills are too expensive, and we should fix it for everyone, or at least every offship role, and not just for the tiro.
## Did You Test It?
1. look at that code and tell me it needs to be tested. LOOK AT IT
2.Yes, actually, I did test it!
## Authorship
Rock
## Changelog

:cl:
tweak: Tiros have less skill points.
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->