### PR TITLE
Fleet uniforms moment

### DIFF
--- a/maps/torch/job/outfits/boh_outfits.dm
+++ b/maps/torch/job/outfits/boh_outfits.dm
@@ -39,7 +39,7 @@
 	pda_type = /obj/item/modular_computer/pda/heads
 
 /decl/hierarchy/outfit/job/torch/crew/command/sea/fleet
-	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/command
+	uniform = /obj/item/clothing/under/solgov/utility/fleet/polopants/command
 
 /decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer/marine
 	name = OUTFIT_JOB_NAME("Bridge Officer - Marine Corps")

--- a/maps/torch/loadout/loadout_uniform_boh.dm
+++ b/maps/torch/loadout/loadout_uniform_boh.dm
@@ -14,15 +14,14 @@
 	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(uniform)
 
 /datum/gear/uniform/fleet
-	display_name = "fleet fatigue"
+	display_name = "fleet coveralls"
 	path = /obj/item/clothing/under/solgov/utility/fleet
 	cost = 0
 	allowed_branches = list(/datum/mil_branch/fleet)
 
 /datum/gear/uniform/fleet/officer
-	display_name = "fleet officer fatigues"
+	display_name = "fleet officer's coveralls"
 	path = /obj/item/clothing/under/solgov/utility/fleet/officer
 	cost = 0
 	allowed_branches = list(/datum/mil_branch/fleet)
 	allowed_roles = COMMANDANDOFFICER_ROLES
-


### PR DESCRIPTION
## About The Pull Request
Changes base FSEA uniform from EC command to fleet polo and pants.
Changes loadout name of the "fatigue and officer fatigues" to coveralls since that's what they are

## Why It's Good For The Game
He is a SNCO while that might sound like he is an officer, he infact is just enlisted and has zero reason to use officer uniform.
Visual clarity.

## Did You Test It?
Yes

## Authorship
Me

## Changelog

:cl:
tweak: Base FSEA uniform
tweak: Coveralls loadout name
/:cl: