### PR TITLE
Headgib Adjustments

### DIFF
--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -274,14 +274,15 @@
 		affecting.losebreath += 25
 		affecting.adjustOxyLoss(25)
 		total_damage += damage
-	if(E.brute_dam >= 100)
-		E.droplimb(1,DROPLIMB_EDGE)
-
 	if(total_damage)
 		user.visible_message("<span class='danger'>\The [user] slit [affecting]'s throat open with \the [W]!</span>")
 
 		if(W.hitsound)
 			playsound(affecting.loc, W.hitsound, 50, 1, -1)
+
+		if(E.brute_dam >= 100)
+			E.droplimb(1,DROPLIMB_EDGE)
+			user.visible_message("<span class='danger'>\The [user] has torn [affecting]'s head off with \the [W]!</span>")
 
 	G.last_action = world.time
 

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -274,7 +274,8 @@
 		affecting.losebreath += 25
 		affecting.adjustOxyLoss(25)
 		total_damage += damage
-
+	if(E.brute_dam >= 100)
+		E.droplimb(1,DROPLIMB_EDGE)
 
 	if(total_damage)
 		user.visible_message("<span class='danger'>\The [user] slit [affecting]'s throat open with \the [W]!</span>")

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -354,6 +354,9 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 //   and the brute damage dealt exceeds the tearoff threshold, the organ is torn off.
 /obj/item/organ/external/proc/attempt_dismemberment(brute, burn, sharp, edge, used_weapon, spillover, force_droplimb)
 	//Check edge eligibility
+	if(src.organ_tag == BP_HEAD)
+		return FALSE
+
 	var/edge_eligible = 0
 	if(edge)
 		if(istype(used_weapon,/obj/item))

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -333,6 +333,6 @@
 /decl/surgery_step/generic/amputate/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, sawing through the bone in [target]'s [affected.name] with \the [tool]!</span>", \
-	"<span class='warning'>Your hand slips, sawwing through the bone in [target]'s [affected.name] with \the [tool]!</span>")
+	"<span class='warning'>Your hand slips, sawing through the bone in [target]'s [affected.name] with \the [tool]!</span>")
 	affected.take_external_damage(30, 0, (DAM_SHARP|DAM_EDGE), used_weapon = tool)
 	affected.fracture()


### PR DESCRIPTION
Hi hi!

As discussed with Carl some time prior, this reworks headgibbing. Right now it's a little bit too easy for one armed player to just perma GGNORE another after taking them down, which isn't really ideal for anyone involved. Being able to experience some kind of gameplay, even if it's just prison RP after being slain, is generally preferably to just being dead.

However, it's important that the ability to remove the head is preserved as it absolutely _can be_ the appropriate call, both for loyalists and antagonists. As such, BEHOLD!

- Simply applying damage to the head will no longer remove it. It can no longer be ashed or gibbed like other body parts, which still can.
- The head can still be removed surgically by tabling the target and applying a circ-saw to the head on help intent.
- It can also be removed via performing a throat-slit while the head is past 100 brute damage. This is performed by having the target in a redgrab, being on harm intent, aiming for the head and clicking them with a sharp object in the active hand. If they've taken over 100 brute, it'll be torn off.

**It's still absolutely possible to decap someone by violence, it just takes a deliberate effort and a couple of moments of your time rather than continuing to click the horizontal man.**

Big, **big** thanks to Anton for helping me with this despite his reservations, as much as this genuinely was a great learning experience for me there was one major roadblock that I just wasn't getting past without his help. Greatly appreciated!

Also fixes a totally unrelated typo that I found while digging through surgery code.


