### PR TITLE
AAAAAAAAARGH, I NEED A prescription glasses.

### DIFF
--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -684,6 +684,15 @@
 	icon_state = "spiderling";
 	name = "dead spider"
 	},
+/obj/structure/table/rack/shelf,
+/obj/item/clothing/glasses/prescription,
+/obj/item/clothing/glasses/prescription,
+/obj/item/clothing/glasses/prescription,
+/obj/item/clothing/glasses/sunglasses/prescription,
+/obj/item/clothing/glasses/sunglasses/prescription,
+/obj/item/clothing/glasses/sunglasses/prescription,
+/obj/item/clothing/glasses/prescription/hipster,
+/obj/item/clothing/glasses/prescription/hipster,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -2092,6 +2092,12 @@
 	icon_state = "railing0-1";
 	dir = 1
 	},
+/obj/item/clothing/glasses/sunglasses/prescription,
+/obj/item/clothing/glasses/sunglasses/prescription,
+/obj/item/clothing/glasses/sunglasses/prescription,
+/obj/item/clothing/glasses/sunglasses/prescription,
+/obj/item/clothing/glasses/sunglasses/prescription,
+/obj/item/clothing/glasses/sunglasses/prescription,
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "dP" = (

--- a/maps/antag_spawn/ninja/ninja_base.dmm
+++ b/maps/antag_spawn/ninja/ninja_base.dmm
@@ -1101,6 +1101,7 @@
 /obj/item/weapon/storage/belt/utility/full,
 /obj/item/device/multitool,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/unsimulated/floor{
 	dir = 2;
 	icon_state = "dark"
@@ -1108,8 +1109,15 @@
 /area/map_template/ninja_dojo/dojo)
 "cs" = (
 /obj/structure/table/steel_reinforced,
-/obj/item/device/multitool/hacktool,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/clothing/glasses/prescription,
+/obj/item/clothing/glasses/prescription,
+/obj/item/clothing/glasses/prescription,
+/obj/item/clothing/glasses/prescription,
+/obj/item/clothing/glasses/sunglasses/prescription,
+/obj/item/clothing/glasses/sunglasses/prescription,
+/obj/item/clothing/glasses/sunglasses/prescription,
+/obj/item/clothing/glasses/sunglasses/prescription,
 /turf/unsimulated/floor{
 	dir = 2;
 	icon_state = "dark"


### PR DESCRIPTION
Adds glasses to off-ship antag spawns since some of you hecking people are blind when you spawn.

yes I tested it, yes I pressed 4 buttons on the map editor.

🆑 Gibong
tweak - Antags off-ship spawns now get glasses. Hooray for the blind people
/🆑