### PR TITLE
Citizens & Feds

### DIFF
--- a/code/datums/mil_ranks.dm
+++ b/code/datums/mil_ranks.dm
@@ -179,6 +179,7 @@ var/datum/mil_branches/mil_branches = new()
 	var/list/accessory		//type of accesory that will be equipped by job code with this rank
 	var/sort_order = 0 // A numerical equivalent of the rank used to indicate its order when compared to other datums: eg e-1 = 1, o-1 = 11
 	var/pow_cat = 0 //A numerical equivelent of the Geneva/Galilei Convention Category of the rank, 0 for non-sol forces unless they have signed for some reason.
+	var/cit_rank = 0 //A character's citizenship ranking. This is based on their job, primarily.
 
 //Returns short designation (yes shorter than name_short), like E1, O3 etc.
 /datum/mil_rank/proc/grade()

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -57,6 +57,7 @@
 	var/required_language
 	var/is_whitelisted = FALSE
 	var/max_pow_cat = 0 //If the rank pow_cat is great then this, set to this.  This is used for Galilei Convention IDs
+	var/max_cit_rank = 0 //If the rank cit_rank is great then this, set to this.
 
 /datum/job/New()
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -187,6 +187,8 @@ var/const/NO_EMAG_ACT = -50
 	var/datum/mil_rank/military_rank = null
 	var/pow_cat = 0
 	var/max_pow_cat = 0
+	var/cit_rank = 0
+	var/max_cit_rank = 0
 
 	var/formal_name_prefix
 	var/formal_name_suffix
@@ -201,6 +203,7 @@ var/const/NO_EMAG_ACT = -50
 		if(j)
 			rank = j.title
 			max_pow_cat = j.max_pow_cat
+			max_cit_rank = j.max_cit_rank
 			assignment = rank
 			access |= j.get_access()
 			if(!detail_color)
@@ -294,8 +297,11 @@ var/const/NO_EMAG_ACT = -50
 	if(GLOB.using_map.flags & MAP_HAS_RANK)
 		id_card.military_rank = char_rank
 		id_card.pow_cat = char_rank.pow_cat
+		id_card.cit_rank = char_rank.cit_rank
 		if(id_card.pow_cat > id_card.max_pow_cat)
 			id_card.pow_cat = id_card.max_pow_cat
+		if(id_card.cit_rank > id_card.max_cit_rank)
+			id_card.cit_rank = id_card.max_cit_rank
 
 /obj/item/weapon/card/id/proc/dat()
 	var/list/dat = list("<table><tr><td>")
@@ -326,6 +332,20 @@ var/const/NO_EMAG_ACT = -50
 			if(5)
 				pow_roman = "V"
 		dat += text("Galilei Convention: Cat []<BR>\n", pow_roman)
+	if(cit_rank && GLOB.using_map.flags & MAP_HAS_RANK)
+		var/cit_ranking = ""
+		switch(cit_rank)
+			if(1)
+				cit_ranking = "Integrated Sentient"
+			if(2)
+				cit_ranking = "Second Civilian"
+			if(3)
+				cit_ranking = "First Civilian"
+			if(4)
+				cit_ranking = "Second Citizen"
+			if(5)
+				cit_ranking = "First Citizen"
+		dat += text("Citizenship Ranking: T-[]<BR>\n", cit_ranking)
 	dat += text("<BR>\n")
 	if(front && side)
 		dat +="<td align = center valign = top>Photo:<br><img src=front.png height=80 width=80 border=4><img src=side.png height=80 width=80 border=4></td>"

--- a/maps/torch/job/security_jobs.dm
+++ b/maps/torch/job/security_jobs.dm
@@ -37,17 +37,14 @@
 							 /datum/computer_file/program/camera_monitor)
 
 /datum/job/detective
-	title = "Forensic Technician"
+	title = "Federal Agent"
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "the Chief of Security"
+	supervisors = "the SolGov Registry"
 	economic_power = 5
 	minimal_player_age = 0
 	minimum_character_age = list(SPECIES_HUMAN = 21)
 	skill_points = 18
-	alt_titles = list(
-		"Criminal Investigator"
-	)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
@@ -56,12 +53,6 @@
 		/datum/mil_branch/solgov = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/agent
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/fleet/e3,
-		/datum/mil_rank/ec/e3,
-		/datum/mil_rank/ec/e5,
-		/datum/mil_rank/fleet/e4,
-		/datum/mil_rank/fleet/e5,
-		/datum/mil_rank/civ/contractor,
 		/datum/mil_rank/sol/agent
 	)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,

--- a/maps/torch/job/service_jobs.dm
+++ b/maps/torch/job/service_jobs.dm
@@ -46,6 +46,7 @@
 		/datum/mil_rank/fleet/e4
 	)
 	max_pow_cat = 1
+	max_cit_rank = 1
 	min_skill = list(   SKILL_HAULING = SKILL_BASIC)
 
 	access = list(access_maint_tunnels, access_emergency_storage, access_janitor, access_solgov_crew, access_hangar)

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -87,6 +87,8 @@
 	   A contractor having a higher Galilei/Geneva Convention Article 3 equivelent rank then then an enlisted person for similar work is expected behavior.
 	   Source material is DOD Instruction 1000.01 */
 	max_pow_cat = 5
+	/* cit_rank is rank equivalent based, max_cit_rank is for wackos.*/
+	max_cit_rank = 5
 
 
 

--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -330,20 +330,10 @@
 
 /datum/job/detective
 	allowed_branches = list(
-		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/contractor,
-		/datum/mil_branch/private_security,
-		/datum/mil_branch/fleet,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/marine,
 		/datum/mil_branch/solgov = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/agent
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/fleet/e4,
-		/datum/mil_rank/fleet/e5,
-		/datum/mil_rank/civ/contractor,
-		/datum/mil_rank/private_security/pcrc_agt = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/pcrc_agent,
-		/datum/mil_rank/sol/agent,
-		/datum/mil_rank/marine_corps/e4,
-		/datum/mil_rank/marine_corps/e5
+		/datum/mil_rank/sol/agent
 	)
 
 /datum/job/officer

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -302,6 +302,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 1
 	pow_cat = 1
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e2
 	name = "Crewman Apprentice"
@@ -309,6 +310,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e2, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 2
 	pow_cat = 1
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e3
 	name = "Crewman"
@@ -316,6 +318,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e3, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 3
 	pow_cat = 1
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e4
 	name = "Petty Officer Third Class"
@@ -323,6 +326,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e4, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 4
 	pow_cat = 1
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e5
 	name = "Petty Officer Second Class"
@@ -330,6 +334,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e5, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 5
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e6
 	name = "Petty Officer First Class"
@@ -337,6 +342,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e6, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 6
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e7
 	name = "Chief Petty Officer"
@@ -344,6 +350,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e7, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 7
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e8
 	name = "Senior Chief Petty Officer"
@@ -351,6 +358,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e8, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 8
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e9
 	name = "Master Chief Petty Officer"
@@ -358,6 +366,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e9_alt1
 	name = "Command Master Chief Petty Officer"
@@ -365,6 +374,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt1, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e9_alt2
 	name = "Fleet Master Chief Petty Officer"
@@ -372,6 +382,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt2, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e9_alt3
 	name = "Force Master Chief Petty Officer"
@@ -379,6 +390,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt3, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e9_alt4
 	name = "Master Chief Petty Officer of the Fleet"
@@ -386,6 +398,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt4, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/o1
 	name = "Ensign"
@@ -393,6 +406,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 11
 	pow_cat = 3
+	cit_rank = 4
 
 /datum/mil_rank/fleet/o2
 	name = "Sub-lieutenant"
@@ -400,6 +414,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o2, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 12
 	pow_cat = 3
+	cit_rank = 4
 
 /datum/mil_rank/fleet/o3
 	name = "Lieutenant"
@@ -407,6 +422,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o3, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 13
 	pow_cat = 3
+	cit_rank = 4
 
 /datum/mil_rank/fleet/o4
 	name = "Lieutenant Commander"
@@ -414,6 +430,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o4, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 14
 	pow_cat = 4
+	cit_rank = 4
 
 /datum/mil_rank/fleet/o5
 	name = "Commander"
@@ -421,6 +438,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o5, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 15
 	pow_cat = 4
+	cit_rank = 4
 
 /datum/mil_rank/fleet/o6
 	name = "Captain"
@@ -428,6 +446,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o6, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 16
 	pow_cat = 4
+	cit_rank = 5
 
 /datum/mil_rank/fleet/o7
 	name = "Commodore"
@@ -435,6 +454,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 17
 	pow_cat = 5
+	cit_rank = 5
 
 /datum/mil_rank/fleet/o8
 	name = "Rear Admiral"
@@ -442,6 +462,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o8, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 18
 	pow_cat = 5
+	cit_rank = 5
 
 /datum/mil_rank/fleet/o9
 	name = "Vice Admiral"
@@ -449,6 +470,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o9, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 19
 	pow_cat = 5
+	cit_rank = 5
 
 /datum/mil_rank/fleet/o10
 	name = "Admiral"
@@ -456,6 +478,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o10, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 20
 	pow_cat = 5
+	cit_rank = 5
 
 /datum/mil_rank/fleet/o10_alt
 	name = "Fleet Admiral"
@@ -463,6 +486,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o10_alt, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 20
 	pow_cat = 5
+	cit_rank = 5
 
 
 /*
@@ -705,24 +729,29 @@
 /datum/mil_rank/civ/civ
 	name = "Civilian"
 	pow_cat = 3
+	cit_rank = 2
 
 /datum/mil_rank/civ/contractor
 	name = "Contractor"
 	pow_cat = 3
+	cit_rank = 2
 
 /datum/mil_rank/civ/ntr
 	name = "NanoTrasen Representative"
 	name_short = "NTR"
 	pow_cat = 5
+	cit_rank = 4
 
 /datum/mil_rank/civ/foundationadvisor
 	name = "Psionic Advisor"
 	name_short = "PADV"
 	pow_cat = 5
+	cit_rank = 4
 
 /datum/mil_rank/civ/synthetic
 	name = "Synthetic"
 	pow_cat = 0
+	cit_rank = 1
 
 /*
  *  SolGov Employees
@@ -734,17 +763,20 @@
 	name_short = "SGR"
 	accessory = list(/obj/item/clothing/accessory/badge/solgov/representative)
 	pow_cat = 5
+	cit_rank = 5
 
 /datum/mil_rank/sol/agent
 	name = "SFP Agent"
 	name_short = "AGT"
 	accessory = list(/obj/item/clothing/accessory/badge/agent)
 	pow_cat = 3
+	cit_rank = 5
 
 /datum/mil_rank/sol/scientist
 	name = "Government Scientist"
 	name_short = "GOVT"
 	pow_cat = 3
+	cit_rank = 4
 
 /*
  *  Terrans

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -257,6 +257,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 1
 	pow_cat = 1
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e1_exp
 	name = "Recruit Explorer"
@@ -271,6 +272,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e2, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 2
 	pow_cat = 1
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e2_exp
 	name = "Junior Explorer"
@@ -285,6 +287,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e3, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 3
 	pow_cat = 1
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e3_exp
 	name = "Explorer"
@@ -299,6 +302,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e4, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 4
 	pow_cat = 1
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e5
 	name = "Petty Officer Second Class"
@@ -306,6 +310,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e5, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 5
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e5_exp
 	name = "Senior Explorer"
@@ -320,6 +325,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e6, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 6
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e7
 	name = "Chief Petty Officer"
@@ -327,6 +333,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e7, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 7
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e7_exp
 	name = "Chief Explorer"
@@ -341,6 +348,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e8, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 8
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e9
 	name = "Master Chief Petty Officer"
@@ -348,6 +356,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e9_alt1
 	name = "Command Master Chief Petty Officer"
@@ -355,6 +364,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt1, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e9_alt2
 	name = "Fleet Master Chief Petty Officer"
@@ -362,6 +372,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt2, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e9_alt3
 	name = "Force Master Chief Petty Officer"
@@ -369,6 +380,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt3, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/e9_alt4
 	name = "Master Chief Petty Officer of the Fleet"
@@ -376,36 +388,42 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e9_alt4, /obj/item/clothing/accessory/solgov/specialty/enlisted)
 	sort_order = 9
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/fleet/w1
 	name = "Junior Warrant Officer"
 	name_short = "JWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/warrant_officer/w1)
 	sort_order = 11
+	cit_rank = 4
 
 /datum/mil_rank/fleet/w2
 	name = "Chief Warrant Officer"
 	name_short = "CWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/warrant_officer/w2)
 	sort_order = 12
+	cit_rank = 4
 
 /datum/mil_rank/fleet/w3
 	name = "Senior Chief Warrant Officer"
 	name_short = "SCWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/warrant_officer/w3)
 	sort_order = 13
+	cit_rank = 4
 
 /datum/mil_rank/fleet/w4
 	name = "Master Chief Warrant Officer"
 	name_short = "MCWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/warrant_officer/w4)
 	sort_order = 14
+	cit_rank = 4
 
 /datum/mil_rank/fleet/w5
 	name = "Command Master Chief Warrant Officer"
 	name_short = "CMCWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/warrant_officer/w5)
 	sort_order = 15
+	cit_rank = 4
 
 /datum/mil_rank/fleet/o1
 	name = "Ensign"
@@ -413,6 +431,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 16
 	pow_cat = 3
+	cit_rank = 4
 
 /datum/mil_rank/fleet/o2
 	name = "Lieutenant Junior-Grade"
@@ -420,6 +439,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o2, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 17
 	pow_cat = 3
+	cit_rank = 4
 
 /datum/mil_rank/fleet/o3
 	name = "Lieutenant"
@@ -427,6 +447,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o3, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 18
 	pow_cat = 3
+	cit_rank = 4
 
 /datum/mil_rank/fleet/o4
 	name = "Lieutenant Commander"
@@ -434,6 +455,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o4, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 19
 	pow_cat = 4
+	cit_rank = 4
 
 /datum/mil_rank/fleet/o5
 	name = "Commander"
@@ -441,6 +463,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o5, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 20
 	pow_cat = 4
+	cit_rank = 4
 
 /datum/mil_rank/fleet/o6
 	name = "Captain"
@@ -448,6 +471,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o6, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 21
 	pow_cat = 4
+	cit_rank = 5
 
 /datum/mil_rank/fleet/o7
 	name = "Commodore"
@@ -455,6 +479,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 22
 	pow_cat = 5
+	cit_rank = 5
 
 /datum/mil_rank/fleet/o8
 	name = "Rear Admiral"
@@ -462,6 +487,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o8, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 23
 	pow_cat = 5
+	cit_rank = 5
 
 /datum/mil_rank/fleet/o9
 	name = "Vice Admiral"
@@ -469,6 +495,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o9, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 24
 	pow_cat = 5
+	cit_rank = 5
 
 /datum/mil_rank/fleet/o10
 	name = "Admiral"
@@ -476,6 +503,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o10, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 25
 	pow_cat = 5
+	cit_rank = 5
 
 /datum/mil_rank/fleet/o10_alt
 	name = "Fleet Admiral"
@@ -483,6 +511,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag/o10_alt, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 25
 	pow_cat = 5
+	cit_rank = 5
 /*****/
 
 /*
@@ -495,6 +524,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted)
 	sort_order = 1
 	pow_cat = 1
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/e2
 	name = "Private First Class"
@@ -502,6 +532,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e2)
 	sort_order = 2
 	pow_cat = 1
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/e3
 	name = "Lance Corporal"
@@ -509,6 +540,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e3)
 	sort_order = 3
 	pow_cat = 1
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/e4
 	name = "Corporal"
@@ -516,6 +548,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e4)
 	sort_order = 4
 	pow_cat = 1
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/e5
 	name = "Sergeant"
@@ -523,6 +556,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e5)
 	sort_order = 5
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/e6
 	name = "Staff Sergeant"
@@ -530,6 +564,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e6)
 	sort_order = 6
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/e7
 	name = "Gunnery Sergeant"
@@ -537,6 +572,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e7)
 	sort_order = 7
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/e8
 	name = "Master Sergeant"
@@ -544,6 +580,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e8)
 	sort_order = 8
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/e8_alt
 	name = "First Sergeant"
@@ -551,6 +588,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e8_alt)
 	sort_order = 8
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/e9
 	name = "Master Gunnery Sergeant"
@@ -558,6 +596,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e9)
 	sort_order = 9
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/e9_alt
 	name = "Sergeant Major"
@@ -565,6 +604,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e9_alt)
 	sort_order = 9
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/e9_alt2
 	name = "Sergeant Major of the Marine Corps"
@@ -572,36 +612,42 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/enlisted/e9_alt2)
 	sort_order = 9
 	pow_cat = 2
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/w1
 	name = "Warrant Officer"
 	name_short = "WO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w1)
 	sort_order = 11
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/w2
 	name = "Second Warrant Officer"
 	name_short = "SWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w2)
 	sort_order = 12
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/w3
 	name = "First Warrant Officer"
 	name_short = "FWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w3)
 	sort_order = 13
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/w4
 	name = "Major Warrant Officer"
 	name_short = "MWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w4)
 	sort_order = 14
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/w5
 	name = "General Warrant Officer"
 	name_short = "GWO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/warrant_officer/w5)
 	sort_order = 15
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/o1
 	name = "Second Lieutenant"
@@ -609,6 +655,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer)
 	sort_order = 16
 	pow_cat = 3
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/o2
 	name = "First Lieutenant"
@@ -616,6 +663,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o2)
 	sort_order = 17
 	pow_cat = 3
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/o3
 	name = "Captain "
@@ -623,6 +671,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o3)
 	sort_order = 18
 	pow_cat = 3
+	cit_rank = 4
 
 // Specially, to avoid two "Capt" on-board.
 /datum/mil_rank/marine_corps/o3_alt
@@ -631,6 +680,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o3_alt)
 	sort_order = 19
 	pow_cat = 3
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/o3_alt2
 	name = "Specialist Captain"
@@ -638,6 +688,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o3_alt2)
 	sort_order = 20
 	pow_cat = 3
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/o4
 	name = "Major"
@@ -645,6 +696,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o4)
 	sort_order = 21
 	pow_cat = 4
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/o5
 	name = "Lieutenant Colonel"
@@ -652,6 +704,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o5)
 	sort_order = 22
 	pow_cat = 4
+	cit_rank = 4
 
 /datum/mil_rank/marine_corps/o6
 	name = "Colonel"
@@ -659,6 +712,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/officer/o6)
 	sort_order = 23
 	pow_cat = 4
+	cit_rank = 5
 
 /datum/mil_rank/marine_corps/o7
 	name = "Brigadier General"
@@ -666,6 +720,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/flag)
 	sort_order = 24
 	pow_cat = 5
+	cit_rank = 5
 
 /datum/mil_rank/marine_corps/o8
 	name = "Major General"
@@ -673,6 +728,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/flag/o8)
 	sort_order = 25
 	pow_cat = 5
+	cit_rank = 5
 
 /datum/mil_rank/marine_corps/o9
 	name = "Lieutenant General"
@@ -680,6 +736,7 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/flag/o9)
 	sort_order = 26
 	pow_cat = 5
+	cit_rank = 5
 
 /datum/mil_rank/marine_corps/o10
 	name = "General"
@@ -687,6 +744,8 @@
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/marine_corps/flag/o10)
 	sort_order = 27
 	pow_cat = 5
+	cit_rank = 5
+
 /*****/
 
 // Addon: Sec Contractors
@@ -711,17 +770,21 @@
 	name = "PCRC Contractor"
 	name_short = "PCRC"
 	pow_cat = 3
+	cit_rank = 3
 
 // Kind of hacky, to allow usage of PCRC suit via outfit.
 /datum/mil_rank/private_security/pcrc_agt
 	name = "PCRC Agent"
 	name_short = "PCRC-AGT"
 	pow_cat = 3
+	cit_rank = 3
 
 /datum/mil_rank/private_security/saare
 	name = "SAARE Operative"
 	name_short = "SAARE"
 	pow_cat = 3
+	cit_rank = 3
+
 /*****/
 
 // Ends of defines


### PR DESCRIPTION
- - -
Additions:
 - Provides a new category to IDs and player characters. This is citizenship within SolGov. Your rank determines where exactly that sits, if anywhere at all. This is likely to need adjustments in the future, but it worked in testing.
- - -
Changes:
 - Detective required to be a Federal Agent now, as per the change above. They, the Captain and SolGov Rep are the only First Citizens aboard at round start.
- - -