### PR TITLE
Removes Skrell Railgun Hardstun

### DIFF
--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -184,7 +184,7 @@
 	initial_capacitor_type = /obj/item/weapon/stock_parts/capacitor/adv
 	load_type = /obj/item/weapon/magnetic_ammo/skrell
 	loaded = /obj/item/weapon/magnetic_ammo/skrell/slug
-	projectile_type = /obj/item/projectile/bullet/magnetic/slug
+	projectile_type = /obj/item/projectile/bullet/magnetic/slug/skrell
 	slot_flags = SLOT_BACK
 	power_cost = 100
 	wielded_item_state = "skrell_rifle-wielded"

--- a/code/modules/projectiles/projectile/magnetic.dm
+++ b/code/modules/projectiles/projectile/magnetic.dm
@@ -17,6 +17,9 @@
 	damage = 50
 	armor_penetration = 75
 
+/obj/item/projectile/bullet/magnetic/slug/skrell
+	stun = 0
+
 /obj/item/projectile/bullet/magnetic/flechette
 	name = "flechette"
 	icon_state = "flechette"


### PR DESCRIPTION
## About The Pull Request
This PR aims to remove the hardstun from the Skrellian 6 shot railgun.

## Why It's Good For The Game
At the moment, this is the fastest firing railgun in the game and, on top of being able to hardstun, it can lock a person in hardstun due to it firing faster than the stun lasts.

The damage and AP remain the same. However, the Skrellian railgun is no longer an instant win gun.
## Did You Test It?
Yes.

## Authorship
PurplePIneapple#0001
## Changelog

:cl:
tweak: Skrellian railgun now fires a new subtype projectile which has no hardstun
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->