### PR TITLE
Adds MULE's to the list of species that may not be a Tiro.

### DIFF
--- a/maps/away/ascent/ascent_jobs.dm
+++ b/maps/away/ascent/ascent_jobs.dm
@@ -257,7 +257,7 @@
 	As this is a roleplaying role, you will be expected to uphold a certain bare-minimum standard when playing. If you have devoted yourself to the role of Tiro enough to be considered a <b>Par</b> by the Ascent (and have accepted the equipment), \
 	please note that you will <u>be held to a higher standard</u> in regards to roleplay as them!"
 	outfit_type = /decl/hierarchy/outfit/job/tiro
-	blacklisted_species = list(SPECIES_VOXPARIAH, SPECIES_VOX, SPECIES_VOX_ARMALIS, SPECIES_ADHERENT)
+	blacklisted_species = list(SPECIES_VOXPARIAH, SPECIES_VOX, SPECIES_VOX_ARMALIS, SPECIES_ADHERENT, SPECIES_MULE)
 	whitelisted_species = null
 	loadout_allowed = TRUE
 	skill_points = 34


### PR DESCRIPTION
This removes MULEs from the list of species that can be a Tiro. 

Their psionic potential already makes the monstrously stronk, having them be able to take a role that's designed to bring them to par with the Ascent is just absolutely wild.