### PR TITLE
makes diona roast recipe possible

### DIFF
--- a/code/modules/cooking/recipes/recipes_oven.dm
+++ b/code/modules/cooking/recipes/recipes_oven.dm
@@ -17,7 +17,7 @@
 /datum/recipe/dionaroast
 	appliance = OVEN
 	fruit = list("apple" = 1)
-	reagents = list(/datum/reagent/acid/polyacid = 5) //It dissolves the carapace. Still poisonous, though.
+	reagents = list(/datum/reagent/hydrazine = 5) //It dissolves the carapace. Still poisonous, though. Would be polyacid but that melts oven trays.
 	items = list(/obj/item/weapon/holder/diona)
 	result = /obj/item/weapon/reagent_containers/food/snacks/dionaroast
 


### PR DESCRIPTION
## About The Pull Request
Replaces polyacid with hydrazine in the recipe.
## Why It's Good For The Game
Trying to make a diona roast and the acid instantly DELETING your tray was funny. once. This isn't a bugfix but it's pretty close.. Hydrazine is a chemical with (slightly lower) rarity but it's A. Corrosive B. Something you don't want in your food C. unable to destroy oven trays. 
## Did You Test It?
Yes
## Authorship
Rock
## Changelog

:cl:
tweak: Diona roast is now made with hydrazine instead of polyacid (making it possible)
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->