### PR TITLE
Adds a check for Operant Psionics for leeching message.

### DIFF
--- a/code/modules/psionics/complexus/complexus_process.dm
+++ b/code/modules/psionics/complexus/complexus_process.dm
@@ -31,7 +31,7 @@
 			sound_to(owner, 'sound/effects/psi/power_unlock.ogg')
 			rating = ceil(combined_rank/rank_count)
 			cost_modifier = 1
-			if(rating > 1) 
+			if(rating > 1)
 				cost_modifier -= min(1, max(0.1, (rating-1) / 10))
 			if(!ui)
 				ui = new(owner)
@@ -85,13 +85,14 @@
 		return
 
 	var/psi_leech = owner.do_psionics_check()
-	if(psi_leech)
-		if(stamina > 10)
-			stamina = max(0, stamina - rand(15,20))
-			to_chat(owner, SPAN_DANGER("You feel your psi-power leeched away by \the [psi_leech]..."))
-		else
-			stamina++
-		return
+	if(get_rank(PSI_REDACTION) >= PSI_RANK_OPERANT || get_rank(PSI_COERCION) >= PSI_RANK_OPERANT || get_rank(PSI_PSYCHOKINESIS) >= PSI_RANK_OPERANT || get_rank(PSI_ENERGISTICS) >= PSI_RANK_OPERANT)
+		if(psi_leech)
+			if(stamina > 10)
+				stamina = max(0, stamina - rand(15,20))
+				to_chat(owner, SPAN_DANGER("You feel your psi-power leeched away by \the [psi_leech]..."))
+			else
+				stamina++
+			return
 
 	else if(stamina < max_stamina)
 		if(owner.stat == CONSCIOUS)


### PR DESCRIPTION
## About The Pull Request
This pull request adds a check for if your psionics are actually activated to be able to be leeched. 

## Why It's Good For The Game
This way you can't just check if someone psionic by walking in and out of the security nullglass cells. It happens often enough and is incredibly dumb. There should be no 'easy' route here. It's psionics. Let a little mystery live.

## Did You Test It?
Yes

## Authorship
PurplePineapple#0001

## Changelog

:cl:
tweak: adds a check for psionic operancy when leeching power using nullglass objects.
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->