### PR TITLE
Neural Lace Changes

### DIFF
--- a/code/modules/boh/organs/disintegratable.dm
+++ b/code/modules/boh/organs/disintegratable.dm
@@ -7,7 +7,6 @@
  * 	can_disintegrate is defined in this file returns 1 by default
  *
  * 	Currently used mainly to nerf disintegration of certain essential player organs like;
- *		* Neural lace					(modules/organs/internal/stack.dm)
  *		* MMI holders for FBPs			(modules/organs/internal/species/fbp.dm)
  *		* Synthetic brains for IPCs		(modules/organs/internal/species/ipc.dm)
  *
@@ -53,9 +52,6 @@
 	return ESSENTIAL_ORGAN_DISINTEGRATABLE
 
 /obj/item/organ/internal/mmi_holder/can_disintegrate()
-	return ESSENTIAL_ORGAN_DISINTEGRATABLE
-
-/obj/item/organ/internal/stack/can_disintegrate()
 	return ESSENTIAL_ORGAN_DISINTEGRATABLE
 
 #undef ESSENTIAL_ORGAN_DISINTEGRATABLE

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -900,11 +900,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(DROPLIMB_BURN)
 			new /obj/effect/decal/cleanable/ash(get_turf(victim))
 			for(var/obj/item/I in src)
-				if(I.w_class > ITEM_SIZE_SMALL && !istype(I,/obj/item/organ))
+				if(I.w_class > ITEM_SIZE_SMALL)
 					I.dropInto(loc)
 			for(var/obj/item/organ/O in internal_organs)
-				if(!O.can_disintegrate())
-					O.drop_organ(victim, src)
+				O.drop_organ(victim, src)
 			qdel(src)
 		if(DROPLIMB_BLUNT)
 			var/obj/gore
@@ -923,9 +922,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			gore.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),30)
 
 			for(var/obj/item/organ/I in internal_organs)
-				I.removed()
-				if(!QDELETED(I) && isturf(loc))
-					I.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),30)
+				I.drop_organ(victim, src)
 
 			for(var/obj/item/I in src)
 				I.dropInto(loc)

--- a/code/modules/organs/internal/stack.dm
+++ b/code/modules/organs/internal/stack.dm
@@ -29,7 +29,7 @@
 
 /obj/item/organ/internal/stack/examine(var/mob/user)
 	. = ..(user)
-	if(istype(backup) && !is_broken()) // Do we have a backup and is the lace functioning?
+	if(istype(backup)) // Do we have a backup?
 		if(user.skill_check(SKILL_DEVICES, SKILL_EXPERT)) // Can we even tell what the blinking means?
 			if(find_dead_player(ownerckey, 1)) // Is the player still around and dead?
 				to_chat(user, "<span class='notice'>The light on [src] is blinking rapidly. Someone might have a second chance.</span>")
@@ -54,8 +54,13 @@
 		if(owner.ckey)
 			ownerckey = owner.ckey
 
-/obj/item/organ/internal/stack/Destroy()
+/obj/item/organ/internal/stack/New()
 	..()
+	do_backup()
+	robotize()
+
+/obj/item/organ/internal/stack/Destroy()
+	. = ..()
 	var/obj/gore
 	playsound(src, "shatter", 70, 1)
 	gore = new /obj/item/weapon/material/shard(get_turf(owner), MATERIAL_GLASS)
@@ -63,22 +68,6 @@
 	gore = new /obj/effect/decal/cleanable/blood/gibs(get_turf(owner))
 	gore.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),30)
 	owner.visible_message(SPAN_WARNING("[owner]'s neck explodes in a shower of strange blue liquid and metallic fragments!"))
-	owner.death()
-	return
-
-/obj/item/organ/internal/stack/Process()
-	..()
-
-	if(!owner || removed())
-		return
-	if(is_broken())
-		Destroy()
-
-/obj/item/organ/internal/stack/New()
-	..()
-	do_backup()
-	robotize()
-	Process()
 
 /obj/item/organ/internal/stack/proc/backup_inviable()
 	return 	(!istype(backup) || backup == owner.mind || (backup.current && backup.current.stat != DEAD))
@@ -101,7 +90,6 @@
 	relacetime = world.time
 	if(world.time >= relacetime + 30 MINUTES)
 		to_chat(owner, SPAN_NOTICE("You feel like you have recovered slightly from your ordeal, still wouldn't make a habit of dying."))
-	Process()
 	return 1
 
 /obj/item/organ/internal/stack/removed()

--- a/code/modules/organs/internal/stack.dm
+++ b/code/modules/organs/internal/stack.dm
@@ -29,7 +29,7 @@
 
 /obj/item/organ/internal/stack/examine(var/mob/user)
 	. = ..(user)
-	if(istype(backup)) // Do we have a backup?
+	if(istype(backup) && !is_broken()) // Do we have a backup and is the lace functioning?
 		if(user.skill_check(SKILL_DEVICES, SKILL_EXPERT)) // Can we even tell what the blinking means?
 			if(find_dead_player(ownerckey, 1)) // Is the player still around and dead?
 				to_chat(user, "<span class='notice'>The light on [src] is blinking rapidly. Someone might have a second chance.</span>")
@@ -54,13 +54,8 @@
 		if(owner.ckey)
 			ownerckey = owner.ckey
 
-/obj/item/organ/internal/stack/New()
-	..()
-	do_backup()
-	robotize()
-
 /obj/item/organ/internal/stack/Destroy()
-	. = ..()
+	..()
 	var/obj/gore
 	playsound(src, "shatter", 70, 1)
 	gore = new /obj/item/weapon/material/shard(get_turf(owner), MATERIAL_GLASS)
@@ -68,6 +63,22 @@
 	gore = new /obj/effect/decal/cleanable/blood/gibs(get_turf(owner))
 	gore.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),30)
 	owner.visible_message(SPAN_WARNING("[owner]'s neck explodes in a shower of strange blue liquid and metallic fragments!"))
+	owner.death()
+	return
+
+/obj/item/organ/internal/stack/Process()
+	..()
+
+	if(!owner || removed())
+		return
+	if(is_broken())
+		Destroy()
+
+/obj/item/organ/internal/stack/New()
+	..()
+	do_backup()
+	robotize()
+	Process()
 
 /obj/item/organ/internal/stack/proc/backup_inviable()
 	return 	(!istype(backup) || backup == owner.mind || (backup.current && backup.current.stat != DEAD))
@@ -90,6 +101,7 @@
 	relacetime = world.time
 	if(world.time >= relacetime + 30 MINUTES)
 		to_chat(owner, SPAN_NOTICE("You feel like you have recovered slightly from your ordeal, still wouldn't make a habit of dying."))
+	Process()
 	return 1
 
 /obj/item/organ/internal/stack/removed()

--- a/code/modules/organs/internal/stack.dm
+++ b/code/modules/organs/internal/stack.dm
@@ -13,6 +13,7 @@
 	vital = 1
 	origin_tech = list(TECH_BIO = 4, TECH_MATERIAL = 4, TECH_MAGNET = 2, TECH_DATA = 3)
 	relative_size = 25
+	max_damage = 30
 
 	var/ownerckey
 	var/invasive
@@ -60,7 +61,6 @@
 	robotize()
 
 /obj/item/organ/internal/stack/Destroy()
-	. = ..()
 	var/obj/gore
 	playsound(src, "shatter", 70, 1)
 	gore = new /obj/item/weapon/material/shard(get_turf(owner), MATERIAL_GLASS)
@@ -68,6 +68,8 @@
 	gore = new /obj/effect/decal/cleanable/blood/gibs(get_turf(owner))
 	gore.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),30)
 	owner.visible_message(SPAN_WARNING("[owner]'s neck explodes in a shower of strange blue liquid and metallic fragments!"))
+	owner.death()
+	..()
 
 /obj/item/organ/internal/stack/proc/backup_inviable()
 	return 	(!istype(backup) || backup == owner.mind || (backup.current && backup.current.stat != DEAD))
@@ -114,3 +116,10 @@
 	if(default_language) owner.default_language = default_language
 	owner.languages = languages.Copy()
 	to_chat(owner, "<span class='notice'>Consciousness slowly creeps over you as your new body awakens.</span>")
+
+/obj/item/organ/internal/stack/Process()
+	..()
+	if(!owner)
+		return
+	if(damage == max_damage)
+		Destroy()

--- a/code/modules/organs/internal/stack.dm
+++ b/code/modules/organs/internal/stack.dm
@@ -12,7 +12,7 @@
 	status = ORGAN_ROBOTIC
 	vital = 1
 	origin_tech = list(TECH_BIO = 4, TECH_MATERIAL = 4, TECH_MAGNET = 2, TECH_DATA = 3)
-	relative_size = 25
+	relative_size = 95 //The relative chance your lace is hit //TEST VALUE, DON'T YELL AT ME -PurplePineapple
 	max_damage = 30
 
 	var/ownerckey

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -245,7 +245,7 @@
 			var/o_a =  (O.gender == PLURAL) ? "" : "a "
 			if(O.organ_tag == BP_POSIBRAIN && !target.species.has_organ[BP_POSIBRAIN])
 				to_chat(user, SPAN_WARNING("There's no place in [target] to fit \the [O.organ_tag]."))
-			else if((O.damage > (O.max_damage * 0.75)) && O.organ_tag != BP_STACK)//Skips neural lace, they can't be repaired outside the body.
+			else if((O.damage > (O.max_damage * 0.75)) && O.organ_tag)
 				to_chat(user, SPAN_WARNING("\The [O.name] [o_is] in no state to be transplanted."))
 			else if(O.w_class > affected.cavity_max_w_class)
 				to_chat(user, SPAN_WARNING("\The [O.name] [o_is] too big for [affected.cavity_name] cavity!"))


### PR DESCRIPTION
## About The Pull Request
This PR changes the way neural laces work, and fixes gibbing not dropping organs.

## Why It's Good For The Game
Originally, this PR was to fix a headgibbing bug, but at Carl's request it has changed to be a rework of laces in general. Laces can now be destroyed if they take enough damage. A lace being destroyed will instantly kill the owner.

Laces are not affected by EMPs or toxins still. However being shot in the head repeatedly will damage your lace. You are more likely to die suddenly from head trauma with a lace than without.

Future PR may need to change lace hit chances or its health. Won't know for sure without some proper gameplay. Consider test merging this before committing to it.

Lace dropping upon headgib:
![image](https://user-images.githubusercontent.com/67706292/159076661-2ce7b6dd-454e-4ae0-9bbf-467b13f4f88e.png)

Lace destruction due to damage:
![image](https://user-images.githubusercontent.com/67706292/159140850-78143f14-5833-406e-84bc-e9de317dd917.png)

## Did You Test It?
Yes.

## Authorship
PurplePineapple#0001

## Changelog

:cl:
tweak: Organs are now guaranteed to drop when you gib a body part with them.
bugfix: Neural laces can now be non-functional if they take enough damage. A neural lace being destroyed kills its owner.
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->