### PR TITLE
Changes yeosa and veteris to make veteris more of a thing instead of wonky

### DIFF
--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -170,9 +170,9 @@
 	fire_mult = 0.75
 
 /obj/aura/regenerating/human/unathi/veteris
-	nutrition_damage_mult = 1.25
-	brute_mult = 1.25
-	organ_mult = 2.5
+	nutrition_damage_mult = 1.5
+	brute_mult = 1.5
+	organ_mult = 3
 	fire_mult = 1.25
 
 /obj/aura/regenerating/human/diona

--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -163,11 +163,17 @@
 	O.set_dna(H.dna)
 
 /obj/aura/regenerating/human/unathi/yeosa
+	nutrition_damage_mult = 1.5
+	brute_mult = 1.5
+	organ_mult = 3
+	tox_mult = 2
+	fire_mult = 0.75
+
+/obj/aura/regenerating/human/unathi/veteris
 	nutrition_damage_mult = 1.25
 	brute_mult = 1.25
 	organ_mult = 2.5
-	tox_mult = 2
-	fire_mult = 0.75
+	fire_mult = 1.25
 
 /obj/aura/regenerating/human/diona
 	brute_mult = 4

--- a/code/modules/species/station/lizard_subspecies.dm
+++ b/code/modules/species/station/lizard_subspecies.dm
@@ -7,10 +7,10 @@
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/tail, /datum/unarmed_attack/claws, /datum/unarmed_attack/punch, /datum/unarmed_attack/punch/venom, /datum/unarmed_attack/bite/sharp, /datum/unarmed_attack/bite/venom)
 	darksight_range = 5
 	darksight_tint = DARKTINT_GOOD
-	breath_pressure = 16
+	breath_pressure = 14
 	slowdown = 0.5
 	brute_mod = 0.9
-	oxy_mod = 0.9
+	oxy_mod = 0.8
 	flash_mod = 1.4
 	metabolism_mod = 0.75
 	blood_volume = 700

--- a/modular_mithra/code/modules/species/station/humanathi.dm
+++ b/modular_mithra/code/modules/species/station/humanathi.dm
@@ -21,13 +21,14 @@
 	darksight_tint = DARKTINT_MODERATE
 	gluttonous = GLUT_TINY | GLUT_ITEM_TINY | GLUT_PROJECTILE_VOMIT //Used to eating ash.
 	strength = STR_HIGH
-	breath_pressure = 12 //Their lungs are strong.
+	breath_pressure = 16 //Smaller, needs less air.
 	slowdown = 0.5
-	brute_mod = 0.8
-	flash_mod = 1.4 //More sensitive to light
-	metabolism_mod = 0.5 //Lower metabolism.
+	brute_mod = 0.9
+	burn_mod = 0.8
+	flash_mod = 1.2
+	radiation_mod = 0.75
+	metabolism_mod = 0.8 //Lower metabolism.
 	blood_volume = SPECIES_BLOOD_DEFAULT // Lower blood than unathi.
-	stomach_capacity = 4 //1 less than humans.
 
 	health_hud_intensity = 2
 	hunger_factor = DEFAULT_HUNGER_FACTOR //Less hungry than Unathi
@@ -54,7 +55,7 @@
 	heat_level_2 = 480 //Default 400
 	heat_level_3 = 1100 //Default 1000
 
-	spawn_flags = SPECIES_CAN_JOIN
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_NO_FBP_CHARGEN | SPECIES_NO_ROBOTIC_INTERNAL_ORGANS
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
 	flesh_color = "#34af10"
@@ -82,7 +83,7 @@
 	breathing_sound = 'sound/voice/lizard.ogg'
 
 	base_auras = list(
-		/obj/aura/regenerating/human/unathi
+		/obj/aura/regenerating/human/unathi/veteris
 		)
 
 	inherent_verbs = list(


### PR DESCRIPTION
## About The Pull Request
Gives Yeosa a breath pressure of 14 and an oxy mod of 0.8

Both veteris and yeosa now have similar modified regen values to sinta. Both are slower (though this does make yeosa regen faster than it was previously) except yeosa has a better toxin multiplier and veteris has a better burn multiplier. 

Veteris have higher breath pressure at 16, though this is still lower than sinta. Their brute mod is now 0.9 instead of 0.8 but they get a 0.8 burn mod because hot. Metabolism is also faster since 0.5 didn't really make sense, this effects chem processing. Their flash mod being 1.4 was pretty random so it's back down to 1.2 Lastly, gives them the radiation mod and prosthetic organ restrictions of other unathi.

## Why It's Good For The Game
Yeosa get better breath because it's their thing, they go in the water, and it's not the same if theirs is the same as veteris.

Aand I'm making veteris distinc  in this way because the previous iteration was just wonky. 12 breath pressure is fucking nuts, that's better than space adapts, and it didn't make sense why they would have it. Their stomach being smaller was just a hassle and also didn't make sense because of their eating habits. 

No reason they shouldn't have the rad resist and prosthetic organ restrictions of other unathi.

Not so sure about this one so feedback is appreciated.

## Did You Test It?
Yes
## Authorship
Rock, YouAreABigLizard
## Changelog

:cl:
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->