### PR TITLE
Changes to security stun weaponry

### DIFF
--- a/code/modules/boh_misc/firearms.dm
+++ b/code/modules/boh_misc/firearms.dm
@@ -341,10 +341,11 @@
 /////////
 
 /obj/item/weapon/gun/energy/gun/small/secure/sec
-	name = "Beagle Mk-4"
-	desc = "Inspired by the SCG's desire to save money, This modified Lawson arms Design gives forces the benefits of weak lasers and command overreach, without expensive ideas such as automatic recharge."
+	name = "Beagle MK-5"
+	desc = "The newest iteration of the SCG's secure Beagle pistol series. This model reintroduces the self-charging mechanism to its compact line. Due to its cost effective nature, however, the MK-5 takes twice the time to charge as its full-sized counterpart."
 	max_shots = 5
-	self_recharge = 0
+	self_recharge = 1
+	recharge_time = 8
 
 /////////
 // Commissar's Dartgun

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -5,7 +5,7 @@
 	icon_state = "taserstun"
 	item_state = null	//so the human update icon uses the icon_state instead.
 	modifystate = "taserstun"
-	max_shots = 9
+	max_shots = 10
 	projectile_type = /obj/item/projectile/beam/stun
 	combustion = 0
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -70,7 +70,7 @@
 	one_hand_penalty = 6
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
 	force = 10
-	max_shots = 5
+	max_shots = 10
 	accuracy = 2
 	projectile_type = /obj/item/projectile/energy/electrode/stunshot
 	wielded_item_state = "stunrifle-wielded"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -234,7 +234,8 @@
 
 /obj/item/projectile/beam/stun/shock/heavy
 	name = "heavy shock beam"
-	damage = 40
+	damage = 20
+	agony = 30
 
 /obj/item/projectile/beam/plasmacutter
 	name = "plasma arc"


### PR DESCRIPTION
## About The Pull Request
This PR aims to slightly revamp the current stun weaponry available to security.

The changes are as follows:

- The Beagle compact smartgun now recharges at half the rate of a full-sized smartgun. Its description has been updated.

- The stun rifle now has 10 shots again to match the carbine in utility.

- The stun carbine's shock mode has been reduced in strength. It does considerably less agony than the stun rifle, however it does 20 damage on top of its agony + electrocution. It is still extremely effective on unarmored opponents but less effective on those with armor. It no longer instantly knocks down people.

## Why It's Good For The Game
The stun carbine was, in every way, better than its full-sized rifle counterpart. It fits in bags, it was hitscan, and it instantly downed anyone outside of a hardsuit.

Now, the stun carbine is a more compact, hitscan medium power taser. Shock mode has the added benefit of causing burn damage to unarmored targets. The stun rifle is a high powered, harder to hit high power taser but completely non-lethal.

The Beagle also had little use over the regular taser security can use. It has less shots and the lethal mode is locked to guards. This change should allow the Beagle to have its own niche as a long term pistol used in short bursts.

The non-lethal security taser also has 10 shots now instead of 9. Because 9 was a strange number.

## Did You Test It?
Yes

## Authorship
PurplePineapple#0001

## Changelog

:cl:
tweak: The stun carbine's shock mode has been reduced in power to prevent instant KOs through zerk and stims.
tweak: The stun rifle has been given 10 shots once more to put it on level with the carbine.
tweak: The compact smartgun now recharges at half the rate of a normal smartgun.
tweak: The non-lethal taser has been given 10 shots instead of 9, because 9 was a strange number.
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->