### PR TITLE
Seizure moment

### DIFF
--- a/code/modules/boh/ascent2/firearms.dm
+++ b/code/modules/boh/ascent2/firearms.dm
@@ -5,7 +5,7 @@
 	name = "defence lance"
 	desc = "A modified variant of the Ascent particle lance, usually carried by rearline combatants."
 	force = 6
-	max_shots = 2
+	max_shots = 6
 	burst = 2
 	move_delay = 2
 	one_hand_penalty = 0

--- a/code/modules/boh/ascent2/firearms.dm
+++ b/code/modules/boh/ascent2/firearms.dm
@@ -5,7 +5,7 @@
 	name = "defence lance"
 	desc = "A modified variant of the Ascent particle lance, usually carried by rearline combatants."
 	force = 6
-	max_shots = 6
+	max_shots = 2
 	burst = 2
 	move_delay = 2
 	one_hand_penalty = 0
@@ -15,6 +15,23 @@
 	firemodes = list(
 		list(mode_name="primary",   projectile_type = /obj/item/projectile/beam/particle/defence),
 		)
+	var/windup = 5
+
+/obj/item/weapon/gun/energy/particle/support/handle_post_fire(mob/user, atom/target)
+	..()
+
+/obj/item/weapon/gun/energy/particle/support/afterattack(atom/A, mob/living/user, adjacent, params)
+	if(adjacent) return
+
+	if(!user.aiming)
+		user.aiming = new(user)
+
+	if(windup > 0)
+		if(do_after(user, windup)) // Do the windup.
+			Fire(A,user,params) //Otherwise, fire normally.
+	else
+		Fire(A,user,params) //Otherwise, fire normally.
+
 
 /obj/item/weapon/gun/energy/drone_particle//near identical to standard one, just without the limit as it's not a subpath
 	name = "particle lance"

--- a/code/modules/boh/ascent2/projectiles.dm
+++ b/code/modules/boh/ascent2/projectiles.dm
@@ -5,9 +5,16 @@
 	name = "particle beam"
 	icon_state = "particle"
 	damage = 5
-	agony = 90
+	agony = 85
 	eyeblur = 1
 	damage_type = ELECTROCUTE//Can be stopped entirely by certain armors.
+
+/obj/item/projectile/beam/particle/defence/on_hit(atom/target, blocked, def_zone)
+	. = ..()
+	if(isliving(target))
+		var/mob/living/L = target
+		to_chat(target, SPAN_WARNING("You feel incredible pain, as if something is invading your mind!"))
+		L.Paralyse(2 SECONDS)
 
 /////////
 //lethals

--- a/code/modules/boh/ascent2/projectiles.dm
+++ b/code/modules/boh/ascent2/projectiles.dm
@@ -5,16 +5,9 @@
 	name = "particle beam"
 	icon_state = "particle"
 	damage = 5
-	agony = 85
+	agony = 90
 	eyeblur = 1
 	damage_type = ELECTROCUTE//Can be stopped entirely by certain armors.
-
-/obj/item/projectile/beam/particle/defence/on_hit(atom/target, blocked, def_zone)
-	. = ..()
-	if(isliving(target))
-		var/mob/living/L = target
-		to_chat(target, SPAN_WARNING("You feel incredible pain, as if something is invading your mind!"))
-		L.seizure()//Which is why, if it does work, it'll drop a target in one hit for cuffing.
 
 /////////
 //lethals

--- a/code/modules/boh/ascent2/projectiles.dm
+++ b/code/modules/boh/ascent2/projectiles.dm
@@ -13,8 +13,8 @@
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
-		to_chat(target, SPAN_WARNING("You feel incredible pain, as if something is invading your mind!"))
-		L.Paralyse(2 SECONDS)
+		to_chat(target, SPAN_WARNING("You feel your muscles locking up, preventing you from moving!"))
+		L.Paralyse(2 SECONDS) //It's actually 20 ticks (around half a minute) but baycode funny
 
 /////////
 //lethals


### PR DESCRIPTION
## About The Pull Request
Removes seizure from defensive lance but in compensation gives 5 more agony damage and 4 more shots.

## Why It's Good For The Game
Seizure has absolutely no counterplay as is, it ignores any armor and any chemicals you can throw at it. So what essentially this turns it into is stronger stun rifle which security already has. Willing to work out details of this but I just don't see why it should just stay in the way this is (and before someone says this is a salt PR read stats of stun rifle).

## Did You Test It?
Yes

## Authorship
Me

## Changelog

:cl:
tweak: Defense Lance
/:cl: