### PR TITLE
corpo gunbox is now the proper equipment typepath

### DIFF
--- a/code/modules/boh_misc/boxes.dm
+++ b/code/modules/boh_misc/boxes.dm
@@ -151,7 +151,7 @@
 /obj/item/gunbox/corpo
 	desc = "A secure box containing a sidearm."
 
-/obj/item/gunbox/pol/attack_self(mob/living/user)
+/obj/item/gunbox/corpo/attack_self(mob/living/user)
 	var/list/options = list()
 	options["Ballistic - ZH Ghoul"] = list(/obj/item/weapon/gun/projectile/dartgun/pol,/obj/item/clothing/accessory/storage/holster/thigh)
 	options["Ballistic - Lumoco Mk12"] = list(/obj/item/weapon/gun/projectile/revolver/medium/sec,/obj/item/clothing/accessory/storage/holster/thigh)


### PR DESCRIPTION
## About The Pull Request
Title, fixed.
## Why It's Good For The Game
I dunno, probably a good thing they're fixed.
## Did You Test It?
Yes.
## Authorship
MJP#4043, Dudeman100-Ckey
## Changelog

:cl:
fix:corpo gunbox now calls the proper equipment typepath
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->