### PR TITLE
Replaces the P20 with the P10

### DIFF
--- a/code/modules/boh_misc/firearms.dm
+++ b/code/modules/boh_misc/firearms.dm
@@ -4,7 +4,7 @@
 
 /obj/item/weapon/gun/projectile/pistol/military/alt/solar
 	name = "Mk59"
-	desc = "The Jhen Bothus, best known as the standard-issue sidearm for the Solar Marine Corps. It is a rugged firearm that can be fired reliably by even the most novice of soldiers."
+	desc = "The Jhen Bothus, best known as the standard-issue sidearm for the Solar Marine Corps. It's known for severe issues with reliability when not maintained well or used by inexperienced shooters."
 	magazine_type = /obj/item/ammo_magazine/pistol/double/pepperball
 	fire_sound = 'sound/weapons/gunshot/pistol_mk59.ogg'
 	jam_chance = 5 //Cheap firearm. Chance of jamming

--- a/code/modules/boh_misc/firearms.dm
+++ b/code/modules/boh_misc/firearms.dm
@@ -4,7 +4,7 @@
 
 /obj/item/weapon/gun/projectile/pistol/military/alt/solar
 	name = "Mk59"
-	desc = "The Jhen Bothus, best known as the standard-issue sidearm for the Solar Marine Corps. It's known for severe issues with reliability when not maintained well or used by inexperienced shooters."
+	desc = "The Jhen Bothus, best known as the standard-issue sidearm for the Solar Marine Corps. It is a rugged firearm that can be fired reliably by even the most novice of soldiers."
 	magazine_type = /obj/item/ammo_magazine/pistol/double/pepperball
 	fire_sound = 'sound/weapons/gunshot/pistol_mk59.ogg'
 	jam_chance = 5 //Cheap firearm. Chance of jamming

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -45,6 +45,7 @@
 	safety_icon = "safety"
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2, TECH_ESOTERIC = 8)
 	fire_delay = 8
+	jam_chance = 0
 
 /obj/item/weapon/gun/projectile/pistol/sec
 	name = "MA-Mk58"

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -39,13 +39,13 @@
 	ammo_indicator = TRUE
 
 /obj/item/weapon/gun/projectile/pistol/military/alt
+	name = "HelTek Optimus"
 	desc = "The HelTek Optimus, best known as the standard-issue sidearm for the ICCG Navy."
 	icon = 'icons/obj/guns/military_pistol2.dmi'
 	icon_state = "military-alt"
 	safety_icon = "safety"
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2, TECH_ESOTERIC = 8)
 	fire_delay = 8
-	jam_chance = 0
 
 /obj/item/weapon/gun/projectile/pistol/sec
 	name = "MA-Mk58"

--- a/maps/torch/infantry/firearms.dm
+++ b/maps/torch/infantry/firearms.dm
@@ -100,9 +100,9 @@
 /////////
 /obj/item/weapon/gun/projectile/pistol/military/sec
 	name = "Hephaestus P10"
-	desc = "The Hephaestus Industries P10 - a mass produced kinetic sidearm in widespread service with the SCGDF. While it has a quick rate of fire, the P10's slide can fail to properly eject casings if not maintained properly.\
-	Unfortunately this gives it a slight chance of jamming in untrained hands."
-	jam_chance = 5
+	desc = "The Hephaestus Industries P10 - a mass produced kinetic sidearm in widespread service with the SCGDF. A slide restrictor is integrated into the handgun to prevent\
+	quick-draw type shooting. A reliable sidearm in the hands of even the most novice of soldiers."
+	fire_delay = 5
 
 /////////
 // LMG

--- a/maps/torch/infantry/firearms.dm
+++ b/maps/torch/infantry/firearms.dm
@@ -99,14 +99,10 @@
 // Pistol
 /////////
 /obj/item/weapon/gun/projectile/pistol/military/sec
-	name = "P10"
-	desc = "The Hephaestus Industries P10 - a mass produced kinetic sidearm in widespread service with the SCGDF. It has a slide restrictor, preventing quick-draw type shooting."
-	fire_delay = 12
-//	req_access = list(access_hop)
-//	authorized_modes = list(UNAUTHORIZED)
-	firemodes = list(
-		list(mode_name="fire", burst=1, fire_delay=null, move_delay=null, one_hand_penalty=2, burst_accuracy=null, dispersion=null),
-		)
+	name = "Hephaestus P10"
+	desc = "The Hephaestus Industries P10 - a mass produced kinetic sidearm in widespread service with the SCGDF. While it has a quick rate of fire, the P10's slide can fail to properly eject casings if not maintained properly.\
+	Unfortunately this gives it a slight chance of jamming in untrained hands."
+	jam_chance = 5
 
 /////////
 // LMG

--- a/maps/torch/loadout/loadout_sikits.dm
+++ b/maps/torch/loadout/loadout_sikits.dm
@@ -13,7 +13,7 @@ This is for standard issue sidearms.
 	..()
 	var/guns = list()
 	guns["Jhen Bothus Mk59"] = /obj/item/weapon/gun/projectile/pistol/military/alt/solar/loadout
-	guns["Hephaestus P20"] = /obj/item/weapon/gun/projectile/pistol/military
+	guns["Hephaestus P10"] = /obj/item/weapon/gun/projectile/pistol/military/sec
 	guns["Lumoco Mk12"] = /obj/item/weapon/gun/projectile/revolver/medium/sec
 	gear_tweaks += new/datum/gear_tweak/path(guns)
 


### PR DESCRIPTION
## About The Pull Request
Continued from my concern brought up in https://github.com/BoHBranch/BoH-Bay/pull/1542

This PR swaps the P20 for the P10, another gun that already exists as a 'sec' subtype of the P20. I've changed it to have a slower fire rate compared to the quick MK59, but the difference is the P10 does not jam.

## Why It's Good For The Game
Balances the starting guns so each is unique and none is a straight upgrade from the others. I also prefer this over #1542 because it does not touch the default guns in any way, just our Hestia assets. It also makes it so that the two pistols aren't identical. They now both have advantages and disadvantages. One is fast and jams, one is slow and reliable. **You can still order the P20 from cargo on code blue and above.** It has not been touched. Infantry still has the standard P20.

## Did You Test It?
Yes

## Authorship
PurplePineapple#0001
## Changelog

:cl:
tweak: Swaps the P20 for the P10 in the loadout. Changes its stats to be more in line with the other starting pistols.
bugfix: Makes the ICCGN pistol actually named HelTek Optimus
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->