### PR TITLE
Unifies naming of suits

### DIFF
--- a/code/modules/ascent/ascent_rigs.dm
+++ b/code/modules/ascent/ascent_rigs.dm
@@ -1,7 +1,7 @@
 // Rigs and gear themselves.
 /obj/item/weapon/rig/mantid
 	name = "alate combat exosuit"
-	desc = "A powerful combat exosuit with integrated power supply, weapon and atmosphere. It's closer to a mech than a rig."
+	desc = "A powerful combat exosuit with integrated power supply, weapon and atmosphere. It's closer to a mech than a hardsuit."
 	icon_state = "kexosuit"
 	item_state = null
 	suit_type = "support exosuit"
@@ -442,7 +442,7 @@
 // Rigs and gear themselves.
 /obj/item/weapon/rig/mantid/seed
 	name = "alate support exosuit"
-	desc = "A powerful support exosuit with integrated power supply, weapon and atmosphere. It's closer to a mech than a rig."
+	desc = "A powerful support exosuit with integrated power supply, weapon and atmosphere. It's closer to a mech than a hardsuit."
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
 		bullet = ARMOR_BALLISTIC_PISTOL,

--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/rig/unathi
 	name = "\improper makeshift breacher chassis control module"
-	desc = "A makeshift Unathi battle-rig. Looks like a fish, moves like a fish, steers like a cow."
+	desc = "A makeshift Unathi hardsuit. Looks like a fish, moves like a fish, steers like a cow."
 	suit_type = "\improper makeshift breacher rig"
 	icon_state = "breacher_rig_cheap"
 	armor = 0

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -1,7 +1,7 @@
 // Light rigs are not space-capable, but don't suffer excessive slowdown or sight issues when depowered.
 /obj/item/weapon/rig/light
 	name = "light suit control module"
-	desc = "A lighter, less armoured hardsuit suit."
+	desc = "A lighter, less armoured hardsuit."
 	icon_state = "ninja_rig"
 	suit_type = "light suit"
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/cell,/obj/item/weapon/storage/)

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -1,7 +1,7 @@
 // Light rigs are not space-capable, but don't suffer excessive slowdown or sight issues when depowered.
 /obj/item/weapon/rig/light
 	name = "light suit control module"
-	desc = "A lighter, less armoured rig suit."
+	desc = "A lighter, less armoured hardsuit suit."
 	icon_state = "ninja_rig"
 	suit_type = "light suit"
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/cell,/obj/item/weapon/storage/)

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -33,7 +33,7 @@
 /obj/item/weapon/rig/industrial
 	name = "industrial suit control module"
 	suit_type = "industrial hardsuit"
-	desc = "A heavy, powerful rig used by construction crews and mining corporations."
+	desc = "A heavy, powerful hardsuit used by construction crews and mining corporations."
 	icon_state = "engineering_rig"
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
@@ -88,7 +88,7 @@
 /obj/item/weapon/rig/eva
 	name = "EVA hardsuit control module"
 	suit_type = "EVA hardsuit"
-	desc = "A light rig for repairs and maintenance to the outside of habitats and vessels."
+	desc = "A light hardsuit for repairs and maintenance to the outside of habitats and vessels."
 	icon_state = "eva_rig"
 	armor = list(
 		melee = ARMOR_MELEE_KNIVES,

--- a/code/modules/clothing/spacesuits/rig/suits/vox.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vox.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/rig/vox
-	name = "alien rig control module"
-	desc = "A strange rig. Parts of it writhe and squirm as if alive. The visor looks more like a thick membrane."
+	name = "alien hardsuit control module"
+	desc = "A strange hardsuit. Parts of it writhe and squirm as if alive. The visor looks more like a thick membrane."
 	suit_type = "alien rig"
 	icon_state = "vox_rig"
 	armor = list(
@@ -47,8 +47,8 @@
 	siemens_coefficient = 0
 
 /obj/item/weapon/rig/vox/quill
-	name = "Quill's rig control module"
-	desc = "The quill's rig suit. It looks exactly like the standard rig suit, but fancier. Parts of it writhe and squirm as if alive. The visor looks more like a thick membrane."
+	name = "Quill's hardsuit control module"
+	desc = "The quill's hardsuit suit. It looks exactly like the standard hardsuit suit, but fancier. Parts of it writhe and squirm as if alive. The visor looks more like a thick membrane."
 	cell_type =  /obj/item/weapon/cell/hyper
 
 	initial_modules = list(

--- a/code/modules/clothing/spacesuits/rig/suits/vox.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vox.dm
@@ -48,7 +48,7 @@
 
 /obj/item/weapon/rig/vox/quill
 	name = "Quill's hardsuit control module"
-	desc = "The quill's hardsuit suit. It looks exactly like the standard hardsuit suit, but fancier. Parts of it writhe and squirm as if alive. The visor looks more like a thick membrane."
+	desc = "The quill's hardsuit. It looks exactly like the standard one, but fancier. Parts of it writhe and squirm as if alive. The visor looks more like a thick membrane."
 	cell_type =  /obj/item/weapon/cell/hyper
 
 	initial_modules = list(

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -1,6 +1,6 @@
 //Regular syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate
-	name = "red space helmet"
+	name = "blood-red space helmet"
 	icon_state = "syndicate"
 	item_state = "syndicate"
 	desc = "A crimson helmet sporting clean lines and durable plating. Engineered to look menacing."
@@ -16,7 +16,7 @@
 	siemens_coefficient = 0.3
 
 /obj/item/clothing/suit/space/syndicate
-	name = "red space suit"
+	name = "blood-red space suit"
 	icon_state = "syndicate"
 	item_state_slots = list(
 		slot_l_hand_str = "space_suit_syndicate",

--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -1,6 +1,6 @@
-//Syndicate rig
+//Syndicate Voidsuit
 /obj/item/clothing/head/helmet/space/void/merc
-	name = "blood-red voidsuit helmet"
+	name = "reinforced blood-red voidsuit helmet"
 	desc = "An advanced helmet designed for work in special operations. Property of Gorlex Marauders."
 	icon_state = "rig0-syndie"
 	item_state = "syndie_helm"
@@ -20,7 +20,7 @@
 
 /obj/item/clothing/suit/space/void/merc
 	icon_state = "rig-syndie"
-	name = "blood-red voidsuit"
+	name = "reinforced blood-red voidsuit"
 	desc = "An advanced suit that protects against injuries during special operations. Property of Gorlex Marauders."
 	item_state_slots = list(
 		slot_l_hand_str = "syndie_voidsuit",

--- a/maps/torch/items/rigs.dm
+++ b/maps/torch/items/rigs.dm
@@ -6,10 +6,10 @@
  * BASE TYPE
  */
 /obj/item/weapon/rig/command
-	name = "command HCM"
+	name = "command hardsuit control module"
 	suit_type = "command hardsuit"
 	icon = 'maps/torch/icons/obj/uniques.dmi'
-	desc = "A specialized hardsuit rig control module issued to command staff of the SolGov Fleet and their peers."
+	desc = "A specialized hardsuit control module issued to command staff of the SolGov Fleet and their peers."
 	icon_state = "command_rig"
 	armor = list(
 		melee = ARMOR_MELEE_KNIVES,
@@ -73,10 +73,10 @@
 * SEA
 */
 /obj/item/weapon/rig/command/sea
-	name = "Senior NCO HCM"
+	name = "Senior NCO hardsuit control module"
 	suit_type = "command hardsuit"
 	icon = 'maps/torch/icons/obj/uniques.dmi'
-	desc = "A specialized hardsuit rig control module issued to senior NCOs of the SolGov Fleet and their peers."
+	desc = "A specialized hardsuit control module issued to senior NCOs of the SolGov Fleet and their peers."
 	icon_state = "sea_rig"
 	armor = list(
 		melee = ARMOR_MELEE_KNIVES,
@@ -140,9 +140,9 @@
  * EXECUTIVE OFFICER
  */
 /obj/item/weapon/rig/command/xo
-	name = "officer's command HCM"
+	name = "officer's command hardsuit control module"
 	suit_type = "advanced command hardsuit"
-	desc = "A specialized hardsuit rig control module issued to high ranking officers of the SolGov Fleet and their peers."
+	desc = "A specialized hardsuit control module issued to high ranking officers of the SolGov Fleet and their peers."
 	icon_state = "command_XO_rig"
 	armor = list(
 		melee = ARMOR_MELEE_KNIVES,
@@ -180,9 +180,9 @@
  * COMMANDING OFFICER
  */
 /obj/item/weapon/rig/command/co
-	name = "commanding officer's command HCM"
+	name = "commanding officer's command hardsuit control module"
 	suit_type = "advanced command hardsuit"
-	desc = "A specialized hardsuit rig control module issued to commanding officers of the SolGov Fleet."
+	desc = "A specialized hardsuit control module issued to commanding officers of the SolGov Fleet."
 	icon_state = "command_CO_rig"
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
@@ -221,9 +221,9 @@
  * CHIEF MEDICAL OFFICER
  */
 /obj/item/weapon/rig/command/medical
-	name = "medical command HCM"
+	name = "medical command hardsuit control module"
 	suit_type = "medical command hardsuit"
-	desc = "A specialized hardsuit rig control module issued to ranking medical officers of the SolGov Fleet and their peers."
+	desc = "A specialized hardsuit control module issued to ranking medical officers of the SolGov Fleet and their peers."
 	icon_state = "command_med_rig"
 
 	chest_type = /obj/item/clothing/suit/space/rig/command/medical
@@ -264,9 +264,9 @@
 * CHIEF OF SECURITY
 */
 /obj/item/weapon/rig/command/security
-	name = "security command HCM"
+	name = "security command hardsuit control module"
 	suit_type = "security command hardsuit"
-	desc = "A specialized hardsuit rig control module issued to ranking security officers of the SolGov Fleet or Marines and their peers."
+	desc = "A specialized hardsuit control module issued to ranking security officers of the SolGov Fleet or Marines and their peers."
 	icon_state = "command_sec_rig"
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
@@ -311,9 +311,9 @@
 * CHIEF SCIENCE OFFICER
 */
 /obj/item/weapon/rig/command/science
-	name = "research command HCM"
+	name = "research command hardsuit control module"
 	suit_type = "research command hardsuit"
-	desc = "A specialized hardsuit rig control module issued to ranking research officers of the SolGov Fleet."
+	desc = "A specialized hardsuit control module issued to ranking research officers of the SolGov Fleet."
 	icon_state = "command_sci_rig"
 	armor = list(
 		melee = ARMOR_MELEE_KNIVES,
@@ -372,7 +372,7 @@
 * EXPLORATION
 */
 /obj/item/weapon/rig/exploration
-	name = "heavy exploration HCM"
+	name = "heavy exploration hardsuit control module"
 	suit_type = "heavy exploration hardsuit"
 	icon = 'maps/torch/icons/obj/uniques.dmi'
 	desc = "Odyssey' Exoplanet Exploration Armored Unit, A-Unit for short. Built for more hostile (and hungry) environments, it features additional armor and powered exoskeleton."


### PR DESCRIPTION
## About The Pull Request
Removes all references to RIGs from descriptions and naming.
Voidsuit = Anything that can make you operate in space, compared to regular space suits actually capable of usage in combat, if they have armor it's usually named reinforced somewhere
Hardsuit = Anything that can take modules and requires power to run (all RIGs until now)
Exosuits = Ascent snowflake code, still just hardsuits but fancy name for them

## Why It's Good For The Game
People for whatever reason don't know the difference

## Did You Test It?
No, literally just a line changes

## Authorship
Me

## Changelog

:cl:
tweak Rig/Hardsuit naming
/:cl: