### PR TITLE
Irkalla rises and starts reflavoring stuff part one: Tiro and Par suits. RUN

### DIFF
--- a/code/modules/ascent/ascent_rigs.dm
+++ b/code/modules/ascent/ascent_rigs.dm
@@ -591,7 +591,7 @@
 		SPECIES_OLDUNATHI = 'icons/mob/species/unathi/generated/onmob_head_unathi.dmi'
 		)
 /obj/item/clothing/suit/space/rig/mantid/tiro
-	desc = "A Mantid exosuit designed for a Humanoid. Offers superb protection."
+	desc = "A Mantid exosuit designed for a Humanoid. Offers good protection."
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_OLDUNATHI)
 	allowed = list(
 		/obj/item/clustertool,
@@ -626,13 +626,13 @@
 		SPECIES_UNATHI = 'icons/mob/species/unathi/generated/onmob_suit_unathi.dmi'
 		)
 /obj/item/clothing/shoes/magboots/rig/mantid/tiro
-	desc = "Feels like you're stepping on a cloud."
+	desc = "Ascent magnetic boots readapted for humanoids."
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_OLDUNATHI)
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'icons/mob/species/unathi/generated/onmob_feet_unathi.dmi',
 		)
 /obj/item/clothing/gloves/rig/mantid/tiro
-	desc = "Highly advanced gloves that bind themselves around your fingers. Despite this, it feels as flexible as air."
+	desc = "Ascent gloves refitted to suit a humanoid. Quite advanced and made out of the same nanosilica composite like most of their armor."
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_OLDUNATHI)
 	sprite_sheets = list(
 		SPECIES_VOX = 'icons/mob/species/vox/onmob_hands_vox.dmi',
@@ -642,8 +642,8 @@
 		)
 
 /obj/item/weapon/rig/mantid/tiro/elite
-	name = "par exosuit"
-	desc = "The exosuit of a Gyne's Par, an esteemed Tiro who has earned their favor through efficiency and loyalty. An armor of this quality has few equals."
+	name = "Auctus exosuit"
+	desc = "A somehwat more advanced variant of the tiro suit Ascent employ on their integrated humanoids. The auctus suit features somewhat improved armor plating and more modules such as an integrated particle projector."
 	icon_state = "par_voidsuit"
 	chest_type = /obj/item/clothing/suit/space/rig/mantid/tiro/elite
 	helm_type = /obj/item/clothing/head/helmet/space/rig/mantid/tiro/elite
@@ -676,7 +676,7 @@
 	)
 
 /obj/item/clothing/head/helmet/space/rig/mantid/tiro/elite
-	desc = "The helmet of the Gyne's Par. Comfortable as air."
+	desc = "The helmet of the auctus exosuit. Features somehwat advanced optics and good armor."
 
 /obj/item/clothing/suit/space/rig/mantid/tiro/elite
-	desc = "The exosuit of the Gyne's Par. Little else can compare to its protection and prestige, besides perhaps the hatred of Solarians towards them."
+	desc = "The chestpiece of an auctus exosuit. Features improved nanosilica composite armor plating almost on par with that of an alate exosuit."


### PR DESCRIPTION

About The Pull Request
This reflavors the Tiro equipment, part of a series to make them more into COMBINE or ADVENT troopers instead of what it was before. Will change later (not today) the description for the particle magnum as well and alter the "par" sigil to be something else.

Par means "equal". Somehow I was not aware of that. A gynes Par means a gynes equal. Sounds very erpy to me, again keep that stuff to discord. That is on par of doing.. wait I get it.

Auctus means  "augmented"/enhanced. The suit already got a few nerfs in so its more on par with Alate suits. Could still be changed by somebody that knows balancing better than I do to make it weaker. The suit is basicly now an "augmented" Tiro suit. Mentions of being the Gynes personal bodyguard are squashed on the suit. They are now more akin to combine elite or advent officers. Which fits them better if you ask me but dunno. Just thought this would suit it better. 

Why It's Good For The Game
Swear to god I am going to beat Tiros with a crowbar clustertool if that isnt going to be reflavored into something more akin to COMBINE or ADVENT with the item descriptions. That and the bloody alate that always puts ~ at the end of every sentence. I hear another tilde from you and 18 Wet Waters is going to kick the living crap out of you with a crowbar clustertool. You know who you are.

Did You Test It?
No, I just changed description names. 

Authorship
Irkalla Epsilon

Changelog
🆑
tweak: Combinefies/Adherentifies Ascent Tiros and makes them less ERPy with their gears flavortext. This is a multi step series. Ascent Par suit to Auctus. Pars are now "Auctus" or "Augmented". No more bodyguard flavortext on this particular suit. To do: Change particle magnum and par emblem to something similar. Fuck coding. I go back make materials and shit.
/🆑
