### PR TITLE
Makes the rawl flooring more user-friendly.

### DIFF
--- a/maps/away/rawl/rawl.dmm
+++ b/maps/away/rawl/rawl.dmm
@@ -85,7 +85,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/autoset,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/cargo)
 "ak" = (
 /obj/effect/floor_decal/corner/white/border{
@@ -133,7 +133,7 @@
 	dir = 4;
 	pixel_z = 0
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "an" = (
 /obj/machinery/atmospherics/unary/engine{
@@ -188,12 +188,12 @@
 /turf/simulated/floor/airless,
 /area/ship/rawl/crew)
 "as" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "at" = (
 /obj/machinery/computer/cryopod{
@@ -209,25 +209,24 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "av" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 1;
-	icon_state = "map"
-	},
 /obj/structure/fuel_port{
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "aw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "ax" = (
 /obj/structure/cable{
@@ -243,7 +242,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "ay" = (
 /obj/structure/table/rack,
@@ -261,9 +261,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/rawl/fore)
 "az" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 4
-	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1331;
 	id_tag = "rawl_ship_dock";
@@ -274,7 +271,10 @@
 	dir = 8;
 	icon_state = "handrail"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "aA" = (
 /obj/machinery/power/smes/buildable/preset/rawl/smes{
@@ -284,16 +284,17 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "aB" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 4
+	dir = 4;
+	name = "Fuel Input"
 	},
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "aC" = (
 /obj/structure/table/standard,
@@ -337,7 +338,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "aG" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide{
@@ -434,18 +435,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "aO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1;
-	icon_state = "map"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	pixel_y = 0
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "aP" = (
 /obj/structure/curtain/open/privacy,
@@ -467,7 +467,7 @@
 	in_use = 0;
 	name = "Air to Main Airlock"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "aR" = (
 /obj/structure/cable{
@@ -486,9 +486,10 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4;
-	icon_state = "map_connector"
+	icon_state = "map_connector";
+	name = "Waste Port"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "aS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -503,15 +504,15 @@
 /turf/simulated/floor/tiled,
 /area/ship/rawl/crew)
 "aT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
-	},
 /obj/machinery/alarm/rawl{
 	dir = 8;
 	pixel_x = 24;
 	pixel_y = 0
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "aU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -628,8 +629,9 @@
 	locked = 1;
 	name = "Rawl Docking Port"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/ship/rawl/pipeworks)
@@ -643,7 +645,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "bf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -652,7 +654,7 @@
 	dir = 8;
 	name = "Docking Port Air Cutoff"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "bg" = (
 /obj/effect/paint/brown,
@@ -670,7 +672,7 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock{
 	start_pressure = 607.95
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "bi" = (
 /obj/machinery/atmospherics/unary/tank/air{
@@ -701,7 +703,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "bm" = (
 /obj/structure/table/rack,
@@ -902,7 +904,7 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock{
 	start_pressure = 1900
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "bL" = (
 /obj/structure/cable{
@@ -920,8 +922,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/portables_connector{
+	name = "Air"
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "bN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -936,6 +940,9 @@
 	dir = 8
 	},
 /obj/effect/submap_landmark/joinable_submap/rawl,
+/obj/effect/floor_decal/industrial/loading{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/rawl/cargo)
 "bP" = (
@@ -966,7 +973,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "bT" = (
 /obj/item/weapon/stool/padded,
@@ -1082,7 +1089,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "ch" = (
 /obj/machinery/computer/ship/sensors{
@@ -1217,8 +1224,8 @@
 /turf/simulated/floor/airless,
 /area/ship/rawl/fore)
 "cx" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "cy" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -1232,7 +1239,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "cz" = (
 /obj/structure/cable{
@@ -1242,7 +1249,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/rawl/pipeworks)
 "cA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{


### PR DESCRIPTION
## About The Pull Request
This gives the Rawl pipeworks flooring as well as making the primary pipe network (aka most pipes aside from waste and distro) pipes visible above the flooring. It also adds a floor decal pointing to where you put ore into the processor.
## Why It's Good For The Game
I don't even remember why that room originally had no flooring.
The Rawl being a horrific mess of pipes was nice thematically, but there's a million different pumps in there and some of those pipes are essential to function of the ship. This makes it more clear- a lot of the pumps and valves were otherwise obscured by distro and waste pipes.
Also if you configure the processor wrong it'll eat your stuff, so this will help make it more clear how to use it correctly.
## Did You Test It?
Yes
## Authorship
Rock
## Changelog

:cl:
tweak:The rawl pipeworks have flooring that covers some of the pipes now.
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->