### PR TITLE
Crossfire/Xenophage doubling requirements

### DIFF
--- a/code/game/gamemodes/mixed/crossfire.dm
+++ b/code/game/gamemodes/mixed/crossfire.dm
@@ -3,7 +3,7 @@
 	round_description = "Mercenaries and raiders are preparing for a nice visit..."
 	extended_round_description = "Nothing can possibly go wrong with lots of people and lots of guns, right?"
 	config_tag = "crossfire"
-	required_players = 14
+	required_players = 30
 	required_enemies = 6
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_RAIDER, MODE_MERCENARY)

--- a/code/game/gamemodes/mixed/infestation.dm
+++ b/code/game/gamemodes/mixed/infestation.dm
@@ -3,7 +3,7 @@
 	round_description = "There's something in the walls!"
 	extended_round_description = "Objective: Survive."
 	config_tag = "infestation"
-	required_players = 15
+	required_players = 32
 	required_enemies = 5
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_XENOMORPH)


### PR DESCRIPTION
## About The Pull Request

Doubles the amount needed for Benos/Crossfire since its usually leaving with 3 people shipside while crossfire is just TDM and benos is boring

## Why It's Good For The Game

makes two annoying gamemodes a bit better to play

## Did You Test It?

yes

## Authorship

Myself

## Changelog

:cl: Gilvian

* Tweak - Benos and Crossfire require more people to play
/:cl: