### PR TITLE
SL Sword!! (Oh look, another SL only change from foxy)

### DIFF
--- a/maps/torch/datums/uniforms_marine-corps.dm
+++ b/maps/torch/datums/uniforms_marine-corps.dm
@@ -43,6 +43,12 @@
 
 	dress_extra = list(/obj/item/clothing/head/beret/solgov)
 
+/decl/hierarchy/mil_uniform/marine_corps/noncom
+	name = "Marine Corps NCO"
+	min_rank = 6
+
+	dress_extra = list(/obj/item/weapon/storage/belt/holster/sheath/marine)
+
 /decl/hierarchy/mil_uniform/marine_corps/com //Can only be officers
 	name = "Marine Corps command"
 	departments = COM


### PR DESCRIPTION
## About The Pull Request
Brute force code that allows the SL to get the sword for their Dress uniform. Shouldn't change any role other than SL.
## Why It's Good For The Game
Because this should already be in. Every other NCO role gets it.
## Did You Test It?
Yes. It does what I want it to do. Hopefully it doesn't do anything else.
## Authorship
Me
## Changelog
:cl:
tweak: Gives SL access to the sword
/:cl: