### PR TITLE
Gives combat medic hardsuit chem injector module and medHUD module

### DIFF
--- a/maps/torch/structures/closets.dm
+++ b/maps/torch/structures/closets.dm
@@ -159,6 +159,8 @@
 		/obj/item/weapon/storage/firstaid/combat,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/weapon/material/knife/combat,
+		/obj/item/rig_module/vision/medhud,
+		/obj/item/rig_module/chem_dispenser/injector,
 		/obj/item/bodybag/rescue,
 		/obj/item/bodybag/rescue,
 		/obj/item/clothing/glasses/tacgoggles,


### PR DESCRIPTION
## About The Pull Request
Hestia infantry powercreep update #999999. See title.

## Why It's Good For The Game
Combat Medic is meant to give chems while in EVA and the syringe doesn't cut it due to the long delay it has. Additionally, the role is unable to use the tac goggles in their locker because they have to take the medHUD- the hardsuit module should rectifiy this

## Did You Test It?

No

## Authorship
DriedCrustyMilkStains#9365
