### PR TITLE
adds the ability to purchase missile parts through supply

### DIFF
--- a/code/datums/supplypacks/munitions.dm
+++ b/code/datums/supplypacks/munitions.dm
@@ -46,3 +46,54 @@
 	name = "OFD-Launched Drop Pod"
 	contains = list(/obj/structure/closet/odst)
 	cost = 30
+
+/decl/hierarchy/supply_pack/munition/missilecasing
+	name = "Missile Casing - Empty"
+	contains = list(/obj/structure/missile)
+	cost = 75
+
+/decl/hierarchy/supply_pack/munition/missilethruster
+	name = "Missile Thrusters - Standard"
+	contains = list(/obj/item/missile_equipment/thruster = 5)
+	cost = 40
+
+/decl/hierarchy/supply_pack/munition/missilethrusterpoint
+	name = "Missile Thrusters - Point"
+	contains = list(/obj/item/missile_equipment/thruster/point = 5)
+	cost = 35
+
+/decl/hierarchy/supply_pack/munition/missilethrusterplanet
+	name = "Missile Thrusters - Planet"
+	contains = list(/obj/item/missile_equipment/thruster/planet = 5)
+	cost = 40
+
+/decl/hierarchy/supply_pack/munition/missilethrusterhunter
+	name = "Missile Thrusters - Hunter"
+	contains = list(/obj/item/missile_equipment/thruster/hunter = 5)
+	cost = 45
+
+/decl/hierarchy/supply_pack/munition/missilepayloadexplosive
+	name = "Missile Payload - Explosive"
+	contains = list(/obj/item/missile_equipment/payload/explosive = 5)
+	cost = 45
+
+/decl/hierarchy/supply_pack/munition/missilepayloaddiffuser
+	name = "Missile Payload - Shield Diffuser"
+	contains = list(/obj/item/missile_equipment/payload/diffuser = 5)
+	cost = 40
+
+/decl/hierarchy/supply_pack/munition/missilepayloademp
+	name = "Missile Payload - EMP"
+	contains = list(/obj/item/missile_equipment/payload/emp = 5)
+	cost = 35
+
+/decl/hierarchy/supply_pack/munition/missilepayloadantimissile
+	name = "Missile Payload - Antimissile"
+	contains = list(/obj/item/missile_equipment/payload/antimissile = 5)
+	cost = 40
+
+/decl/hierarchy/supply_pack/munition/missileequipmentautoarm
+	name = "Missile Activator - Automatic"
+	contains = list(/obj/item/missile_equipment/autoarm = 5)
+	cost = 40
+


### PR DESCRIPTION
## About The Pull Request
You can now order all missile parts, including casings, through supply. Missile parts come in packs of five for about 40, depends on the type of missile components. Missile CASINGS are 1 for 75.
## Why It's Good For The Game
Missile supplies should be at least slightly replenishable, this makes sense, and the prices are high enough that it won't overshadow a more complex missile construction option if one is ever added. This also makes munitions actually related to supply.
Talked with Antonkr on prices. Casings are expensive so missile factory would be really hard to pull off.
## Did You Test It?
yes
## Authorship
Rock
## Changelog

:cl:
rscadd: you can now order missile components from supply.
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->