### PR TITLE
plasmaman burning no longer double-dips burn damage

### DIFF
--- a/code/modules/species/station/plasmasans.dm
+++ b/code/modules/species/station/plasmasans.dm
@@ -227,7 +227,6 @@
 					"<span class='warning'>Your body reacts with the atmosphere and starts to sizzle and burn!</span>"
 				)
 				H.IgniteMob()
-			H.burn_skin(H.get_pressure_weakness())
 			H.updatehealth()
 
 /datum/hud_data/phorosian


### PR DESCRIPTION
## About The Pull Request

plasmamen are both set on fire and take constant burn damage which is absurd

this puts them more in line with tg plasmemes
:cl:
balance: plasmaman burn less
/:cl:
