### PR TITLE
Restricts Vox to Merchant Only

### DIFF
--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -3,6 +3,8 @@
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
 									 /datum/job/roboticist, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender, /datum/job/assistant),
 	 	/datum/species/human/mule = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
+	 	/datum/species/vox/ = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
+	 	/datum/species/vox/armalis = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
 	)
 
 	species_to_job_blacklist = list(

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -92,7 +92,7 @@
 		/datum/species/tajaran		= list(UNRESTRICTED, SEMIRESTRICTED, /datum/mil_branch/solgov),
  		/datum/species/shapeshifter/promethean	= list(UNRESTRICTED, /datum/mil_branch/solgov, /datum/mil_branch/private_security),
 		/datum/species/plasmasans	= list(/datum/mil_branch/civilian, /datum/mil_branch/solgov),
-		/datum/species/vox			= list(/datum/mil_branch/alien, /datum/mil_branch/civilian, /datum/mil_branch/private_security),
+		/datum/species/vox			= list(/datum/mil_branch/alien, /datum/mil_branch/civilian),
 		/datum/species/vox/armalis	= list(/datum/mil_branch/alien)
 	)
 


### PR DESCRIPTION
## About The Pull Request
This PR aims to remove Vox from the ship's crew, however keeps them as an option for the merchant roles.

## Why It's Good For The Game
While it was funny for the first few rounds, Vox on the ship in roles such as security, engineering, medical, and more is incredibly strange. While I've heard of *lore* being added for it, I see no such thing.

Vox as a species are mistrusted by SolGov and have a reputation for backstabbing at a moment's notice. There is no sane way in which SolGov would suddenly allow this race of raiders, pirates, and scavengers to be in charge of the security and maintenance of a military vessel. It's extremely jarring and frankly seems a little like pandering. It undermines the species and domesticates them in a way that makes it far less interesting to encounter Vox. Never mind the random PVP on Vox since this has been added.

At this point, why not just add Ascent to the ship if we're letting the standard slip this low.

EDIT: To add to this, using the actual Weezer lore doc:

" The Vox are a proud people, and face much in the way of mistrust by the galactic community, but this will not stop them."

It is 100% part of our current lore that Vox are widely mistrusted. I did not make that up. The reason I elected to keep Vox as merchants is because an entire culture of 'Sworn Merchants' exists in our lore. This is fine. However it also is stated that 
groups such as the Voidborne only interact with humans that have proven their loyalty to the Vox, and there is absolutely **no** lore related to Vox that defect and join Sol. There is quite literally zero reason Vox should be aboard Sol military vessels at the moment.

That said, I am open to adding Vox to other off-ship roles such as the Bearcat and colony. These are multi-cultural communities with no allegiance to any large empire or group. This would make far more sense than Vox aboard a military vessel of a nation that is known for their mistrust of aliens, going so far as to declare their own citizens 'second class' if they are heavily genemodded or vat grown.

## Did You Test It?
Yes.

## Authorship
PurplePineapple#0001

## Changelog

:cl:
tweak: Vox are no longer allowed on ship-bound roles. They are still permitted in merchant slots to fit with their current lore.
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->