### PR TITLE
Revert "Adds a check for Operant Psionics for leeching message."

### DIFF
--- a/code/modules/psionics/complexus/complexus_process.dm
+++ b/code/modules/psionics/complexus/complexus_process.dm
@@ -31,7 +31,7 @@
 			sound_to(owner, 'sound/effects/psi/power_unlock.ogg')
 			rating = ceil(combined_rank/rank_count)
 			cost_modifier = 1
-			if(rating > 1)
+			if(rating > 1) 
 				cost_modifier -= min(1, max(0.1, (rating-1) / 10))
 			if(!ui)
 				ui = new(owner)
@@ -85,14 +85,13 @@
 		return
 
 	var/psi_leech = owner.do_psionics_check()
-	if(get_rank(PSI_REDACTION) >= PSI_RANK_OPERANT || get_rank(PSI_COERCION) >= PSI_RANK_OPERANT || get_rank(PSI_PSYCHOKINESIS) >= PSI_RANK_OPERANT || get_rank(PSI_ENERGISTICS) >= PSI_RANK_OPERANT)
-		if(psi_leech)
-			if(stamina > 10)
-				stamina = max(0, stamina - rand(15,20))
-				to_chat(owner, SPAN_DANGER("You feel your psi-power leeched away by \the [psi_leech]..."))
-			else
-				stamina++
-			return
+	if(psi_leech)
+		if(stamina > 10)
+			stamina = max(0, stamina - rand(15,20))
+			to_chat(owner, SPAN_DANGER("You feel your psi-power leeched away by \the [psi_leech]..."))
+		else
+			stamina++
+		return
 
 	else if(stamina < max_stamina)
 		if(owner.stat == CONSCIOUS)


### PR DESCRIPTION
Reverts BoHBranch/BoH-Bay#1545

Checks are fucked. Looked fine code wise, but it doesn't actually work. Wacky stuff.
Stops regeneration entirely.