### PR TITLE
Vox, Abuse & Plasmamen, Oh My!

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/xenowear_boh.dm
+++ b/code/modules/client/preference_setup/loadout/lists/xenowear_boh.dm
@@ -1,7 +1,20 @@
-
 /datum/gear/cooler_ipc
 	display_name = "cooling unit (IPC)"
 	path = /obj/item/device/suit_cooling_unit
 	sort_category = "Xenowear"
 	whitelisted = list(SPECIES_IPC)
+	cost = 0
+
+/datum/gear/head/plasmasans
+	display_name = "Phoron Restructurant Helmet"
+	path = /obj/item/clothing/head/helmet/space/plasmasans
+	whitelisted = list(SPECIES_PLASMASANS)
+	sort_category = "Xenowear"
+	cost = 0
+
+/datum/gear/suit/plasmasans
+	display_name = "Phoron Restructurant Suit"
+	path = /obj/item/clothing/suit/space/plasmasans
+	whitelisted = list(SPECIES_PLASMASANS)
+	sort_category = "Xenowear"
 	cost = 0

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -240,7 +240,7 @@
 	)
 
 	species_flags = SPECIES_FLAG_NO_SCAN//shouldn't be needed, but in game happenings have shown otherwise. For some reason.
-	spawn_flags = SPECIES_IS_RESTRICTED
+	spawn_flags = SPECIES_CAN_JOIN// | SPECIES_IS_WHITELISTED
 	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
 
 /datum/species/vox/pariah/get_bodytype(var/mob/living/carbon/human/H)

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -240,7 +240,7 @@
 	)
 
 	species_flags = SPECIES_FLAG_NO_SCAN//shouldn't be needed, but in game happenings have shown otherwise. For some reason.
-	spawn_flags = SPECIES_CAN_JOIN// | SPECIES_IS_WHITELISTED
+	spawn_flags = SPECIES_IS_RESTRICTED
 	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
 
 /datum/species/vox/pariah/get_bodytype(var/mob/living/carbon/human/H)

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -2,9 +2,7 @@
 	species_to_job_whitelist = list(
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
 									 /datum/job/roboticist, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender, /datum/job/assistant),
-		/datum/species/vox/ = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
 	 	/datum/species/human/mule = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
-		/datum/species/vox/armalis = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
 	)
 
 	species_to_job_blacklist = list(

--- a/maps/torch/loadout/loadout_xeno.dm
+++ b/maps/torch/loadout/loadout_xeno.dm
@@ -39,4 +39,3 @@
 	whitelisted = list(SPECIES_NABBER)
 	allowed_roles = ENGINEERING_ROLES
 	sort_category = "Xenowear"
-

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -47,9 +47,7 @@
 		/datum/species/custom      = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
 		/datum/species/humanathi      = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
 		/datum/species/tajaran      = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
-		/datum/species/customhuman      = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps, /datum/mil_branch/solgov),
-		/datum/species/vox        = list(/datum/mil_branch/alien),
-		/datum/species/vox/armalis        = list(/datum/mil_branch/alien)
+		/datum/species/customhuman      = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps, /datum/mil_branch/solgov)
 	)
 /*
 	species_to_rank_whitelist = list(

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -77,15 +77,7 @@
 	species_to_branch_blacklist = list(
 		/datum/species/human   = list(/datum/mil_branch/alien, /datum/mil_branch/skrell_fleet),
 		/datum/species/machine = list(/datum/mil_branch/alien, /datum/mil_branch/skrell_fleet),
-		/datum/species/vox     = list(
-			/datum/mil_branch/expeditionary_corps,
-			/datum/mil_branch/fleet,
-			/datum/mil_branch/marine_corps,
-			/datum/mil_branch/civilian,
-			/datum/mil_branch/private_security,
-			/datum/mil_branch/solgov,
-			/datum/mil_branch/skrell_fleet
-		)
+		/datum/species/vox     = list(/datum/mil_branch/solgov, /datum/mil_branch/fleet, /datum/mil_branch/marine_corps, /datum/mil_branch/skrell_fleet)
 	)
 
 	species_to_branch_whitelist = list(
@@ -100,8 +92,9 @@
 		/datum/species/tajaran		= list(UNRESTRICTED, SEMIRESTRICTED, /datum/mil_branch/solgov),
  		/datum/species/shapeshifter/promethean	= list(UNRESTRICTED, /datum/mil_branch/solgov, /datum/mil_branch/private_security),
 		/datum/species/plasmasans	= list(/datum/mil_branch/civilian, /datum/mil_branch/solgov),
-		/datum/species/vox			= list(/datum/mil_branch/alien),
-		/datum/species/vox/armalis	= list(/datum/mil_branch/alien)
+		/datum/species/vox			= list(/datum/mil_branch/alien, /datum/mil_branch/civilian, /datum/mil_branch/private_security),
+		/datum/species/vox/armalis	= list(/datum/mil_branch/alien),
+		/datum/species/vox/pariah	= list(/datum/mil_branch/civilian, /datum/mil_branch/private_security),
 	)
 
 	species_to_rank_whitelist = list(

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -93,8 +93,7 @@
  		/datum/species/shapeshifter/promethean	= list(UNRESTRICTED, /datum/mil_branch/solgov, /datum/mil_branch/private_security),
 		/datum/species/plasmasans	= list(/datum/mil_branch/civilian, /datum/mil_branch/solgov),
 		/datum/species/vox			= list(/datum/mil_branch/alien, /datum/mil_branch/civilian, /datum/mil_branch/private_security),
-		/datum/species/vox/armalis	= list(/datum/mil_branch/alien),
-		/datum/species/vox/pariah	= list(/datum/mil_branch/civilian, /datum/mil_branch/private_security),
+		/datum/species/vox/armalis	= list(/datum/mil_branch/alien)
 	)
 
 	species_to_rank_whitelist = list(


### PR DESCRIPTION
- - -
Changes:
 - Standard Vox, in line with lore, are now permitted to serve as contractors via third parties aboard the ship. They're only permitted in Private Security and Civilian roles.
- - -
Bugfixes:
 - Plasmamen provided suits in Xenowear, allowing them to bypass the overwear that some jobs they can play as force. They will no longer burn to death out of cryo, rejoice!
- - -