### PR TITLE
Fixes Uniforms

### DIFF
--- a/maps/torch/datums/uniforms_exp_fleet.dm
+++ b/maps/torch/datums/uniforms_exp_fleet.dm
@@ -27,7 +27,7 @@
 
 // Expeditionary Fleet (overrides normal fleet)
 /decl/hierarchy/mil_uniform/fleet
-	name = "Master NTEF outfit"
+	name = "Master Fleet outfit"
 	hierarchy_type = /decl/hierarchy/mil_uniform/fleet
 	branches = list(/datum/mil_branch/fleet)
 
@@ -68,7 +68,7 @@
 	dress_extra_alt = list(/obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/com //Can only be officers
-	name = "NTEF command"
+	name = "Fleet command"
 	departments = COM
 
 	utility_under = /obj/item/clothing/under/solgov/utility/expeditionary/officer/command
@@ -104,8 +104,8 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/command, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/com/seniorofficer
-	name = "NTEF senior command"
-	min_rank = 15
+	name = "Fleet senior command"
+	min_rank = 19
 
 	service_hat = /obj/item/clothing/head/solgov/service/expedition/senior_command
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/command/cdr
@@ -114,23 +114,22 @@
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
 
 /decl/hierarchy/mil_uniform/fleet/com/capt //Can only be officers
-	name = "NTEF captain"
-	min_rank = 16
+	name = "Fleet captain"
+	min_rank = 21
 
 	utility_hat = /obj/item/clothing/head/soft/solgov/expedition/co
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/command/capt
 	dress_hat = /obj/item/clothing/head/solgov/service/expedition/captain
 
 /decl/hierarchy/mil_uniform/fleet/com/flagofficer
-	name = "NTEF flag command"
-	min_rank = 17
+	name = "Fleet flag command"
+	min_rank = 23
 
 	service_over_alt = /obj/item/clothing/suit/storage/solgov/service/fleet/flag
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet/flag
 
 /decl/hierarchy/mil_uniform/fleet/com/flagofficer/adm //Can only be officers
-	name = "NTEF admiral"
-	min_rank = 18
+	name = "Fleet admiral"
 
 	utility_hat = /obj/item/clothing/head/soft/solgov/expedition/co
 
@@ -138,7 +137,7 @@
 	dress_hat = /obj/item/clothing/head/solgov/service/expedition/captain
 
 /decl/hierarchy/mil_uniform/fleet/eng
-	name = "NTEF engineering"
+	name = "Fleet engineering"
 	departments = ENG
 
 	utility_under = /obj/item/clothing/under/solgov/utility/expeditionary/engineering
@@ -165,7 +164,7 @@
 	dress_extra_alt = list(/obj/item/clothing/accessory/cloak/boh/engineering, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/eng/noncom
-	name = "NTEF engineering NCO"
+	name = "Fleet engineering NCO"
 	min_rank = 4
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/senior
@@ -176,7 +175,7 @@
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet
 
 /decl/hierarchy/mil_uniform/fleet/eng/snco
-	name = "NTEF engineering SNCO"
+	name = "Fleet engineering SNCO"
 	min_rank = 7
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/chief
@@ -191,8 +190,8 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/engineering, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/eng/officer
-	name = "NTEF engineering CO"
-	min_rank = 11
+	name = "Fleet engineering CO"
+	min_rank = 16
 
 	utility_under = /obj/item/clothing/under/solgov/utility/expeditionary/officer/engineering
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/expedition/command,
@@ -225,25 +224,25 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/engineering, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/eng/officer/com //Can only be officers
-	name = "NTEF engineering command"
+	name = "Fleet engineering command"
 	departments = ENG|COM
 
 /decl/hierarchy/mil_uniform/fleet/eng/officer/com/seniorofficer
-	name = "NTEF engineering senior command"
-	min_rank = 15
+	name = "Fleet engineering senior command"
+	min_rank = 19
 
 	service_over_alt = /obj/item/clothing/suit/storage/solgov/service/fleet/command
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
 
 /decl/hierarchy/mil_uniform/fleet/eng/officer/com/flagofficer
-	name = "NTEF engineering flag command"
-	min_rank = 17
+	name = "Fleet engineering flag command"
+	min_rank = 23
 
 	service_over_alt = /obj/item/clothing/suit/storage/solgov/service/fleet/flag
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet/flag
 
 /decl/hierarchy/mil_uniform/fleet/sec
-	name = "NTEF security"
+	name = "Fleet security"
 	departments = SEC
 
 	utility_under = /obj/item/clothing/under/solgov/utility/expeditionary/security
@@ -270,7 +269,7 @@
 	dress_extra_alt = list(/obj/item/clothing/accessory/cloak/boh/security, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/sec/noncom
-	name = "NTEF security NCO"
+	name = "Fleet security NCO"
 	min_rank = 4
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/senior
@@ -281,7 +280,7 @@
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet
 
 /decl/hierarchy/mil_uniform/fleet/sec/snco
-	name = "NTEF security SNCO"
+	name = "Fleet security SNCO"
 	min_rank = 7
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/chief
@@ -293,8 +292,8 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/security, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/sec/officer
-	name = "NTEF security CO"
-	min_rank = 11
+	name = "Fleet security CO"
+	min_rank = 16
 
 	utility_under = /obj/item/clothing/under/solgov/utility/expeditionary/officer/security
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/expedition/command,
@@ -327,25 +326,25 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/security, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/sec/officer/com //Can only be officers
-	name = "NTEF security command"
+	name = "Fleet security command"
 	departments = SEC|COM
 
 /decl/hierarchy/mil_uniform/fleet/sec/officer/com/seniorofficer
-	name = "NTEF security senior command"
-	min_rank = 15
+	name = "Fleet security senior command"
+	min_rank = 19
 
 	service_over_alt = /obj/item/clothing/suit/storage/solgov/service/fleet/command
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
 
 /decl/hierarchy/mil_uniform/fleet/sec/officer/com/flagofficer
-	name = "NTEF security flag command"
-	min_rank = 17
+	name = "Fleet security flag command"
+	min_rank = 23
 
 	service_over_alt = /obj/item/clothing/suit/storage/solgov/service/fleet/flag
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet/flag
 
 /decl/hierarchy/mil_uniform/fleet/med
-	name = "NTEF medical"
+	name = "Fleet medical"
 	departments = MED
 
 	utility_under = /obj/item/clothing/under/solgov/utility/expeditionary/medical
@@ -373,7 +372,7 @@
 	dress_extra_alt = list(/obj/item/clothing/accessory/cloak/boh/medical, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/med/noncom
-	name = "NTEF medical NCO"
+	name = "Fleet medical NCO"
 	min_rank = 4
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/senior
@@ -384,7 +383,7 @@
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet
 
 /decl/hierarchy/mil_uniform/fleet/med/snco
-	name = "NTEF medical SNCO"
+	name = "Fleet medical SNCO"
 	min_rank = 7
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/chief
@@ -396,8 +395,8 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/medical, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/med/officer
-	name = "NTEF medical CO"
-	min_rank = 11
+	name = "Fleet medical CO"
+	min_rank = 16
 
 	utility_under = /obj/item/clothing/under/solgov/utility/expeditionary/officer/medical
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/expedition/command,
@@ -430,25 +429,25 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/medical, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/med/officer/com //Can only be officers
-	name = "NTEF medical command"
+	name = "Fleet medical command"
 	departments = MED|COM
 
 /decl/hierarchy/mil_uniform/fleet/med/officer/com/seniorofficer
-	name = "NTEF medical senior command"
-	min_rank = 15
+	name = "Fleet medical senior command"
+	min_rank = 19
 
 	service_over_alt = /obj/item/clothing/suit/storage/solgov/service/fleet/command
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
 
 /decl/hierarchy/mil_uniform/fleet/med/officer/com/flagofficer
-	name = "NTEF medical flag command"
-	min_rank = 17
+	name = "Fleet medical flag command"
+	min_rank = 23
 
 	service_over_alt = /obj/item/clothing/suit/storage/solgov/service/fleet/flag
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet/flag
 
 /decl/hierarchy/mil_uniform/fleet/sup
-	name = "NTEF supply"
+	name = "Fleet supply"
 	departments = SUP
 
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/expedition/supply,
@@ -474,7 +473,7 @@
 	dress_extra_alt = list(/obj/item/clothing/accessory/cloak/boh/supply, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/sup/noncom
-	name = "NTEF supply NCO"
+	name = "Fleet supply NCO"
 	min_rank = 4
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/senior
@@ -485,7 +484,7 @@
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet
 
 /decl/hierarchy/mil_uniform/fleet/sup/snco
-	name = "NTEF supply SNCO"
+	name = "Fleet supply SNCO"
 	min_rank = 7
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/chief
@@ -497,8 +496,8 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/supply, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/sup/officer
-	name = "NTEF supply CO"
-	min_rank = 11
+	name = "Fleet supply CO"
+	min_rank = 16
 
 	utility_under = /obj/item/clothing/under/solgov/utility/expeditionary/officer/supply
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/expedition/command,
@@ -530,8 +529,8 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/supply, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/sup/seniorofficer
-	name = "NTEF supply senior command"
-	min_rank = 15
+	name = "Fleet supply senior command"
+	min_rank = 19
 
 	utility_extra_alt = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command, /obj/item/clothing/head/beret/solgov/fleet/command, /obj/item/clothing/head/ushanka/solgov/fleet, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet, /obj/item/clothing/head/soft/solgov/fleet)
 	utility_under_alt = /obj/item/clothing/under/solgov/utility/fleet/command
@@ -544,8 +543,8 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/supply, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/sup/flagofficer
-	name = "NTEF supply flag command"
-	min_rank = 17
+	name = "Fleet supply flag command"
+	min_rank = 23
 
 	utility_extra_alt = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command, /obj/item/clothing/head/beret/solgov/fleet/command, /obj/item/clothing/head/ushanka/solgov/fleet, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet, /obj/item/clothing/head/soft/solgov/fleet)
 	utility_under_alt = /obj/item/clothing/under/solgov/utility/fleet/command
@@ -558,7 +557,7 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/supply, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/srv
-	name = "NTEF service"
+	name = "Fleet service"
 	departments = SRV
 
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/expedition/service,
@@ -584,7 +583,7 @@
 	dress_extra_alt = list(/obj/item/clothing/accessory/cloak/boh/service, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/srv/noncom
-	name = "NTEF service NCO"
+	name = "Fleet service NCO"
 	min_rank = 4
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/senior
@@ -595,7 +594,7 @@
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet
 
 /decl/hierarchy/mil_uniform/fleet/srv/snco
-	name = "NTEF service SNCO"
+	name = "Fleet service SNCO"
 	min_rank = 7
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/chief
@@ -607,8 +606,8 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/service, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/srv/officer
-	name = "NTEF service CO"
-	min_rank = 11
+	name = "Fleet service CO"
+	min_rank = 16
 
 	utility_under = /obj/item/clothing/under/solgov/utility/expeditionary/officer/service
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/expedition/command,
@@ -641,7 +640,7 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/service, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/exp
-	name = "NTEF exploration"
+	name = "Fleet exploration"
 	departments = EXP
 
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/expedition/exploration,
@@ -668,7 +667,7 @@
 	dress_extra_alt = list(/obj/item/clothing/accessory/cloak/boh/explorer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/exp/noncom
-	name = "NTEF exploration NCO"
+	name = "Fleet exploration NCO"
 	min_rank = 4
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/senior
@@ -679,7 +678,7 @@
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet
 
 /decl/hierarchy/mil_uniform/fleet/exp/snco
-	name = "NTEF exploration SNCO"
+	name = "Fleet exploration SNCO"
 	min_rank = 7
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/chief
@@ -691,8 +690,8 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/explorer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/exp/officer
-	name = "NTEF exploration CO"
-	min_rank = 11
+	name = "Fleet exploration CO"
+	min_rank = 16
 
 	utility_under = /obj/item/clothing/under/solgov/utility/expeditionary/officer/exploration
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/expedition/command,
@@ -725,7 +724,7 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/explorer, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/spt
-	name = "NTEF command support"
+	name = "Fleet command support"
 	departments = SPT
 
 	utility_under= /obj/item/clothing/under/solgov/utility/expeditionary/command
@@ -748,7 +747,7 @@
 	dress_extra_alt = list(/obj/item/clothing/accessory/cloak/boh/command/support, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/spt/noncom
-	name = "NTEF support NCO"
+	name = "Fleet support NCO"
 	min_rank = 4
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/senior
@@ -759,7 +758,7 @@
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet
 
 /decl/hierarchy/mil_uniform/fleet/spt/snco
-	name = "NTEF support SNCO"
+	name = "Fleet support SNCO"
 	min_rank = 7
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/chief
@@ -771,8 +770,8 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/command/support, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/spt/officer
-	name = "NTEF command support CO"
-	min_rank = 11
+	name = "Fleet command support CO"
+	min_rank = 16
 
 	utility_under= /obj/item/clothing/under/solgov/utility/expeditionary/officer/command
 	utility_extra_alt = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command, /obj/item/clothing/head/beret/solgov/fleet/command, /obj/item/clothing/head/ushanka/solgov/fleet, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet, /obj/item/clothing/head/soft/solgov/fleet, /obj/item/clothing/under/solgov/utility/fleet/polopants/command, /obj/item/clothing/suit/storage/jacket/solgov/fleet/command)
@@ -793,8 +792,8 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/command/support, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/spt/seniorofficer
-	name = "NTEF senior command support"
-	min_rank = 15
+	name = "Fleet senior command support"
+	min_rank = 19
 
 	utility_extra_alt = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command,
 						 /obj/item/clothing/head/beret/solgov/fleet/command,
@@ -813,8 +812,8 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/command/support, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/spt/flagofficer
-	name = "NTEF flag command support"
-	min_rank = 17
+	name = "Fleet flag command support"
+	min_rank = 23
 
 	utility_extra_alt = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command,
 						 /obj/item/clothing/head/beret/solgov/fleet/command,
@@ -833,7 +832,7 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/command/support, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/sci
-	name = "NTEF science"
+	name = "Fleet science"
 	departments = SCI
 
 	utility_under = /obj/item/clothing/under/solgov/utility/expeditionary/research
@@ -850,7 +849,7 @@
 	dress_extra_alt = list(/obj/item/clothing/accessory/cloak/boh/explorer/science, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/sci/senior
-	name = "NTEF science senior"
+	name = "Fleet science senior"
 	min_rank = 4
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/senior
@@ -861,7 +860,7 @@
 	dress_over_alt = /obj/item/clothing/suit/storage/solgov/dress/fleet
 
 /decl/hierarchy/mil_uniform/fleet/sci/chief
-	name = "NTEF science chief"
+	name = "Fleet science chief"
 	min_rank = 7
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/expedition/chief
@@ -873,8 +872,8 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/explorer/science, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/sci/officer
-	name = "NTEF science CO"
-	min_rank = 11
+	name = "Fleet science CO"
+	min_rank = 16
 
 	utility_under = /obj/item/clothing/under/solgov/utility/expeditionary/officer/research
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/expedition/command,
@@ -894,7 +893,7 @@
 	dress_extra_alt = list(/obj/item/weapon/storage/belt/holster/sheath/fleet, /obj/item/clothing/accessory/cloak/boh/explorer/science, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/sci/officer/com //Can only be officers
-	name = "NTEF science command"
+	name = "Fleet science command"
 	departments = SCI|COM
 
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/expedition/command,

--- a/maps/torch/datums/uniforms_marine-corps.dm
+++ b/maps/torch/datums/uniforms_marine-corps.dm
@@ -69,7 +69,7 @@
 
 /decl/hierarchy/mil_uniform/marine_corps/com/seniorofficer
 	name = "Marine Corps senior command"
-	min_rank = 15
+	min_rank = 21
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
@@ -126,10 +126,12 @@
 /decl/hierarchy/mil_uniform/marine_corps/eng/officer/com //Can only be officers
 	name = "Marine Corps engineering command"
 	departments = ENG|COM
+	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
+	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 
 /decl/hierarchy/mil_uniform/marine_corps/eng/officer/com/seniorofficer
 	name = "Marine Corps engineering senior command"
-	min_rank = 15
+	min_rank = 21
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
@@ -186,10 +188,12 @@
 /decl/hierarchy/mil_uniform/marine_corps/sec/officer/com //Can only be officers
 	name = "Marine Corps security command"
 	departments = SEC|COM
+	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
+	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
 
 /decl/hierarchy/mil_uniform/marine_corps/sec/officer/com/seniorofficer
 	name = "Marine Corps security senior command"
-	min_rank = 15
+	min_rank = 21
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
@@ -222,7 +226,7 @@
 
 /decl/hierarchy/mil_uniform/marine_corps/med/officer
 	name = "Marine Corps medical CO"
-	min_rank = 11
+	min_rank = 16
 
 	utility_extra = list(
 		/obj/item/clothing/under/solgov/utility/army/command,
@@ -248,7 +252,7 @@
 
 /decl/hierarchy/mil_uniform/marine_corps/med/officer/com/seniorofficer
 	name = "Marine Corps medical senior command"
-	min_rank = 15
+	min_rank = 21
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
 	dress_over = /obj/item/clothing/suit/dress/solgov/army/command
@@ -281,7 +285,7 @@
 
 /decl/hierarchy/mil_uniform/marine_corps/sup/officer
 	name = "Marine Corps supply CO"
-	min_rank = 11
+	min_rank = 16
 
 	utility_extra = list(
 		/obj/item/clothing/under/solgov/utility/army/command,
@@ -303,7 +307,7 @@
 
 /decl/hierarchy/mil_uniform/marine_corps/sup/seniorofficer
 	name = "Marine Corps supply senior command"
-	min_rank = 15
+	min_rank = 21
 
 	utility_extra = list(
 		/obj/item/clothing/under/solgov/utility/army/command,
@@ -400,7 +404,7 @@
 
 /decl/hierarchy/mil_uniform/marine_corps/exp/officer
 	name = "Marine Corps exploration CO"
-	min_rank = 11
+	min_rank = 16
 
 	utility_extra = list(
 		/obj/item/clothing/under/solgov/utility/army/command,
@@ -441,7 +445,7 @@
 
 /decl/hierarchy/mil_uniform/marine_corps/spt/officer
 	name = "Marine Corps command support CO"
-	min_rank = 11
+	min_rank = 16
 
 	utility_extra = list(
 		/obj/item/clothing/under/solgov/utility/army/command,
@@ -467,7 +471,7 @@
 
 /decl/hierarchy/mil_uniform/marine_corps/spt/seniorofficer
 	name = "Marine Corps senior command support"
-	min_rank = 15
+	min_rank = 21
 
 	utility_extra = list(
 		/obj/item/clothing/under/solgov/utility/army/command,

--- a/maps/torch/items/clothing/solgov-suit.dm
+++ b/maps/torch/items/clothing/solgov-suit.dm
@@ -210,21 +210,25 @@
 	name = "fleet dress SNCO jacket"
 	desc = "A navy blue SolGov Fleet dress jacket with silver cuffs. Don't get near pasta sauce or vox."
 	icon_state = "whitedress_snco"
+	item_state = "whitedress_snco"
 
 /obj/item/clothing/suit/storage/solgov/dress/fleet/officer
 	name = "fleet officer's dress jacket"
 	desc = "A navy blue SolGov Fleet dress jacket with silver accents. Don't get near pasta sauce or vox."
 	icon_state = "whitedress_off"
+	item_state = "whitedress_off"
 
 /obj/item/clothing/suit/storage/solgov/dress/fleet/command
 	name = "fleet senior officer's dress jacket"
 	desc = "A navy blue SolGov Fleet dress jacket with gold accents. Don't get near pasta sauce or vox."
 	icon_state = "whitedress_comm"
+	item_state = "whitedress_comm"
 
 /obj/item/clothing/suit/storage/solgov/dress/fleet/flag
 	name = "fleet flag officer's dress jacket"
 	desc = "A navy blue SolGov Fleet dress jacket with red accents. Don't get near pasta sauce or vox."
 	icon_state = "whitedress_flag"
+	item_state = "whitedress_flag"
 
 /obj/item/clothing/suit/dress/solgov
 	name = "dress jacket"


### PR DESCRIPTION
## About The Pull Request
This pull request fixes the code for uniform vendors and the rank distribution of the Fleet and Marine Corps.

## Why It's Good For The Game
Previously the ranks for the Marine Corps and Fleet were slightly messed up due to someone with moonbrain adding Warrant Officer ranks in the middle of Enlisted and Officers and moving the officer rank order up by five. This resulted in junior officers receiving flag officer uniforms and roles like the Commanding Officer could not wear the Captain hat.

This PR fixes that and the icons for the Fleet dress uniforms. Junior officers from O-1 to O-3 receive silver trimmed uniforms, senior officers from O-4 to O-6 receive gold trim uniforms. Captain and Commanders have special 'senior officer' and 'captain' EC hats respectively as well.

This should not affect the other ranks very much except for now Warrant Officers will receive SNCO uniforms.

## Did You Test It?
Yes.
## Authorship
PurplePineapple#0001
## Changelog

:cl:
bugfix: The rank order for the Fleet and Marines has been fixed. Uniforms should work as expected now.
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->