### PR TITLE
Pistol standard changes

### DIFF
--- a/code/modules/boh_misc/firearms.dm
+++ b/code/modules/boh_misc/firearms.dm
@@ -8,7 +8,7 @@
 	magazine_type = /obj/item/ammo_magazine/pistol/double/pepperball
 	fire_sound = 'sound/weapons/gunshot/pistol_mk59.ogg'
 	jam_chance = 5 //Cheap firearm. Chance of jamming
-	fire_delay = 2 // Fires faster than usual
+	fire_delay = 3.5 // Fires faster than usual
 	damage_mult = 0.9 // Damages a bit less than peers.
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2, TECH_ESOTERIC = -1) //bandaid fix to prevent r&d from getting free esoterics
 

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -35,7 +35,7 @@
 	item_state = "secgundark"
 	safety_icon = "safety"
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2)
-	fire_delay = 2.5
+	fire_delay = 4
 	ammo_indicator = TRUE
 
 /obj/item/weapon/gun/projectile/pistol/military/alt
@@ -44,7 +44,6 @@
 	icon_state = "military-alt"
 	safety_icon = "safety"
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2, TECH_ESOTERIC = 8)
-	fire_delay = 8
 
 /obj/item/weapon/gun/projectile/pistol/sec
 	name = "MA-Mk58"


### PR DESCRIPTION
## About The Pull Request
P20 .25->.4 (3 bullets  a second)
MK59 .2->.3 (5 to 3, this is the same as the MK58 funnily enough.)
Removed the military/alt for whatever reason having a different fire delay, which was odd.
## Why It's Good For The Game
I was making my balance assumptions off of the MA-Pariah, but it seems this fire delay is far too fast for the slower pace of Hestia in general, but these numbers are probably a better idea.
They're based off the MA-Swords firerate, though I think that one should get reduced to .25 in automatic, not sure why its .4..
## Did You Test It?
Yeah, numbers work better. P20/MK59 no longer can spam click, I think the FEEL of the guns is worse, but I prefer faster firing guns with lower damage, which is absolutely subjective
## Authorship
Pariah919
## Changelog
:cl:
balance: Standard issue pistols other than the revolver have their firerate decreased, P20 goes from .25->.4, MK59 goes from .2->.3.
/:cl:

