### PR TITLE
protolathe Process() now takes into account ticks are every 2s

### DIFF
--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -33,7 +33,7 @@
 	var/datum/design/D = queue[1]
 	if(canBuild(D))
 		busy = 1
-		progress += speed
+		progress += speed * 2
 		if(progress >= D.time)
 			build(D)
 			progress = 0


### PR DESCRIPTION
## About The Pull Request

time of recipes is generally measured in S, but process ticks happen every 2s so protolathes were 2x as slow
## Why It's Good For The Game

protolathe slow af, more research buffs soon
## Did You Test It?

no

## Changelog

:cl:
balance: protolathe is 2x as fast (more a oversightfix than anything)
/:cl: