### PR TITLE
vox removal (of the useless holopads)

### DIFF
--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -3976,11 +3976,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint/vox,
 /area/voxship/engineering)
-"EA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/techmaint/vox,
-/area/voxship/engineering)
 "EB" = (
 /obj/structure/window/phoronreinforced{
 	dir = 8
@@ -4982,16 +4977,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint/vox,
 /area/voxship/engineering)
-"Mz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/reinforced/vox,
-/area/voxship/armory)
 "MD" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4
@@ -5733,10 +5718,6 @@
 	},
 /turf/simulated/floor/reinforced/vox,
 /area/voxship/misslie)
-"Ty" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/reinforced/vox,
-/area/voxship/ofd)
 "TE" = (
 /obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/tiled/techmaint/vox,
@@ -14360,7 +14341,7 @@ uh
 Bt
 KF
 oI
-Ty
+oI
 iS
 qI
 Bt
@@ -16637,7 +16618,7 @@ Wb
 eQ
 YO
 GK
-Mz
+HM
 YO
 YO
 eQ
@@ -23784,7 +23765,7 @@ hb
 Vd
 jW
 CV
-EA
+Sl
 Sl
 Jr
 al

--- a/maps/away/voxship/voxship-2.dmm
+++ b/maps/away/voxship/voxship-2.dmm
@@ -389,13 +389,6 @@
 /obj/random/drinkbottle,
 /turf/simulated/floor/tiled/techmaint/vox,
 /area/voxship/dorms)
-"gf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/techmaint/vox,
-/area/voxship/hydro)
 "gl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -986,7 +979,6 @@
 "os" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/kafel_full{
 	initial_gas = list("nitrogen" = 101.23)
 	},
@@ -2341,7 +2333,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/hologram/holopad/longrange,
 /turf/simulated/floor/tiled/white/usedup{
 	initial_gas = list("nitrogen" = 101.23)
 	},
@@ -16006,7 +15997,7 @@ bC
 qE
 ah
 Xl
-gf
+fM
 yW
 UF
 uB


### PR DESCRIPTION
clickbait title oh no

## About The Pull Request

Removes low-range holopads since they are being useless, only leaving the long range ones in the Vox medical, quills room and the control room

## Why It's Good For The Game

So people don't scroll down on long range holopads and just see 8 useless vox pads.

## Did You Test It?

yes

## Authorship
BoH-Bay hestia github
## Changelog

:cl: 
* tweak - removes few useless holopads from vox ship
/:cl:
