### PR TITLE
Fixes Ninja Uplink

### DIFF
--- a/code/game/antagonist/outsider/ninja.dm
+++ b/code/game/antagonist/outsider/ninja.dm
@@ -20,6 +20,16 @@ GLOBAL_DATUM_INIT(ninjas, /datum/antagonist/ninja, new)
 	faction = "ninja"
 	base_to_load = /datum/map_template/ruin/antag_spawn/ninja
 
+/datum/antagonist/ninja/get_extra_panel_options(var/datum/mind/player)
+	return "<a href='?src=\ref[player];common=crystals'>\[set crystals\]</a><a href='?src=\ref[src];spawn_uplink=\ref[player.current]'>\[spawn uplink\]</a>"
+
+/datum/antagonist/ninja/Topic(href, href_list)
+	if (..())
+		return 1
+	if(href_list["spawn_uplink"])
+		spawn_uplink(locate(href_list["spawn_uplink"]))
+		return 1
+
 /datum/antagonist/ninja/attempt_random_spawn()
 	if(config.ninjas_allowed) ..()
 
@@ -92,10 +102,11 @@ GLOBAL_DATUM_INIT(ninjas, /datum/antagonist/ninja, new)
 		player.equip_to_slot_or_del(new /obj/item/device/flashlight(player), slot_belt)
 		create_id("Infiltrator", player)
 		equip_rig(/obj/item/weapon/rig/light/ninja, player)
-		var/obj/item/modular_computer/pda/syndicate/U = new
-		player.put_in_hands(U)
-		var/decl/uplink_source/pda/uplink_source = new
-		uplink_source.setup_uplink_source(player, 0)
+
+		spawn_uplink(player)
+
+/datum/antagonist/ninja/proc/spawn_uplink(var/mob/living/carbon/human/player)
+	setup_uplink_source(player, DEFAULT_TELECRYSTAL_AMOUNT)
 
 /datum/antagonist/ninja/proc/generate_ninja_directive(side)
 	var/directive = "[side=="face"?"[GLOB.using_map.company_name]":"A criminal syndicate"] is your employer. "//Let them know which side they're on.


### PR DESCRIPTION
## About The Pull Request
Previously, Ninja spawned with a PDA uplink with 0 TC. There is a shortwave radio uplink next to them with 180TC. The PDA uplink functioned as normal, however the shortwave radio is a nonfunctional uplink. As ejecting TCs is an uplink option, this meant that the TCs could not be ejected and put into the working uplink. Leaving ninja with 0 spendable TCs.

This PR updates the ninja uplink spawn to respect the player's preferences exactly in the way that the traitor uplink does. If they wish to spawn with a radio uplink, they may, same with the implant and shortwave uplink. I recommend removing the nonfunctioning uplink from the map the next time the dojo is edited: 
![image](https://user-images.githubusercontent.com/100093914/160724507-59c4ad48-b8ee-479f-b1a4-96c0518ef9dd.png)

## Why It's Good For The Game
It fixes a bug.
## Did You Test It?
![image](https://user-images.githubusercontent.com/100093914/160724307-4c4f560c-854c-4ff5-a85c-886c818e43a0.png)
## Authorship
Rafflesia
## Changelog
