### PR TITLE
Buffs shields.

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -100,7 +100,7 @@
 	throw_range = 3
 	w_class = ITEM_SIZE_HUGE
 	matter = list(MATERIAL_PLASTEEL = 8500)
-	max_block = 55
+	max_block = 50
 	can_block_lasers = TRUE
 	slowdown_general = 1.5
 

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -100,9 +100,9 @@
 	throw_range = 3
 	w_class = ITEM_SIZE_HUGE
 	matter = list(MATERIAL_PLASTEEL = 8500)
-	max_block = 50
+	max_block = 55
 	can_block_lasers = TRUE
-	slowdown_general = 1
+	slowdown_general = 1.5
 
 /obj/item/weapon/shield/buckler
 	name = "buckler"

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -100,7 +100,7 @@
 	throw_range = 3
 	w_class = ITEM_SIZE_HUGE
 	matter = list(MATERIAL_PLASTEEL = 8500)
-	max_block = 55
+	max_block = 50
 	can_block_lasers = TRUE
 	slowdown_general = 1
 

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -31,7 +31,7 @@
 
 /obj/item/weapon/shield
 	name = "shield"
-	var/base_block_chance = 60
+	var/base_block_chance = 70
 
 /obj/item/weapon/shield/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 	if(user.incapacitated())
@@ -100,9 +100,9 @@
 	throw_range = 3
 	w_class = ITEM_SIZE_HUGE
 	matter = list(MATERIAL_PLASTEEL = 8500)
-	max_block = 50
+	max_block = 55
 	can_block_lasers = TRUE
-	slowdown_general = 1.5
+	slowdown_general = 1
 
 /obj/item/weapon/shield/buckler
 	name = "buckler"


### PR DESCRIPTION
## About The Pull Request
When shields were first introduced and these values set, you could accurately fire longarms while holding one. This is no longer the case, and a result, they have fallen into disuse, only used for the rule of cool. This PR slightly buffs the combat shield's block chance, the amount of damage it is capable of blocking, and moves the shield's slowdown to match it's current capabilities.

## Why It's Good For The Game
Adds more options to the stale combat meta.

## Did You Test It?
Yes.
## Authorship
Rafflesia
## Changelog