### PR TITLE
Glowing eyes no longer glow through fucking voidsuits.

### DIFF
--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -37,11 +37,15 @@
 	var/icon/I = get_onhead_icon()
 	if(I)
 		var/cache_key = "[last_eye_cache_key]-glow"
-		if(!human_icon_cache[cache_key])
-			var/image/eye_glow = image(I)
+		var/blockages = 0
+		var/image/eye_glow = image(I)
+		for(var/obj/item/protection in list(owner.head, owner.wear_mask, owner.glasses))
+			if(protection && (protection.body_parts_covered & EYES))
+				blockages = 1
+		if(blockages == 0)
 			eye_glow.layer = EYE_GLOW_LAYER
 			eye_glow.plane = EFFECTS_ABOVE_LIGHTING_PLANE
-			human_icon_cache[cache_key] = eye_glow
+		human_icon_cache[cache_key] = eye_glow
 		return human_icon_cache[cache_key]
 
 /obj/item/organ/internal/eyes/proc/change_eye_color()


### PR DESCRIPTION
## About The Pull Request
Glowing eyes stop glowing if they're covered by glasses, masks, or voidsuit helmets, stopping the most obnoxious of its effects.
## Why It's Good For The Game
it's a comically ugly and broken effect. I don't think this code will be any laggier because this *only* runs on species who have eye glow anyways.
## Did You Test It?
This took me eight hours.
## Authorship
Rock
## Changelog

:cl:
fix:glowing eyes no longer pierce through fucking voidsuits.
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->